### PR TITLE
refactor: HTTP Client to use Functional Options for Request Configuration

### DIFF
--- a/client.go
+++ b/client.go
@@ -93,7 +93,7 @@ func NewClient(baseURL, token string, doer Doer) (*Client, error) {
 	// --- Inject HTTP method wrappers ------------------------------------------
 	c.method = &method{
 		Get: func(spath string, query url.Values) (*http.Response, error) {
-			return c.do(http.MethodGet, spath, nil, nil, query)
+			return c.do(http.MethodGet, spath, withQuery(query))
 		},
 		Post: func(spath string, form url.Values) (*http.Response, error) {
 			header := http.Header{}
@@ -101,7 +101,7 @@ func NewClient(baseURL, token string, doer Doer) (*Client, error) {
 			if form == nil {
 				form = url.Values{}
 			}
-			return c.do(http.MethodPost, spath, header, strings.NewReader(form.Encode()), nil)
+			return c.do(http.MethodPost, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
 		},
 		Patch: func(spath string, form url.Values) (*http.Response, error) {
 			header := http.Header{}
@@ -109,7 +109,7 @@ func NewClient(baseURL, token string, doer Doer) (*Client, error) {
 			if form == nil {
 				form = url.Values{}
 			}
-			return c.do(http.MethodPatch, spath, header, strings.NewReader(form.Encode()), nil)
+			return c.do(http.MethodPatch, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
 		},
 		Delete: func(spath string, form url.Values) (*http.Response, error) {
 			header := http.Header{}
@@ -117,7 +117,7 @@ func NewClient(baseURL, token string, doer Doer) (*Client, error) {
 			if form == nil {
 				form = url.Values{}
 			}
-			return c.do(http.MethodDelete, spath, header, strings.NewReader(form.Encode()), nil)
+			return c.do(http.MethodDelete, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
 		},
 		Upload: func(spath, fileName string, r io.Reader) (*http.Response, error) {
 			if fileName == "" {
@@ -140,7 +140,7 @@ func NewClient(baseURL, token string, doer Doer) (*Client, error) {
 			header := http.Header{}
 			header.Set("Content-Type", mw.FormDataContentType())
 
-			return c.do(http.MethodPost, spath, header, &buf, nil)
+			return c.do(http.MethodPost, spath, withHeader(header), withBody(&buf))
 		},
 	}
 
@@ -154,24 +154,31 @@ func NewClient(baseURL, token string, doer Doer) (*Client, error) {
 // ──────────────────────────────────────────────────────────────
 
 // newRequest builds a new HTTP request with token-based authentication.
-func (c *Client) newRequest(method, spath string, header http.Header, body io.Reader, query url.Values) (*http.Request, error) {
+func (c *Client) newRequest(method, spath string, opts ...*httpRequestOption) (*http.Request, error) {
 	if spath == "" {
 		return nil, errors.New("spath must not be empty")
 	}
 
-	u := *c.baseURL
-	u.Path = path.Join(u.Path, "api", apiVersion, spath)
-	if query != nil {
-		u.RawQuery = query.Encode()
+	config := &httpRequestConfig{}
+	for _, option := range opts {
+		if option != nil {
+			option.Set(config)
+		}
 	}
 
-	req, err := http.NewRequest(method, u.String(), body)
+	u := *c.baseURL
+	u.Path = path.Join(u.Path, "api", apiVersion, spath)
+	if config.Query != nil {
+		u.RawQuery = config.Query.Encode()
+	}
+
+	req, err := http.NewRequest(method, u.String(), config.Body)
 	if err != nil {
 		return nil, err
 	}
 
-	if header != nil {
-		req.Header = header.Clone()
+	if config.Header != nil {
+		req.Header = config.Header.Clone()
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
 
@@ -180,8 +187,8 @@ func (c *Client) newRequest(method, spath string, header http.Header, body io.Re
 
 // do executes the given HTTP request using the injected Doer.
 // All HTTP calls pass through this function, ensuring consistent error handling.
-func (c *Client) do(method, spath string, header http.Header, body io.Reader, query url.Values) (*http.Response, error) {
-	req, err := c.newRequest(method, spath, header, body, query)
+func (c *Client) do(method, spath string, opts ...*httpRequestOption) (*http.Response, error) {
+	req, err := c.newRequest(method, spath, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -162,7 +162,7 @@ func (c *Client) newRequest(method, spath string, opts ...*httpRequestOption) (*
 	config := &httpRequestConfig{}
 	for _, option := range opts {
 		if option != nil {
-			option.Set(config)
+			option.set(config)
 		}
 	}
 

--- a/client_option.go
+++ b/client_option.go
@@ -1,0 +1,45 @@
+package backlog
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// ──────────────────────────────────────────────────────────────
+//  Http request otions
+// ──────────────────────────────────────────────────────────────
+
+type httpRequestOption struct {
+	Set func(config *httpRequestConfig)
+}
+
+type httpRequestConfig struct {
+	Header http.Header
+	Body   io.Reader
+	Query  url.Values
+}
+
+func withHeader(header http.Header) *httpRequestOption {
+	return &httpRequestOption{
+		Set: func(config *httpRequestConfig) {
+			config.Header = header
+		},
+	}
+}
+
+func withBody(body io.Reader) *httpRequestOption {
+	return &httpRequestOption{
+		Set: func(config *httpRequestConfig) {
+			config.Body = body
+		},
+	}
+}
+
+func withQuery(query url.Values) *httpRequestOption {
+	return &httpRequestOption{
+		Set: func(config *httpRequestConfig) {
+			config.Query = query
+		},
+	}
+}

--- a/client_option.go
+++ b/client_option.go
@@ -11,7 +11,7 @@ import (
 // ──────────────────────────────────────────────────────────────
 
 type httpRequestOption struct {
-	Set func(config *httpRequestConfig)
+	set func(config *httpRequestConfig)
 }
 
 type httpRequestConfig struct {
@@ -22,7 +22,7 @@ type httpRequestConfig struct {
 
 func withHeader(header http.Header) *httpRequestOption {
 	return &httpRequestOption{
-		Set: func(config *httpRequestConfig) {
+		set: func(config *httpRequestConfig) {
 			config.Header = header
 		},
 	}
@@ -30,7 +30,7 @@ func withHeader(header http.Header) *httpRequestOption {
 
 func withBody(body io.Reader) *httpRequestOption {
 	return &httpRequestOption{
-		Set: func(config *httpRequestConfig) {
+		set: func(config *httpRequestConfig) {
 			config.Body = body
 		},
 	}
@@ -38,7 +38,7 @@ func withBody(body io.Reader) *httpRequestOption {
 
 func withQuery(query url.Values) *httpRequestOption {
 	return &httpRequestOption{
-		Set: func(config *httpRequestConfig) {
+		set: func(config *httpRequestConfig) {
 			config.Query = query
 		},
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -85,7 +85,7 @@ func TestNewClient_initialization(t *testing.T) {
 		require.NoError(t, err)
 
 		{
-			req, _ := c.newRequest(http.MethodGet, "test", nil, nil, nil)
+			req, _ := c.newRequest(http.MethodGet, "test")
 			res, err := c.doer.Do(req)
 			require.Error(t, err)
 			assert.Nil(t, res)
@@ -230,9 +230,6 @@ func TestClient_do(t *testing.T) {
 			res, err := c.do(
 				http.MethodGet,
 				"test",
-				http.Header{},
-				nil,
-				nil,
 			)
 
 			if tc.wantErr {
@@ -350,7 +347,13 @@ func TestClient_newRequest(t *testing.T) {
 			t.Parallel()
 
 			c := newClientMock(t, "https://test.com", "test", nil)
-			request, err := c.newRequest(tc.method, tc.spath, tc.header, tc.body, tc.query)
+			request, err := c.newRequest(
+				tc.method,
+				tc.spath,
+				withHeader(tc.header),
+				withBody(tc.body),
+				withQuery(tc.query),
+			)
 
 			if tc.wantError {
 				assert.Error(t, err)


### PR DESCRIPTION
## Summary
[cite_start]Internal HTTP request handling has been refactored from a fixed-parameter signature to a **Functional Options pattern**[cite: 4, 7]. [cite_start]This reduces the need to pass multiple `nil` arguments and improves code flexibility[cite: 8].

## Changes
* [cite_start]**New Options Mechanism**: Added `httpRequestOption` and helpers (`withHeader`, `withBody`, `withQuery`) in a new file `client_option.go`[cite: 8].
* [cite_start]**Simplified Signatures**: Updated `newRequest` and `do` to accept variadic options (`...*httpRequestOption`)[cite: 4, 7].
* [cite_start]**Cleaner Wrappers**: Simplified `Get`, `Post`, `Patch`, `Delete`, and `Upload` by passing only relevant data[cite: 1, 2, 3].
* [cite_start]**Test Updates**: Cleaned up `client_test.go` to match the new API[cite: 8].

## Impact
* [cite_start]**Readability**: Eliminates boilerplate `nil` values in method calls[cite: 1, 8].
* [cite_start]**Maintainability**: Future request configurations can be added without changing existing function signatures[cite: 4].

Closes #146