### PR TITLE
refactor!: add Client option for NewClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ func main() {
     token := "BACKLOG_TOKEN"
 
     // Create Backlog API client.
-    c, err := backlog.NewClient(baseURL, token, nil)
+    c, err := backlog.NewClient(baseURL, token)
     if err != nil {
         log.Fatalln(err)
     }
@@ -81,7 +81,7 @@ func main() {
     token := "BACKLOG_TOKEN"
 
     // Create Backlog API client.
-    c, err := backlog.NewClient(baseURL, token, nil)
+    c, err := backlog.NewClient(baseURL, token)
     if err != nil {
         log.Fatalln(err)
     }

--- a/client.go
+++ b/client.go
@@ -65,9 +65,12 @@ type method struct {
 // ──────────────────────────────────────────────────────────────
 
 // NewClient creates and initializes a Backlog API Client.
-// A custom Doer (e.g., *http.Client or mock) may be provided for testing.
-// If doer is nil, http.DefaultClient is used.
-func NewClient(baseURL, token string, doer Doer) (*Client, error) {
+// It requires a baseURL and an API token.
+//
+// This function supports options returned by package-level functions,
+// such as:
+//   - WithDoer
+func NewClient(baseURL, token string, opts ...*clientOption) (*Client, error) {
 	if token == "" {
 		return nil, newInternalClientError("missing token")
 	}
@@ -80,13 +83,20 @@ func NewClient(baseURL, token string, doer Doer) (*Client, error) {
 		return nil, err
 	}
 
-	if doer == nil {
-		doer = http.DefaultClient
+	config := &clientConfig{}
+	for _, option := range opts {
+		if option != nil {
+			option.set(config)
+		}
+	}
+
+	if config.Doer == nil {
+		config.Doer = http.DefaultClient
 	}
 
 	c := &Client{
 		baseURL: u,
-		doer:    doer,
+		doer:    config.Doer,
 		token:   token,
 		wrapper: &defaultWrapper{},
 	}

--- a/client.go
+++ b/client.go
@@ -70,7 +70,7 @@ type method struct {
 // This function supports options returned by package-level functions,
 // such as:
 //   - WithDoer
-func NewClient(baseURL, token string, opts ...*clientOption) (*Client, error) {
+func NewClient(baseURL, token string, opts ...*ClientOption) (*Client, error) {
 	if token == "" {
 		return nil, newInternalClientError("missing token")
 	}

--- a/client_option.go
+++ b/client_option.go
@@ -10,16 +10,24 @@ import (
 //  Client options
 // ──────────────────────────────────────────────────────────────
 
-type clientOption struct {
+// ClientOption defines a functional option for configuring a Client.
+// It is used to change the default behavior of the Client.
+type ClientOption struct {
 	set func(config *clientConfig)
 }
 
+// clientConfig holds the internal configuration settings for the Client.
 type clientConfig struct {
+	// Doer is the HTTP client used to make requests.
 	Doer Doer
 }
 
-func WithDoer(doer Doer) *clientOption {
-	return &clientOption{
+// WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.
+// This is useful for providing a custom *http.Client or a mock implementation during testing.
+//
+// If this option is not provided, http.DefaultClient is used by default.
+func WithDoer(doer Doer) *ClientOption {
+	return &ClientOption{
 		set: func(config *clientConfig) {
 			config.Doer = doer
 		},

--- a/client_option.go
+++ b/client_option.go
@@ -7,6 +7,26 @@ import (
 )
 
 // ──────────────────────────────────────────────────────────────
+//  Client options
+// ──────────────────────────────────────────────────────────────
+
+type clientOption struct {
+	set func(config *clientConfig)
+}
+
+type clientConfig struct {
+	Doer Doer
+}
+
+func WithDoer(doer Doer) *clientOption {
+	return &clientOption{
+		set: func(config *clientConfig) {
+			config.Doer = doer
+		},
+	}
+}
+
+// ──────────────────────────────────────────────────────────────
 //  Http request otions
 // ──────────────────────────────────────────────────────────────
 

--- a/client_test.go
+++ b/client_test.go
@@ -53,7 +53,7 @@ func TestNewClient_validation(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			c, err := NewClient(tc.baseURL, tc.token, nil)
+			c, err := NewClient(tc.baseURL, tc.token)
 
 			if tc.wantError {
 				assert.Error(t, err)
@@ -82,7 +82,7 @@ func TestNewClient_initialization(t *testing.T) {
 		mockDoer := &mockDoer{t: t,
 			doFunc: func(_ *http.Request) (*http.Response, error) { return nil, errors.New("mockDoer error") },
 		}
-		c, err := NewClient(baseURL, token, mockDoer)
+		c, err := NewClient(baseURL, token, WithDoer(mockDoer))
 		require.NoError(t, err)
 
 		{
@@ -98,7 +98,7 @@ func TestNewClient_initialization(t *testing.T) {
 	t.Run("without-Doer", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := NewClient(baseURL, token, nil)
+		c, err := NewClient(baseURL, token)
 		require.NoError(t, err)
 		assert.NotNil(t, c)
 

--- a/examples/attachment/all/main.go
+++ b/examples/attachment/all/main.go
@@ -15,7 +15,7 @@ func main() {
 	token := "BACKLOG_TOKEN"
 
 	// Create Backlog API client.
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/attachment/attatch/main.go
+++ b/examples/attachment/attatch/main.go
@@ -15,7 +15,7 @@ func main() {
 	token := "BACKLOG_TOKEN"
 
 	// Create Backlog API client.
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/attachment/delete/main.go
+++ b/examples/attachment/delete/main.go
@@ -15,7 +15,7 @@ func main() {
 	token := "BACKLOG_TOKEN"
 
 	// Create Backlog API client.
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/attachment/one/main.go
+++ b/examples/attachment/one/main.go
@@ -15,7 +15,7 @@ func main() {
 	token := "BACKLOG_TOKEN"
 
 	// Create Backlog API client.
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/attachment/upload/main.go
+++ b/examples/attachment/upload/main.go
@@ -16,7 +16,7 @@ func main() {
 	token := "BACKLOG_TOKEN"
 
 	// Create Backlog API client.
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/change_wiki_name/main.go
+++ b/examples/change_wiki_name/main.go
@@ -28,7 +28,7 @@ func main() {
 	projectKey := scanner(stdin, "project name:")
 
 	// Get all Wikis in the project.
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/wiki/all/main.go
+++ b/examples/wiki/all/main.go
@@ -14,7 +14,7 @@ func main() {
 	// The token for request to Backlog API.
 	token := "BACKLOG_TOKEN"
 	// Create Backlog API client.
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/wiki/count/main.go
+++ b/examples/wiki/count/main.go
@@ -15,7 +15,7 @@ func main() {
 	token := "BACKLOG_TOKEN"
 
 	// Create Backlog API client.
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/wiki/create/main.go
+++ b/examples/wiki/create/main.go
@@ -15,7 +15,7 @@ func main() {
 	token := "BACKLOG_TOKEN"
 
 	// Create Backlog API client.
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/wiki/delete/main.go
+++ b/examples/wiki/delete/main.go
@@ -15,7 +15,7 @@ func main() {
 	token := "BACKLOG_TOKEN"
 
 	// Create Backlog API client.
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/wiki/one/main.go
+++ b/examples/wiki/one/main.go
@@ -15,7 +15,7 @@ func main() {
 	token := "BACKLOG_TOKEN"
 
 	// Create Backlog API client.
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/wiki/update/main.go
+++ b/examples/wiki/update/main.go
@@ -14,7 +14,7 @@ func main() {
 	// The token for request to Backlog API.
 	token := "BACKLOG_TOKEN"
 
-	c, err := backlog.NewClient(baseURL, token, nil)
+	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/mock_test.go
+++ b/mock_test.go
@@ -48,7 +48,7 @@ func newClientMock(t *testing.T, baseURL, token string, doer Doer) *Client {
 		}
 	}
 
-	c, err := NewClient(baseURL, token, doer)
+	c, err := NewClient(baseURL, token, WithDoer(doer))
 	require.NoError(t, err)
 
 	return c


### PR DESCRIPTION
Transitioned the `NewClient` constructor to the **Functional Options** pattern to improve API flexibility and maintainability.

## Key Changes
* **Functional Options Support**: Introduced `WithDoer` to allow custom HTTP clients (or mocks) via the new `...*ClientOption` variadic argument.
* **Refactored Initialization**: Centralized internal settings into a private `clientConfig` struct to decouple configuration logic from the `Client` instance.
* **Encapsulation**: Kept configuration structs unexported to maintain a clean public API while allowing future parameter expansions without breaking changes.

## Usage
```go
// Default initialization
client, _ := NewClient(baseURL, token)

// Initialization with a custom Doer (e.g., for testing)
client, _ := NewClient(baseURL, token, WithDoer(customDoer))
```

## Motivation
To separate required arguments (URL and Token) from optional configurations, providing a more idiomatic and scalable way to initialize the API client.