### PR TITLE
feat!: add context.Context support to all API methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ go get github.com/nattokin/go-backlog
 package main
 
 import (
+    "context"
 	"fmt"
 	"log"
 
@@ -52,7 +53,7 @@ func main() {
 
     // The wiki ID.
     wikiID := 12345
-    r, err := c.Wiki.One(wikiID)
+    r, err := c.Wiki.One(context.Background(), wikiID)
     if err != nil {
         log.Fatalln(err)
     }
@@ -66,6 +67,7 @@ func main() {
 package main
 
 import (
+    "context"
 	"fmt"
 	"log"
 
@@ -86,7 +88,7 @@ func main() {
 
     // The project ID or Key.
     projectIDOrKey := "PROJECTKEY"
-    r, err := c.Wiki.All(projectIDOrKey)
+    r, err := c.Wiki.All(context.Background(), projectIDOrKey)
 
     if err != nil {
         log.Fatalln(err)

--- a/activity.go
+++ b/activity.go
@@ -1,19 +1,20 @@
 package backlog
 
 import (
+	"context"
 	"net/url"
 	"path"
 	"strconv"
 )
 
-func getActivityList(base *OptionService, m *method, spath string, opts ...RequestOption) ([]*Activity, error) {
+func getActivityList(ctx context.Context, base *OptionService, m *method, spath string, opts ...RequestOption) ([]*Activity, error) {
 	query := url.Values{}
 	validOptionKeys := []apiParamOptionType{paramActivityTypeIDs, paramMinID, paramMaxID, paramCount, paramOrder}
 	if err := applyOptions(query, validOptionKeys, opts...); err != nil {
 		return nil, err
 	}
 
-	resp, err := m.Get(spath, query)
+	resp, err := m.Get(ctx, spath, query)
 	if err != nil {
 		return nil, err
 	}
@@ -44,13 +45,13 @@ type ProjectActivityService struct {
 //   - WithOrder
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates
-func (s *ProjectActivityService) List(projectIDOrKey string, opts ...RequestOption) ([]*Activity, error) {
+func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*Activity, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("projects", projectIDOrKey, "activities")
-	return getActivityList(s.Option.base, s.method, spath, opts...)
+	return getActivityList(ctx, s.Option.base, s.method, spath, opts...)
 }
 
 // SpaceActivityService handles communication with the space activities-related methods of the Backlog API.
@@ -71,8 +72,8 @@ type SpaceActivityService struct {
 //   - WithOrder
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-recent-updates
-func (s *SpaceActivityService) List(opts ...RequestOption) ([]*Activity, error) {
-	return getActivityList(s.Option.base, s.method, "space/activities", opts...)
+func (s *SpaceActivityService) List(ctx context.Context, opts ...RequestOption) ([]*Activity, error) {
+	return getActivityList(ctx, s.Option.base, s.method, "space/activities", opts...)
 }
 
 // UserActivityService handles communication with the user activities-related methods of the Backlog API.
@@ -93,12 +94,12 @@ type UserActivityService struct {
 //   - WithOrder
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates
-func (s *UserActivityService) List(userID int, opts ...RequestOption) ([]*Activity, error) {
+func (s *UserActivityService) List(ctx context.Context, userID int, opts ...RequestOption) ([]*Activity, error) {
 	uID := UserID(userID)
 	if err := uID.validate(); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("users", strconv.Itoa(userID), "activities")
-	return getActivityList(s.Option.base, s.method, spath, opts...)
+	return getActivityList(ctx, s.Option.base, s.method, spath, opts...)
 }

--- a/activity_test.go
+++ b/activity_test.go
@@ -118,6 +118,23 @@ func TestUserActivityService_List_invalidID(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestUserActivityService_List_invalidJson(t *testing.T) {
+	t.Parallel()
+
+	s := newUserActivityService()
+	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
+		}
+		return resp, nil
+	}
+
+	activities, err := s.List(context.Background(), 1)
+	assert.Nil(t, activities)
+	assert.Error(t, err)
+}
+
 func TestBaseActivityService_GetList(t *testing.T) {
 	t.Parallel()
 
@@ -277,6 +294,8 @@ func TestBaseActivityService_GetList(t *testing.T) {
 
 // TestActivityService_contextPropagation verifies that the context passed to each
 // activity service method is correctly relayed to the underlying method call.
+// A sentinel value is embedded in the context and its pointer identity is
+// asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
 func TestActivityService_contextPropagation(t *testing.T) {
 	t.Parallel()
 

--- a/activity_test.go
+++ b/activity_test.go
@@ -282,8 +282,6 @@ func TestBaseActivityService_GetList(t *testing.T) {
 // A sentinel value is embedded in the context and its pointer identity is
 // asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
 func TestActivityService_contextPropagation(t *testing.T) {
-	t.Parallel()
-
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)

--- a/activity_test.go
+++ b/activity_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,13 +16,13 @@ import (
 func TestProjectActivityService_List(t *testing.T) {
 	t.Parallel()
 
-	projectKey := "TEST"
-
 	want := struct {
 		spath string
 	}{
-		spath: "projects/" + projectKey + "/activities",
+		spath: "projects/TEST/activities",
 	}
+
+	projectKey := "TEST"
 
 	s := newProjectActivityService()
 	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
@@ -88,12 +87,11 @@ func TestSpaceActivityService_List(t *testing.T) {
 func TestUserActivityService_List(t *testing.T) {
 	t.Parallel()
 
-	id := 1234
-
+	id := 1
 	want := struct {
 		spath string
 	}{
-		spath: "users/" + strconv.Itoa(id) + "/activities",
+		spath: "users/1/activities",
 	}
 
 	s := newUserActivityService()
@@ -121,134 +119,136 @@ func TestUserActivityService_List_invalidID(t *testing.T) {
 }
 
 func TestBaseActivityService_GetList(t *testing.T) {
-	o := newActivityOptionService()
-	type want struct {
-		activityTypeID []string
-		minID          string
-		maxID          string
-		count          string
-		order          string
-	}
+	t.Parallel()
+
 	cases := map[string]struct {
-		opts      []RequestOption
+		opts []RequestOption
+
+		want struct {
+			activityTypeID []string
+			minID          string
+			maxID          string
+			count          string
+			order          string
+		}
+
 		wantError bool
-		want      want
 	}{
-		"success-no-option": {
-			opts:      []RequestOption{},
-			wantError: false,
-			want: want{
+		"no-option": {
+			want: struct {
+				activityTypeID []string
+				minID          string
+				maxID          string
+				count          string
+				order          string
+			}{
 				activityTypeID: nil,
 				minID:          "",
 				maxID:          "",
 				count:          "",
 				order:          "",
 			},
+			wantError: true,
 		},
-		"success-withActivityTypeIDs": {
+		"with-activityTypeID": {
 			opts: []RequestOption{
-				o.WithActivityTypeIDs([]int{1}),
+				newSpaceActivityOptionService().WithActivityTypeIDs([]int{1, 2}),
 			},
-			wantError: false,
-			want: want{
-				activityTypeID: []string{"1"},
-				minID:          "",
-				maxID:          "",
-				count:          "",
-				order:          "",
-			},
-		},
-		"success-withMinID": {
-			opts: []RequestOption{
-				o.WithMinID(1),
-			},
-			wantError: false,
-			want: want{
-				activityTypeID: nil,
-				minID:          "1",
-				maxID:          "",
-				count:          "",
-				order:          "",
-			},
-		},
-		"success-withMaxID": {
-			opts: []RequestOption{
-				o.WithMaxID(1),
-			},
-			wantError: false,
-			want: want{
-				activityTypeID: nil,
-				minID:          "",
-				maxID:          "1",
-				count:          "",
-				order:          "",
-			},
-		},
-		"success-withCount": {
-			opts: []RequestOption{
-				o.WithCount(1),
-			},
-			wantError: false,
-			want: want{
-				activityTypeID: nil,
-				minID:          "",
-				maxID:          "",
-				count:          "1",
-				order:          "",
-			},
-		},
-		"success-withOrder": {
-			opts: []RequestOption{
-				o.WithOrder(OrderAsc),
-			},
-			wantError: false,
-			want: want{
-				activityTypeID: nil,
-				minID:          "",
-				maxID:          "",
-				count:          "",
-				order:          "asc",
-			},
-		},
-		"success-multiple-options": {
-			opts: []RequestOption{
-				o.WithActivityTypeIDs([]int{1, 2}),
-				o.WithMinID(1),
-				o.WithMaxID(26),
-				o.WithCount(20),
-				o.WithOrder(OrderAsc),
-			},
-			wantError: false,
-			want: want{
+			want: struct {
+				activityTypeID []string
+				minID          string
+				maxID          string
+				count          string
+				order          string
+			}{
 				activityTypeID: []string{"1", "2"},
-				minID:          "1",
-				maxID:          "26",
+				minID:          "",
+				maxID:          "",
+				count:          "",
+				order:          "",
+			},
+			wantError: true,
+		},
+		"with-minID": {
+			opts: []RequestOption{
+				newSpaceActivityOptionService().WithMinID(10),
+			},
+			want: struct {
+				activityTypeID []string
+				minID          string
+				maxID          string
+				count          string
+				order          string
+			}{
+				activityTypeID: nil,
+				minID:          "10",
+				maxID:          "",
+				count:          "",
+				order:          "",
+			},
+			wantError: true,
+		},
+		"with-maxID": {
+			opts: []RequestOption{
+				newSpaceActivityOptionService().WithMaxID(100),
+			},
+			want: struct {
+				activityTypeID []string
+				minID          string
+				maxID          string
+				count          string
+				order          string
+			}{
+				activityTypeID: nil,
+				minID:          "",
+				maxID:          "100",
+				count:          "",
+				order:          "",
+			},
+			wantError: true,
+		},
+		"with-count": {
+			opts: []RequestOption{
+				newSpaceActivityOptionService().WithCount(20),
+			},
+			want: struct {
+				activityTypeID []string
+				minID          string
+				maxID          string
+				count          string
+				order          string
+			}{
+				activityTypeID: nil,
+				minID:          "",
+				maxID:          "",
 				count:          "20",
+				order:          "",
+			},
+			wantError: true,
+		},
+		"with-order": {
+			opts: []RequestOption{
+				newSpaceActivityOptionService().WithOrder(OrderAsc),
+			},
+			want: struct {
+				activityTypeID []string
+				minID          string
+				maxID          string
+				count          string
+				order          string
+			}{
+				activityTypeID: nil,
+				minID:          "",
+				maxID:          "",
+				count:          "",
 				order:          "asc",
-			},
-		},
-		"error-option-invalid-value": {
-			opts: []RequestOption{
-				o.WithCount(0),
-			},
-			wantError: true,
-			want:      want{},
-		},
-		"error-option-invalid-type": {
-			opts:      []RequestOption{newInvalidTypeOption()},
-			wantError: true,
-			want:      want{},
-		},
-		"error-option-set-failed": {
-			opts: []RequestOption{
-				newFailingSetOption(paramCount),
 			},
 			wantError: true,
 		},
 	}
 
-	for n, tc := range cases {
-		t.Run(n, func(t *testing.T) {
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
 			s := newSpaceActivityService()
@@ -258,21 +258,66 @@ func TestBaseActivityService_GetList(t *testing.T) {
 				assert.Equal(t, tc.want.maxID, query.Get("maxId"))
 				assert.Equal(t, tc.want.count, query.Get("count"))
 				assert.Equal(t, tc.want.order, query.Get("order"))
-
-				resp := &http.Response{
+				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(testdataActivityListJSON))),
-				}
-				return resp, nil
+					Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
+				}, nil
 			}
 
 			if resp, err := s.List(context.Background(), tc.opts...); tc.wantError {
 				require.Error(t, err)
 				assert.Nil(t, resp)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, resp)
 			}
+		})
+	}
+}
+
+// TestActivityService_contextPropagation verifies that the context passed to each
+// activity service method is correctly relayed to the underlying method call.
+func TestActivityService_contextPropagation(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+	sentinel := &struct{}{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+
+	cases := []struct {
+		name string
+		call func(t *testing.T)
+	}{
+		{"ProjectActivityService.List", func(t *testing.T) {
+			s := newProjectActivityService()
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.List(ctx, "TEST") //nolint:errcheck
+		}},
+		{"SpaceActivityService.List", func(t *testing.T) {
+			s := newSpaceActivityService()
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.List(ctx) //nolint:errcheck
+		}},
+		{"UserActivityService.List", func(t *testing.T) {
+			s := newUserActivityService()
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.List(ctx, 1) //nolint:errcheck
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.call(t)
 		})
 	}
 }

--- a/activity_test.go
+++ b/activity_test.go
@@ -2,6 +2,7 @@ package backlog
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -25,12 +26,12 @@ func TestProjectActivityService_List(t *testing.T) {
 	}
 
 	s := newProjectActivityService()
-	s.method.Get = func(spath string, query url.Values) (*http.Response, error) {
+	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 		assert.Equal(t, want.spath, spath)
 		return nil, errors.New("error")
 	}
 
-	_, err := s.List(projectKey)
+	_, err := s.List(context.Background(), projectKey)
 	assert.Error(t, err)
 }
 
@@ -39,12 +40,12 @@ func TestProjectActivityService_List_projectIDOrKeyIsEmpty(t *testing.T) {
 
 	projectKey := ""
 	s := newProjectActivityService()
-	s.method.Get = func(spath string, query url.Values) (*http.Response, error) {
+	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 		t.Error("s.method.Get must never be called")
 		return nil, errors.New("error")
 	}
 
-	_, err := s.List(projectKey)
+	_, err := s.List(context.Background(), projectKey)
 	assert.Error(t, err)
 }
 
@@ -52,7 +53,7 @@ func TestProjectActivityService_List_invalidJson(t *testing.T) {
 	t.Parallel()
 
 	s := newProjectActivityService()
-	s.method.Get = func(spath string, query url.Values) (*http.Response, error) {
+	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 		resp := &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
@@ -60,7 +61,7 @@ func TestProjectActivityService_List_invalidJson(t *testing.T) {
 		return resp, nil
 	}
 
-	projects, err := s.List("TEST")
+	projects, err := s.List(context.Background(), "TEST")
 	assert.Nil(t, projects)
 	assert.Error(t, err)
 }
@@ -75,12 +76,12 @@ func TestSpaceActivityService_List(t *testing.T) {
 	}
 
 	s := newSpaceActivityService()
-	s.method.Get = func(spath string, query url.Values) (*http.Response, error) {
+	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 		assert.Equal(t, want.spath, spath)
 		return nil, errors.New("error")
 	}
 
-	_, err := s.List()
+	_, err := s.List(context.Background())
 	assert.Error(t, err)
 }
 
@@ -96,12 +97,12 @@ func TestUserActivityService_List(t *testing.T) {
 	}
 
 	s := newUserActivityService()
-	s.method.Get = func(spath string, query url.Values) (*http.Response, error) {
+	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 		assert.Equal(t, want.spath, spath)
 		return nil, errors.New("error")
 	}
 
-	_, err := s.List(id)
+	_, err := s.List(context.Background(), id)
 	assert.Error(t, err)
 }
 
@@ -110,12 +111,12 @@ func TestUserActivityService_List_invalidID(t *testing.T) {
 
 	id := 0
 	s := newUserActivityService()
-	s.method.Get = func(spath string, query url.Values) (*http.Response, error) {
+	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 		t.Error("s.method.Get must never be called")
 		return nil, errors.New("error")
 	}
 
-	_, err := s.List(id)
+	_, err := s.List(context.Background(), id)
 	assert.Error(t, err)
 }
 
@@ -251,7 +252,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 			t.Parallel()
 
 			s := newSpaceActivityService()
-			s.method.Get = func(spath string, query url.Values) (*http.Response, error) {
+			s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, tc.want.activityTypeID, (query)["activityTypeId[]"])
 				assert.Equal(t, tc.want.minID, query.Get("minId"))
 				assert.Equal(t, tc.want.maxID, query.Get("maxId"))
@@ -265,7 +266,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 				return resp, nil
 			}
 
-			if resp, err := s.List(tc.opts...); tc.wantError {
+			if resp, err := s.List(context.Background(), tc.opts...); tc.wantError {
 				require.Error(t, err)
 				assert.Nil(t, resp)
 			} else {

--- a/activity_test.go
+++ b/activity_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,13 +17,13 @@ import (
 func TestProjectActivityService_List(t *testing.T) {
 	t.Parallel()
 
+	projectKey := "TEST"
+
 	want := struct {
 		spath string
 	}{
-		spath: "projects/TEST/activities",
+		spath: "projects/" + projectKey + "/activities",
 	}
-
-	projectKey := "TEST"
 
 	s := newProjectActivityService()
 	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
@@ -87,11 +88,12 @@ func TestSpaceActivityService_List(t *testing.T) {
 func TestUserActivityService_List(t *testing.T) {
 	t.Parallel()
 
-	id := 1
+	id := 1234
+
 	want := struct {
 		spath string
 	}{
-		spath: "users/1/activities",
+		spath: "users/" + strconv.Itoa(id) + "/activities",
 	}
 
 	s := newUserActivityService()
@@ -118,154 +120,135 @@ func TestUserActivityService_List_invalidID(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestUserActivityService_List_invalidJson(t *testing.T) {
-	t.Parallel()
-
-	s := newUserActivityService()
-	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-		resp := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
-		}
-		return resp, nil
-	}
-
-	activities, err := s.List(context.Background(), 1)
-	assert.Nil(t, activities)
-	assert.Error(t, err)
-}
-
 func TestBaseActivityService_GetList(t *testing.T) {
-	t.Parallel()
-
+	o := newActivityOptionService()
+	type want struct {
+		activityTypeID []string
+		minID          string
+		maxID          string
+		count          string
+		order          string
+	}
 	cases := map[string]struct {
-		opts []RequestOption
-
-		want struct {
-			activityTypeID []string
-			minID          string
-			maxID          string
-			count          string
-			order          string
-		}
-
+		opts      []RequestOption
 		wantError bool
+		want      want
 	}{
-		"no-option": {
-			want: struct {
-				activityTypeID []string
-				minID          string
-				maxID          string
-				count          string
-				order          string
-			}{
+		"success-no-option": {
+			opts:      []RequestOption{},
+			wantError: false,
+			want: want{
 				activityTypeID: nil,
 				minID:          "",
 				maxID:          "",
 				count:          "",
 				order:          "",
 			},
-			wantError: true,
 		},
-		"with-activityTypeID": {
+		"success-withActivityTypeIDs": {
 			opts: []RequestOption{
-				newSpaceActivityOptionService().WithActivityTypeIDs([]int{1, 2}),
+				o.WithActivityTypeIDs([]int{1}),
 			},
-			want: struct {
-				activityTypeID []string
-				minID          string
-				maxID          string
-				count          string
-				order          string
-			}{
-				activityTypeID: []string{"1", "2"},
+			wantError: false,
+			want: want{
+				activityTypeID: []string{"1"},
 				minID:          "",
 				maxID:          "",
 				count:          "",
 				order:          "",
 			},
-			wantError: true,
 		},
-		"with-minID": {
+		"success-withMinID": {
 			opts: []RequestOption{
-				newSpaceActivityOptionService().WithMinID(10),
+				o.WithMinID(1),
 			},
-			want: struct {
-				activityTypeID []string
-				minID          string
-				maxID          string
-				count          string
-				order          string
-			}{
+			wantError: false,
+			want: want{
 				activityTypeID: nil,
-				minID:          "10",
+				minID:          "1",
 				maxID:          "",
 				count:          "",
 				order:          "",
 			},
-			wantError: true,
 		},
-		"with-maxID": {
+		"success-withMaxID": {
 			opts: []RequestOption{
-				newSpaceActivityOptionService().WithMaxID(100),
+				o.WithMaxID(1),
 			},
-			want: struct {
-				activityTypeID []string
-				minID          string
-				maxID          string
-				count          string
-				order          string
-			}{
+			wantError: false,
+			want: want{
 				activityTypeID: nil,
 				minID:          "",
-				maxID:          "100",
+				maxID:          "1",
 				count:          "",
 				order:          "",
 			},
-			wantError: true,
 		},
-		"with-count": {
+		"success-withCount": {
 			opts: []RequestOption{
-				newSpaceActivityOptionService().WithCount(20),
+				o.WithCount(1),
 			},
-			want: struct {
-				activityTypeID []string
-				minID          string
-				maxID          string
-				count          string
-				order          string
-			}{
+			wantError: false,
+			want: want{
 				activityTypeID: nil,
 				minID:          "",
 				maxID:          "",
-				count:          "20",
+				count:          "1",
 				order:          "",
 			},
-			wantError: true,
 		},
-		"with-order": {
+		"success-withOrder": {
 			opts: []RequestOption{
-				newSpaceActivityOptionService().WithOrder(OrderAsc),
+				o.WithOrder(OrderAsc),
 			},
-			want: struct {
-				activityTypeID []string
-				minID          string
-				maxID          string
-				count          string
-				order          string
-			}{
+			wantError: false,
+			want: want{
 				activityTypeID: nil,
 				minID:          "",
 				maxID:          "",
 				count:          "",
 				order:          "asc",
 			},
+		},
+		"success-multiple-options": {
+			opts: []RequestOption{
+				o.WithActivityTypeIDs([]int{1, 2}),
+				o.WithMinID(1),
+				o.WithMaxID(26),
+				o.WithCount(20),
+				o.WithOrder(OrderAsc),
+			},
+			wantError: false,
+			want: want{
+				activityTypeID: []string{"1", "2"},
+				minID:          "1",
+				maxID:          "26",
+				count:          "20",
+				order:          "asc",
+			},
+		},
+		"error-option-invalid-value": {
+			opts: []RequestOption{
+				o.WithCount(0),
+			},
+			wantError: true,
+			want:      want{},
+		},
+		"error-option-invalid-type": {
+			opts:      []RequestOption{newInvalidTypeOption()},
+			wantError: true,
+			want:      want{},
+		},
+		"error-option-set-failed": {
+			opts: []RequestOption{
+				newFailingSetOption(paramCount),
+			},
 			wantError: true,
 		},
 	}
 
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
 			t.Parallel()
 
 			s := newSpaceActivityService()
@@ -275,17 +258,19 @@ func TestBaseActivityService_GetList(t *testing.T) {
 				assert.Equal(t, tc.want.maxID, query.Get("maxId"))
 				assert.Equal(t, tc.want.count, query.Get("count"))
 				assert.Equal(t, tc.want.order, query.Get("order"))
-				return &http.Response{
+
+				resp := &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
-				}, nil
+					Body:       io.NopCloser(bytes.NewReader([]byte(testdataActivityListJSON))),
+				}
+				return resp, nil
 			}
 
 			if resp, err := s.List(context.Background(), tc.opts...); tc.wantError {
 				require.Error(t, err)
 				assert.Nil(t, resp)
 			} else {
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				assert.NotNil(t, resp)
 			}
 		})

--- a/attachment.go
+++ b/attachment.go
@@ -1,6 +1,7 @@
 package backlog
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/url"
@@ -25,8 +26,8 @@ type SpaceAttachmentService struct {
 // The file name must not be empty.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/post-attachment-file
-func (s *SpaceAttachmentService) Upload(fileName string, r io.Reader) (*Attachment, error) {
-	resp, err := s.method.Upload("space/attachment", fileName, r)
+func (s *SpaceAttachmentService) Upload(ctx context.Context, fileName string, r io.Reader) (*Attachment, error) {
+	resp, err := s.method.Upload(ctx, "space/attachment", fileName, r)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +40,8 @@ func (s *SpaceAttachmentService) Upload(fileName string, r io.Reader) (*Attachme
 	return &v, nil
 }
 
-func listAttachments(m *method, spath string) ([]*Attachment, error) {
-	resp, err := m.Get(spath, nil)
+func listAttachments(ctx context.Context, m *method, spath string) ([]*Attachment, error) {
+	resp, err := m.Get(ctx, spath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +54,8 @@ func listAttachments(m *method, spath string) ([]*Attachment, error) {
 	return v, nil
 }
 
-func removeAttachment(m *method, spath string) (*Attachment, error) {
-	resp, err := m.Delete(spath, nil)
+func removeAttachment(ctx context.Context, m *method, spath string) (*Attachment, error) {
+	resp, err := m.Delete(ctx, spath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +76,7 @@ type WikiAttachmentService struct {
 // Attach attaches files uploaded to the space to the specified wiki.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/attach-file-to-wiki
-func (s *WikiAttachmentService) Attach(wikiID int, attachmentIDs []int) ([]*Attachment, error) {
+func (s *WikiAttachmentService) Attach(ctx context.Context, wikiID int, attachmentIDs []int) ([]*Attachment, error) {
 	if err := validateWikiID(wikiID); err != nil {
 		return nil, err
 	}
@@ -92,7 +93,7 @@ func (s *WikiAttachmentService) Attach(wikiID int, attachmentIDs []int) ([]*Atta
 	}
 
 	spath := path.Join("wikis/", strconv.Itoa(wikiID), "/attachments")
-	resp, err := s.method.Post(spath, form)
+	resp, err := s.method.Post(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
@@ -108,19 +109,19 @@ func (s *WikiAttachmentService) Attach(wikiID int, attachmentIDs []int) ([]*Atta
 // List returns a list of all attachments in the wiki.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-wiki-attachments
-func (s *WikiAttachmentService) List(wikiID int) ([]*Attachment, error) {
+func (s *WikiAttachmentService) List(ctx context.Context, wikiID int) ([]*Attachment, error) {
 	if err := validateWikiID(wikiID); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("wikis", strconv.Itoa(wikiID), "attachments")
-	return listAttachments(s.method, spath)
+	return listAttachments(ctx, s.method, spath)
 }
 
 // Remove removes a file attached to the wiki.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/remove-wiki-attachment
-func (s *WikiAttachmentService) Remove(wikiID, attachmentID int) (*Attachment, error) {
+func (s *WikiAttachmentService) Remove(ctx context.Context, wikiID, attachmentID int) (*Attachment, error) {
 	if err := validateWikiID(wikiID); err != nil {
 		return nil, err
 	}
@@ -129,7 +130,7 @@ func (s *WikiAttachmentService) Remove(wikiID, attachmentID int) (*Attachment, e
 	}
 
 	spath := path.Join("wikis", strconv.Itoa(wikiID), "attachments", strconv.Itoa(attachmentID))
-	return removeAttachment(s.method, spath)
+	return removeAttachment(ctx, s.method, spath)
 }
 
 // IssueAttachmentService handles communication with the issue attachment-related methods of the Backlog API.
@@ -140,19 +141,19 @@ type IssueAttachmentService struct {
 // List returns a list of all attachments in the issue.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-issue-attachments
-func (s *IssueAttachmentService) List(issueIDOrKey string) ([]*Attachment, error) {
+func (s *IssueAttachmentService) List(ctx context.Context, issueIDOrKey string) ([]*Attachment, error) {
 	if err := validateIssueIDOrKey(issueIDOrKey); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("issues", issueIDOrKey, "attachments")
-	return listAttachments(s.method, spath)
+	return listAttachments(ctx, s.method, spath)
 }
 
 // Remove removes a file attached to the issue.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-issue-attachment
-func (s *IssueAttachmentService) Remove(issueIDOrKey string, attachmentID int) (*Attachment, error) {
+func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string, attachmentID int) (*Attachment, error) {
 	if err := validateIssueIDOrKey(issueIDOrKey); err != nil {
 		return nil, err
 	}
@@ -161,7 +162,7 @@ func (s *IssueAttachmentService) Remove(issueIDOrKey string, attachmentID int) (
 	}
 
 	spath := path.Join("issues", issueIDOrKey, "attachments", strconv.Itoa(attachmentID))
-	return removeAttachment(s.method, spath)
+	return removeAttachment(ctx, s.method, spath)
 }
 
 // PullRequestAttachmentService handles communication with the pull request attachment-related methods of the Backlog API.
@@ -172,7 +173,7 @@ type PullRequestAttachmentService struct {
 // List returns a list of all attachments in the pull request.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-pull-request-attachment
-func (s *PullRequestAttachmentService) List(projectIDOrKey string, repositoryIDOrName string, prNumber int) ([]*Attachment, error) {
+func (s *PullRequestAttachmentService) List(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int) ([]*Attachment, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -184,13 +185,13 @@ func (s *PullRequestAttachmentService) List(projectIDOrKey string, repositoryIDO
 	}
 
 	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repositoryIDOrName, "pullRequests", strconv.Itoa(prNumber), "attachments")
-	return listAttachments(s.method, spath)
+	return listAttachments(ctx, s.method, spath)
 }
 
 // Remove removes a file attached to the pull request.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-pull-request-attachments
-func (s *PullRequestAttachmentService) Remove(projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*Attachment, error) {
+func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*Attachment, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -205,5 +206,5 @@ func (s *PullRequestAttachmentService) Remove(projectIDOrKey string, repositoryI
 	}
 
 	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repositoryIDOrName, "pullRequests", strconv.Itoa(prNumber), "attachments", strconv.Itoa(attachmentID))
-	return removeAttachment(s.method, spath)
+	return removeAttachment(ctx, s.method, spath)
 }

--- a/attachment_test.go
+++ b/attachment_test.go
@@ -885,3 +885,92 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 		})
 	}
 }
+
+// TestAttachmentService_contextPropagation verifies that the context passed to
+// each attachment service method is correctly relayed to the underlying method call.
+// A sentinel value is embedded in the context and its pointer identity is
+// asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
+func TestAttachmentService_contextPropagation(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+	sentinel := &struct{}{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+
+	cases := []struct {
+		name string
+		call func(t *testing.T)
+	}{
+		{"SpaceAttachmentService.Upload", func(t *testing.T) {
+			s := newSpaceAttachmentService()
+			s.method.Upload = func(got context.Context, _, _ string, _ io.Reader) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Upload(ctx, "f", bytes.NewReader(nil)) //nolint:errcheck
+		}},
+		{"WikiAttachmentService.Attach", func(t *testing.T) {
+			s := newWikiAttachmentService()
+			s.method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Attach(ctx, 1, []int{1}) //nolint:errcheck
+		}},
+		{"WikiAttachmentService.List", func(t *testing.T) {
+			s := newWikiAttachmentService()
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.List(ctx, 1) //nolint:errcheck
+		}},
+		{"WikiAttachmentService.Remove", func(t *testing.T) {
+			s := newWikiAttachmentService()
+			s.method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Remove(ctx, 1, 1) //nolint:errcheck
+		}},
+		{"IssueAttachmentService.List", func(t *testing.T) {
+			s := newIssueAttachmentService()
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.List(ctx, "TEST-1") //nolint:errcheck
+		}},
+		{"IssueAttachmentService.Remove", func(t *testing.T) {
+			s := newIssueAttachmentService()
+			s.method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Remove(ctx, "TEST-1", 1) //nolint:errcheck
+		}},
+		{"PullRequestAttachmentService.List", func(t *testing.T) {
+			s := newPullRequestAttachmentService()
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.List(ctx, "TEST", "repo", 1) //nolint:errcheck
+		}},
+		{"PullRequestAttachmentService.Remove", func(t *testing.T) {
+			s := newPullRequestAttachmentService()
+			s.method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Remove(ctx, "TEST", "repo", 1, 1) //nolint:errcheck
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.call(t)
+		})
+	}
+}

--- a/attachment_test.go
+++ b/attachment_test.go
@@ -2,6 +2,7 @@ package backlog
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -93,11 +94,11 @@ func TestSpaceAttachmentService_Upload(t *testing.T) {
 
 		expectError bool
 
-		mockUploadFn func(spath, fileName string, r io.Reader) (*http.Response, error)
+		mockUploadFn func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error)
 	}{
 		"success": {
 			fpath: "fpath",
-			mockUploadFn: func(spath, fileName string, r io.Reader) (*http.Response, error) {
+			mockUploadFn: func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
 				assert.Equal(t, "space/attachment", spath)
 				assert.Equal(t, "fpath", fileName)
 
@@ -111,7 +112,7 @@ func TestSpaceAttachmentService_Upload(t *testing.T) {
 		"error-client-failure": {
 			fpath:       "fpath",
 			expectError: true,
-			mockUploadFn: func(spath, fileName string, r io.Reader) (*http.Response, error) {
+			mockUploadFn: func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 		},
@@ -119,7 +120,7 @@ func TestSpaceAttachmentService_Upload(t *testing.T) {
 		"error-invalid-json": {
 			fpath:       "fpath",
 			expectError: true,
-			mockUploadFn: func(spath, fileName string, r io.Reader) (*http.Response, error) {
+			mockUploadFn: func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
@@ -139,7 +140,7 @@ func TestSpaceAttachmentService_Upload(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			attachment, err := s.Upload(tc.fpath, f)
+			attachment, err := s.Upload(context.Background(), tc.fpath, f)
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -165,13 +166,13 @@ func TestWikiAttachmentService_Attach(t *testing.T) {
 		expectError bool
 		want        []*Attachment
 
-		mockPostFn func(spath string, form url.Values) (*http.Response, error)
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 	}{
 		"success-single": {
 			wikiID:        1234,
 			attachmentIDs: []int{2},
 			want:          newTestAttachmentSingleList(),
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/attachments", spath)
 
 				v := form
@@ -190,7 +191,7 @@ func TestWikiAttachmentService_Attach(t *testing.T) {
 			wikiID:        1,
 			attachmentIDs: []int{2, 5},
 			want:          newTestAttachmentList(),
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body: io.NopCloser(
@@ -225,7 +226,7 @@ func TestWikiAttachmentService_Attach(t *testing.T) {
 			wikiID:        1234,
 			attachmentIDs: []int{2},
 			expectError:   true,
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 		},
@@ -234,7 +235,7 @@ func TestWikiAttachmentService_Attach(t *testing.T) {
 			wikiID:        1234,
 			attachmentIDs: []int{2},
 			expectError:   true,
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body: io.NopCloser(
@@ -252,7 +253,7 @@ func TestWikiAttachmentService_Attach(t *testing.T) {
 			s := newWikiAttachmentService()
 			s.method.Post = tc.mockPostFn
 
-			attachments, err := s.Attach(tc.wikiID, tc.attachmentIDs)
+			attachments, err := s.Attach(context.Background(), tc.wikiID, tc.attachmentIDs)
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -282,12 +283,12 @@ func TestWikiAttachmentService_List(t *testing.T) {
 		expectError bool
 		want        []*Attachment
 
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 	}{
 		"success": {
 			wikiID: 1234,
 			want:   newTestAttachmentList(),
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/attachments", spath)
 
 				return &http.Response{
@@ -314,7 +315,7 @@ func TestWikiAttachmentService_List(t *testing.T) {
 		"error-client": {
 			wikiID:      1234,
 			expectError: true,
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 		},
@@ -322,7 +323,7 @@ func TestWikiAttachmentService_List(t *testing.T) {
 		"error-invalid-json": {
 			wikiID:      1234,
 			expectError: true,
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body: io.NopCloser(
@@ -340,7 +341,7 @@ func TestWikiAttachmentService_List(t *testing.T) {
 			s := newWikiAttachmentService()
 			s.method.Get = tc.mockGetFn
 
-			attachments, err := s.List(tc.wikiID)
+			attachments, err := s.List(context.Background(), tc.wikiID)
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -371,13 +372,13 @@ func TestWikiAttachmentService_Remove(t *testing.T) {
 		expectError bool
 		want        *Attachment
 
-		mockDeleteFn func(spath string, form url.Values) (*http.Response, error)
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 	}{
 		"success": {
 			wikiID:       1234,
 			attachmentID: 8,
 			want:         newTestAttachment(),
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/attachments/8", spath)
 
 				return &http.Response{
@@ -421,7 +422,7 @@ func TestWikiAttachmentService_Remove(t *testing.T) {
 			wikiID:       1234,
 			attachmentID: 8,
 			expectError:  true,
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 		},
@@ -430,7 +431,7 @@ func TestWikiAttachmentService_Remove(t *testing.T) {
 			wikiID:       1234,
 			attachmentID: 8,
 			expectError:  true,
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body: io.NopCloser(
@@ -448,7 +449,7 @@ func TestWikiAttachmentService_Remove(t *testing.T) {
 			s := newWikiAttachmentService()
 			s.method.Delete = tc.mockDeleteFn
 
-			attachment, err := s.Remove(tc.wikiID, tc.attachmentID)
+			attachment, err := s.Remove(context.Background(), tc.wikiID, tc.attachmentID)
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -474,12 +475,12 @@ func TestIssueAttachmentService_List(t *testing.T) {
 		expectError bool
 		want        []*Attachment
 
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 	}{
 		"success": {
 			issueIDOrKey: "1234",
 			want:         newTestAttachmentList(),
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/1234/attachments", spath)
 
 				return &http.Response{
@@ -500,7 +501,7 @@ func TestIssueAttachmentService_List(t *testing.T) {
 		"error-client": {
 			issueIDOrKey: "1234",
 			expectError:  true,
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 		},
@@ -508,7 +509,7 @@ func TestIssueAttachmentService_List(t *testing.T) {
 		"error-invalid-json": {
 			issueIDOrKey: "1234",
 			expectError:  true,
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body: io.NopCloser(
@@ -526,7 +527,7 @@ func TestIssueAttachmentService_List(t *testing.T) {
 			s := newIssueAttachmentService()
 			s.method.Get = tc.mockGetFn
 
-			attachments, err := s.List(tc.issueIDOrKey)
+			attachments, err := s.List(context.Background(), tc.issueIDOrKey)
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -557,13 +558,13 @@ func TestIssueAttachmentService_Remove(t *testing.T) {
 		expectError bool
 		want        *Attachment
 
-		mockDeleteFn func(spath string, form url.Values) (*http.Response, error)
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 	}{
 		"success": {
 			issueIDOrKey: "1234",
 			attachmentID: 8,
 			want:         newTestAttachment(),
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/1234/attachments/8", spath)
 
 				return &http.Response{
@@ -593,7 +594,7 @@ func TestIssueAttachmentService_Remove(t *testing.T) {
 			issueIDOrKey: "1234",
 			attachmentID: 8,
 			expectError:  true,
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 		},
@@ -602,7 +603,7 @@ func TestIssueAttachmentService_Remove(t *testing.T) {
 			issueIDOrKey: "1234",
 			attachmentID: 8,
 			expectError:  true,
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body: io.NopCloser(
@@ -620,7 +621,7 @@ func TestIssueAttachmentService_Remove(t *testing.T) {
 			s := newIssueAttachmentService()
 			s.method.Delete = tc.mockDeleteFn
 
-			attachment, err := s.Remove(tc.issueIDOrKey, tc.attachmentID)
+			attachment, err := s.Remove(context.Background(), tc.issueIDOrKey, tc.attachmentID)
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -648,14 +649,14 @@ func TestPullRequestAttachmentService_List(t *testing.T) {
 		expectError bool
 		want        []*Attachment
 
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 	}{
 		"success": {
 			projectIDOrKey:     "TEST",
 			repositoryIDOrName: "test",
 			prNumber:           1234,
 			want:               newTestAttachmentList(),
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(
 					t,
 					"projects/TEST/git/repositories/test/pullRequests/1234/attachments",
@@ -700,7 +701,7 @@ func TestPullRequestAttachmentService_List(t *testing.T) {
 			repositoryIDOrName: "test",
 			prNumber:           10,
 			expectError:        true,
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 		},
@@ -710,7 +711,7 @@ func TestPullRequestAttachmentService_List(t *testing.T) {
 			repositoryIDOrName: "test",
 			prNumber:           10,
 			expectError:        true,
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body: io.NopCloser(
@@ -728,7 +729,7 @@ func TestPullRequestAttachmentService_List(t *testing.T) {
 			s := newPullRequestAttachmentService()
 			s.method.Get = tc.mockGetFn
 
-			attachments, err := s.List(
+			attachments, err := s.List(context.Background(),
 				tc.projectIDOrKey,
 				tc.repositoryIDOrName,
 				tc.prNumber,
@@ -765,7 +766,7 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 		expectError bool
 		want        *Attachment
 
-		mockDeleteFn func(spath string, form url.Values) (*http.Response, error)
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 	}{
 		"success": {
 			projectIDOrKey:     "TEST",
@@ -773,7 +774,7 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 			prNumber:           1234,
 			attachmentID:       8,
 			want:               newTestAttachment(),
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(
 					t,
 					"projects/TEST/git/repositories/test/pullRequests/1234/attachments/8",
@@ -831,7 +832,7 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 			prNumber:           10,
 			attachmentID:       8,
 			expectError:        true,
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 		},
@@ -842,7 +843,7 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 			prNumber:           10,
 			attachmentID:       8,
 			expectError:        true,
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body: io.NopCloser(
@@ -861,6 +862,7 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 			s.method.Delete = tc.mockDeleteFn
 
 			attachment, err := s.Remove(
+				context.Background(),
 				tc.projectIDOrKey,
 				tc.repositoryIDOrName,
 				tc.prNumber,

--- a/attachment_test.go
+++ b/attachment_test.go
@@ -891,8 +891,6 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 // A sentinel value is embedded in the context and its pointer identity is
 // asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
 func TestAttachmentService_contextPropagation(t *testing.T) {
-	t.Parallel()
-
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)

--- a/client.go
+++ b/client.go
@@ -155,7 +155,7 @@ func NewClient(baseURL, token string, doer Doer) (*Client, error) {
 // ──────────────────────────────────────────────────────────────
 
 // newRequest builds a new HTTP request with token-based authentication.
-func (c *Client) newRequest(method, spath string, opts ...*httpRequestOption) (*http.Request, error) {
+func (c *Client) newRequest(ctx context.Context, method, spath string, opts ...*httpRequestOption) (*http.Request, error) {
 	if spath == "" {
 		return nil, errors.New("spath must not be empty")
 	}
@@ -173,7 +173,7 @@ func (c *Client) newRequest(method, spath string, opts ...*httpRequestOption) (*
 		u.RawQuery = config.Query.Encode()
 	}
 
-	req, err := http.NewRequest(method, u.String(), config.Body)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), config.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (c *Client) newRequest(method, spath string, opts ...*httpRequestOption) (*
 // do executes the given HTTP request using the injected Doer.
 // All HTTP calls pass through this function, ensuring consistent error handling.
 func (c *Client) do(ctx context.Context, method, spath string, opts ...*httpRequestOption) (*http.Response, error) {
-	req, err := c.newRequest(method, spath, opts...)
+	req, err := c.newRequest(ctx, method, spath, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package backlog
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -52,11 +53,11 @@ type Client struct {
 // Each function delegates to Client.do() but can be replaced in tests
 // for fine-grained unit testing of individual services.
 type method struct {
-	Get    func(spath string, query url.Values) (*http.Response, error)
-	Post   func(spath string, form url.Values) (*http.Response, error)
-	Patch  func(spath string, form url.Values) (*http.Response, error)
-	Delete func(spath string, form url.Values) (*http.Response, error)
-	Upload func(spath, fileName string, r io.Reader) (*http.Response, error)
+	Get    func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+	Post   func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+	Patch  func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+	Delete func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+	Upload func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -92,34 +93,34 @@ func NewClient(baseURL, token string, doer Doer) (*Client, error) {
 
 	// --- Inject HTTP method wrappers ------------------------------------------
 	c.method = &method{
-		Get: func(spath string, query url.Values) (*http.Response, error) {
-			return c.do(http.MethodGet, spath, withQuery(query))
+		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+			return c.do(ctx, http.MethodGet, spath, withQuery(query))
 		},
-		Post: func(spath string, form url.Values) (*http.Response, error) {
+		Post: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 			header := http.Header{}
 			header.Set("Content-Type", "application/x-www-form-urlencoded")
 			if form == nil {
 				form = url.Values{}
 			}
-			return c.do(http.MethodPost, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
+			return c.do(ctx, http.MethodPost, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
 		},
-		Patch: func(spath string, form url.Values) (*http.Response, error) {
+		Patch: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 			header := http.Header{}
 			header.Set("Content-Type", "application/x-www-form-urlencoded")
 			if form == nil {
 				form = url.Values{}
 			}
-			return c.do(http.MethodPatch, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
+			return c.do(ctx, http.MethodPatch, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
 		},
-		Delete: func(spath string, form url.Values) (*http.Response, error) {
+		Delete: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 			header := http.Header{}
 			header.Set("Content-Type", "application/x-www-form-urlencoded")
 			if form == nil {
 				form = url.Values{}
 			}
-			return c.do(http.MethodDelete, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
+			return c.do(ctx, http.MethodDelete, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
 		},
-		Upload: func(spath, fileName string, r io.Reader) (*http.Response, error) {
+		Upload: func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
 			if fileName == "" {
 				return nil, newInternalClientError("fileName is required")
 			}
@@ -140,7 +141,7 @@ func NewClient(baseURL, token string, doer Doer) (*Client, error) {
 			header := http.Header{}
 			header.Set("Content-Type", mw.FormDataContentType())
 
-			return c.do(http.MethodPost, spath, withHeader(header), withBody(&buf))
+			return c.do(ctx, http.MethodPost, spath, withHeader(header), withBody(&buf))
 		},
 	}
 
@@ -187,7 +188,7 @@ func (c *Client) newRequest(method, spath string, opts ...*httpRequestOption) (*
 
 // do executes the given HTTP request using the injected Doer.
 // All HTTP calls pass through this function, ensuring consistent error handling.
-func (c *Client) do(method, spath string, opts ...*httpRequestOption) (*http.Response, error) {
+func (c *Client) do(ctx context.Context, method, spath string, opts ...*httpRequestOption) (*http.Response, error) {
 	req, err := c.newRequest(method, spath, opts...)
 	if err != nil {
 		return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package backlog
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -228,6 +229,7 @@ func TestClient_do(t *testing.T) {
 			})
 
 			res, err := c.do(
+				context.Background(),
 				http.MethodGet,
 				"test",
 			)
@@ -376,7 +378,7 @@ func TestClient_method(t *testing.T) {
 	}{
 		"GET": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Get("/path1", nil)
+				return c.method.Get(context.Background(), "/path1", nil)
 			},
 			check: func(t *testing.T, captured *httpCapture) {
 				assert.Equal(t, "GET", captured.Method)
@@ -392,7 +394,7 @@ func TestClient_method(t *testing.T) {
 			call: func(c *Client) (*http.Response, error) {
 				form := url.Values{}
 				form.Add("k", "v")
-				return c.method.Post("/path2", form)
+				return c.method.Post(context.Background(), "/path2", form)
 			},
 			check: func(t *testing.T, captured *httpCapture) {
 				assert.Equal(t, "POST", captured.Method)
@@ -408,7 +410,7 @@ func TestClient_method(t *testing.T) {
 			call: func(c *Client) (*http.Response, error) {
 				form := url.Values{}
 				form.Add("id", "123")
-				return c.method.Patch("/path3", form)
+				return c.method.Patch(context.Background(), "/path3", form)
 			},
 			check: func(t *testing.T, captured *httpCapture) {
 				assert.Equal(t, "PATCH", captured.Method)
@@ -423,7 +425,7 @@ func TestClient_method(t *testing.T) {
 			call: func(c *Client) (*http.Response, error) {
 				form := url.Values{}
 				form.Add("id", "321")
-				return c.method.Delete("/path4", form)
+				return c.method.Delete(context.Background(), "/path4", form)
 			},
 			check: func(t *testing.T, captured *httpCapture) {
 				assert.Equal(t, "DELETE", captured.Method)
@@ -437,7 +439,7 @@ func TestClient_method(t *testing.T) {
 		"UPLOAD": {
 			call: func(c *Client) (*http.Response, error) {
 				buf := bytes.NewBufferString("dummyfiledata")
-				return c.method.Upload("/upload-path", "file.txt", buf)
+				return c.method.Upload(context.Background(), "/upload-path", "file.txt", buf)
 			},
 			check: func(t *testing.T, captured *httpCapture) {
 				assert.Equal(t, "POST", captured.Method)
@@ -471,40 +473,40 @@ func TestClient_method(t *testing.T) {
 		// エラーケースは変更なし
 		"GET newRequest error": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Get("", url.Values{})
+				return c.method.Get(context.Background(), "", url.Values{})
 			},
 			wantErr: true,
 		},
 
 		"POST newRequest error": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Post("", nil)
+				return c.method.Post(context.Background(), "", nil)
 			},
 			wantErr: true,
 		},
 
 		"PATCH empty params": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Patch("spath", nil)
+				return c.method.Patch(context.Background(), "spath", nil)
 			},
 		},
 
 		"PATCH newRequest error": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Patch("", nil)
+				return c.method.Patch(context.Background(), "", nil)
 			},
 			wantErr: true,
 		},
 
 		"DELETE empty params": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Delete("spath", nil)
+				return c.method.Delete(context.Background(), "spath", nil)
 			},
 		},
 
 		"DELETE newRequest error": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Delete("", nil)
+				return c.method.Delete(context.Background(), "", nil)
 			},
 			wantErr: true,
 		},
@@ -594,7 +596,7 @@ func TestClient_methodUpload_errors(t *testing.T) {
 
 			f := io.NopCloser(bytes.NewBufferString(tc.fileData))
 
-			resp, err := c.method.Upload(tc.spath, tc.fileName, f)
+			resp, err := c.method.Upload(context.Background(), tc.spath, tc.fileName, f)
 
 			assert.Error(t, err)
 			assert.Nil(t, resp)

--- a/client_test.go
+++ b/client_test.go
@@ -86,7 +86,7 @@ func TestNewClient_initialization(t *testing.T) {
 		require.NoError(t, err)
 
 		{
-			req, _ := c.newRequest(http.MethodGet, "test")
+			req, _ := c.newRequest(context.Background(), http.MethodGet, "test")
 			res, err := c.doer.Do(req)
 			require.Error(t, err)
 			assert.Nil(t, res)
@@ -350,6 +350,7 @@ func TestClient_newRequest(t *testing.T) {
 
 			c := newClientMock(t, "https://test.com", "test", nil)
 			request, err := c.newRequest(
+				context.Background(),
 				tc.method,
 				tc.spath,
 				withHeader(tc.header),

--- a/examples/attachment/all/main.go
+++ b/examples/attachment/all/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -20,7 +21,7 @@ func main() {
 	}
 
 	// You get all attachments of the Wiki.
-	r, err := c.Wiki.Attachment.List(12345)
+	r, err := c.Wiki.Attachment.List(context.Background(), 12345)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/attachment/attatch/main.go
+++ b/examples/attachment/attatch/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -22,7 +23,7 @@ func main() {
 	attachmentIDs := []int{0123, 0124, 0125}
 
 	// Attach uploded files to Wiki.
-	r, err := c.Wiki.Attachment.Attach(12345, attachmentIDs)
+	r, err := c.Wiki.Attachment.Attach(context.Background(), 12345, attachmentIDs)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/attachment/delete/main.go
+++ b/examples/attachment/delete/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -19,7 +20,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	r, err := c.Wiki.Delete(1234)
+	r, err := c.Wiki.Delete(context.Background(), 1234)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/attachment/one/main.go
+++ b/examples/attachment/one/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -19,7 +20,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	r, err := c.Wiki.One(12345)
+	r, err := c.Wiki.One(context.Background(), 12345)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/attachment/upload/main.go
+++ b/examples/attachment/upload/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -26,7 +27,7 @@ func main() {
 	}
 	defer f.Close()
 
-	r, err := c.Space.Attachment.Upload(f.Name(), f)
+	r, err := c.Space.Attachment.Upload(context.Background(), f.Name(), f)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/change_wiki_name/main.go
+++ b/examples/change_wiki_name/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -32,7 +33,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	r, err := c.Wiki.All(projectKey)
+	r, err := c.Wiki.All(context.Background(), projectKey)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -74,7 +75,7 @@ func main() {
 	// When agreement is obtained, update the name of the Wiki
 	if agree == "y" || agree == "Y" || agree == "yes" || agree == "Yes" {
 		for _, t := range targets {
-			c.Wiki.Update(t.wikiID, c.Wiki.Option.WithName(t.name))
+			c.Wiki.Update(context.Background(), t.wikiID, c.Wiki.Option.WithName(t.name))
 		}
 	} else {
 		fmt.Println("exit.")

--- a/examples/wiki/all/main.go
+++ b/examples/wiki/all/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -19,7 +20,7 @@ func main() {
 	}
 	// ID or Key of the project.
 	projectKey := "PROJECTKEY"
-	r, err := c.Wiki.All(projectKey)
+	r, err := c.Wiki.All(context.Background(), projectKey)
 	// projectID := "1234"
 	// r, err := c.Wiki.All(projectID)
 

--- a/examples/wiki/count/main.go
+++ b/examples/wiki/count/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -24,7 +25,7 @@ func main() {
 	// projectKey := "ProjectKey"
 
 	// Get count of how many Wiki in project.
-	count, err := c.Wiki.Count(projectID)
+	count, err := c.Wiki.Count(context.Background(), projectID)
 	// count, err := c.Wiki.Count(projectKey)
 
 	if err != nil {

--- a/examples/wiki/create/main.go
+++ b/examples/wiki/create/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -21,7 +22,7 @@ func main() {
 
 	// Create a new Wiki by ID of the project.
 	// You get struct where represented the Wiki created.
-	r, err := c.Wiki.Create(12345, "name", "content")
+	r, err := c.Wiki.Create(context.Background(), 12345, "name", "content")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/wiki/delete/main.go
+++ b/examples/wiki/delete/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -21,7 +22,7 @@ func main() {
 
 	// Delete a Wiki by ID of the Wiki.
 	// You get struct where represented the Wiki deleted.
-	r, err := c.Wiki.Delete(1234)
+	r, err := c.Wiki.Delete(context.Background(), 1234)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/wiki/one/main.go
+++ b/examples/wiki/one/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -19,7 +20,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	r, err := c.Wiki.One(12345)
+	r, err := c.Wiki.One(context.Background(), 12345)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/wiki/update/main.go
+++ b/examples/wiki/update/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -18,7 +19,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	r, err := c.Wiki.Update(1234, c.Wiki.Option.WithName("changed name"), c.Wiki.Option.WithContent("changed content"))
+	r, err := c.Wiki.Update(context.Background(), 1234, c.Wiki.Option.WithName("changed name"), c.Wiki.Option.WithContent("changed content"))
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,6 +1,7 @@
 package backlog
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -185,28 +186,28 @@ func newPullRequestAttachmentService() *PullRequestAttachmentService {
 // Each API function (Get, Post, Patch, Delete) returns a default "not implemented" error.
 func newClientMethod() *method {
 	return &method{
-		Get: func(spath string, query url.Values) (*http.Response, error) {
+		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 			return nil, errors.New("default mock not implemented")
 		},
-		Post: func(spath string, form url.Values) (*http.Response, error) {
+		Post: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 			return nil, errors.New("default mock not implemented")
 		},
-		Patch: func(spath string, form url.Values) (*http.Response, error) {
+		Patch: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 			return nil, errors.New("default mock not implemented")
 		},
-		Delete: func(spath string, form url.Values) (*http.Response, error) {
+		Delete: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 			return nil, errors.New("default mock not implemented")
 		},
-		Upload: func(spath, fileName string, r io.Reader) (*http.Response, error) {
+		Upload: func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
 			return nil, errors.New("default mock not implemented")
 		},
 	}
 }
 
 // newUnexpectedGetFn returns a mock function for http GET that fails if called.
-func newUnexpectedGetFn(t *testing.T) func(spath string, query url.Values) (*http.Response, error) {
+func newUnexpectedGetFn(t *testing.T) func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 	t.Helper()
-	return func(spath string, query url.Values) (*http.Response, error) {
+	return func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 		t.Helper()
 		t.Error("Get must not be called")
 		return nil, errors.New("unexpected call")
@@ -214,9 +215,9 @@ func newUnexpectedGetFn(t *testing.T) func(spath string, query url.Values) (*htt
 }
 
 // newUnexpectedPostFn returns a mock function for http POST that fails if called.
-func newUnexpectedPostFn(t *testing.T) func(spath string, form url.Values) (*http.Response, error) {
+func newUnexpectedPostFn(t *testing.T) func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 	t.Helper()
-	return func(spath string, form url.Values) (*http.Response, error) {
+	return func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 		t.Helper()
 		t.Error("Post must not be called")
 		return nil, errors.New("unexpected call")
@@ -224,9 +225,9 @@ func newUnexpectedPostFn(t *testing.T) func(spath string, form url.Values) (*htt
 }
 
 // newUnexpectedPatchFn returns a mock function for http PATCH that fails if called.
-func newUnexpectedPatchFn(t *testing.T) func(spath string, form url.Values) (*http.Response, error) {
+func newUnexpectedPatchFn(t *testing.T) func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 	t.Helper()
-	return func(spath string, form url.Values) (*http.Response, error) {
+	return func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 		t.Helper()
 		t.Error("Patch must not be called")
 		return nil, errors.New("unexpected call")
@@ -234,9 +235,9 @@ func newUnexpectedPatchFn(t *testing.T) func(spath string, form url.Values) (*ht
 }
 
 // newUnexpectedDeleteFn returns a mock function for http DELETE that fails if called.
-func newUnexpectedDeleteFn(t *testing.T) func(spath string, form url.Values) (*http.Response, error) {
+func newUnexpectedDeleteFn(t *testing.T) func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 	t.Helper()
-	return func(spath string, form url.Values) (*http.Response, error) {
+	return func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 		t.Helper()
 		t.Error("Delete must not be called")
 		return nil, errors.New("unexpected call")
@@ -244,9 +245,9 @@ func newUnexpectedDeleteFn(t *testing.T) func(spath string, form url.Values) (*h
 }
 
 // newUnexpectedUploadFn returns a mock function for http Upload that fails if called.
-func newUnexpectedUploadFn(t *testing.T) func(spath, fileName string, r io.Reader) (*http.Response, error) {
+func newUnexpectedUploadFn(t *testing.T) func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
 	t.Helper()
-	return func(spath, fileName string, r io.Reader) (*http.Response, error) {
+	return func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
 		t.Helper()
 		t.Error("Upload must not be called")
 		return nil, errors.New("unexpected call")

--- a/project.go
+++ b/project.go
@@ -1,6 +1,7 @@
 package backlog
 
 import (
+	"context"
 	"net/url"
 	"path"
 )
@@ -39,7 +40,7 @@ type ProjectService struct {
 //   - WithQueryArchived
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-list
-func (s *ProjectService) All(opts ...RequestOption) ([]*Project, error) {
+func (s *ProjectService) All(ctx context.Context, opts ...RequestOption) ([]*Project, error) {
 
 	query := url.Values{}
 	validTypes := []apiParamOptionType{paramAll, paramArchived}
@@ -47,7 +48,7 @@ func (s *ProjectService) All(opts ...RequestOption) ([]*Project, error) {
 		return nil, err
 	}
 
-	resp, err := s.method.Get("projects", query)
+	resp, err := s.method.Get(ctx, "projects", query)
 	if err != nil {
 		return nil, err
 	}
@@ -63,13 +64,13 @@ func (s *ProjectService) All(opts ...RequestOption) ([]*Project, error) {
 // One returns one of the projects searched by ID or key.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project
-func (s *ProjectService) One(projectIDOrKey string) (*Project, error) {
+func (s *ProjectService) One(ctx context.Context, projectIDOrKey string) (*Project, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("projects", projectIDOrKey)
-	resp, err := s.method.Get(spath, nil)
+	resp, err := s.method.Get(ctx, spath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +93,7 @@ func (s *ProjectService) One(projectIDOrKey string) (*Project, error) {
 //   - WithTextFormattingRule
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project
-func (s *ProjectService) Create(key, name string, opts ...RequestOption) (*Project, error) {
+func (s *ProjectService) Create(ctx context.Context, key, name string, opts ...RequestOption) (*Project, error) {
 
 	form := url.Values{}
 	validTypes := []apiParamOptionType{paramKey, paramName, paramChartEnabled, paramSubtaskingEnabled, paramProjectLeaderCanEditProjectLeader, paramTextFormattingRule}
@@ -101,7 +102,7 @@ func (s *ProjectService) Create(key, name string, opts ...RequestOption) (*Proje
 		return nil, err
 	}
 
-	resp, err := s.method.Post("projects", form)
+	resp, err := s.method.Post(ctx, "projects", form)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +128,7 @@ func (s *ProjectService) Create(key, name string, opts ...RequestOption) (*Proje
 //   - WithTextFormattingRule
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-project
-func (s *ProjectService) Update(projectIDOrKey string, opts ...RequestOption) (*Project, error) {
+func (s *ProjectService) Update(ctx context.Context, projectIDOrKey string, opts ...RequestOption) (*Project, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -142,7 +143,7 @@ func (s *ProjectService) Update(projectIDOrKey string, opts ...RequestOption) (*
 	}
 
 	spath := path.Join("projects", projectIDOrKey)
-	resp, err := s.method.Patch(spath, form)
+	resp, err := s.method.Patch(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
@@ -158,13 +159,13 @@ func (s *ProjectService) Update(projectIDOrKey string, opts ...RequestOption) (*
 // Delete deletes a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-project
-func (s *ProjectService) Delete(projectIDOrKey string) (*Project, error) {
+func (s *ProjectService) Delete(ctx context.Context, projectIDOrKey string) (*Project, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("projects", projectIDOrKey)
-	resp, err := s.method.Delete(spath, url.Values{})
+	resp, err := s.method.Delete(ctx, spath, url.Values{})
 	if err != nil {
 		return nil, err
 	}

--- a/project_test.go
+++ b/project_test.go
@@ -653,8 +653,6 @@ func TestProjectService_Delete(t *testing.T) {
 // TestProjectService_contextPropagation verifies that the context passed to each
 // ProjectService method is correctly relayed to the underlying method call.
 func TestProjectService_contextPropagation(t *testing.T) {
-	t.Parallel()
-
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)

--- a/project_test.go
+++ b/project_test.go
@@ -2,6 +2,7 @@ package backlog
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -20,7 +21,7 @@ func TestProjectService_All(t *testing.T) {
 	cases := map[string]struct {
 		opts []RequestOption
 
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantIDs     []int
 		wantNames   []string
@@ -29,7 +30,7 @@ func TestProjectService_All(t *testing.T) {
 		"success-without-option": {
 			opts: []RequestOption{},
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects", spath)
 				require.NotNil(t, query)
 				assert.Empty(t, query)
@@ -49,7 +50,7 @@ func TestProjectService_All(t *testing.T) {
 				o.WithArchived(true),
 			},
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects", spath)
 				assert.Equal(t, "false", query.Get("all"))
 				assert.Equal(t, "true", query.Get("archived"))
@@ -76,7 +77,7 @@ func TestProjectService_All(t *testing.T) {
 		"error-client-network": {
 			opts: []RequestOption{},
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 
@@ -85,7 +86,7 @@ func TestProjectService_All(t *testing.T) {
 		"error-response-invalid-json": {
 			opts: []RequestOption{},
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
@@ -109,7 +110,7 @@ func TestProjectService_All(t *testing.T) {
 				s.method.Get = tc.mockGetFn
 			}
 
-			projects, err := s.All(tc.opts...)
+			projects, err := s.All(context.Background(), tc.opts...)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)
@@ -134,14 +135,14 @@ func TestProjectService_One(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantErrType error
 	}{
 		"success-projectIDOrKey-key": {
 			projectIDOrKey: "TEST",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST", spath)
 				assert.Nil(t, query)
 				return &http.Response{
@@ -155,7 +156,7 @@ func TestProjectService_One(t *testing.T) {
 		"success-projectIDOrKey-id": {
 			projectIDOrKey: strconv.Itoa(6),
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/6", spath)
 				assert.Nil(t, query)
 				return &http.Response{
@@ -174,7 +175,7 @@ func TestProjectService_One(t *testing.T) {
 		"error-client-network": {
 			projectIDOrKey: "TEST",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 
@@ -183,7 +184,7 @@ func TestProjectService_One(t *testing.T) {
 		"error-response-invalid-json": {
 			projectIDOrKey: "TEST",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
@@ -207,7 +208,7 @@ func TestProjectService_One(t *testing.T) {
 				s.method.Get = tc.mockGetFn
 			}
 
-			project, err := s.One(tc.projectIDOrKey)
+			project, err := s.One(context.Background(), tc.projectIDOrKey)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)
@@ -234,7 +235,7 @@ func TestProjectService_Create(t *testing.T) {
 		name string
 		opts []RequestOption
 
-		mockPostFn func(spath string, form url.Values) (*http.Response, error)
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantErrType error
 	}{
@@ -242,7 +243,7 @@ func TestProjectService_Create(t *testing.T) {
 			key:  "TEST",
 			name: "test",
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects", spath)
 				assert.NotNil(t, form)
 				assert.Equal(t, "TEST", form.Get("key"))
@@ -262,7 +263,7 @@ func TestProjectService_Create(t *testing.T) {
 			name: "test",
 			opts: []RequestOption{},
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "", form.Get("chartEnabled"))
 				assert.Equal(t, "", form.Get("subtaskingEnabled"))
 				assert.Equal(t, "", form.Get("projectLeaderCanEditProjectLeader"))
@@ -288,7 +289,7 @@ func TestProjectService_Create(t *testing.T) {
 				o.WithTextFormattingRule(FormatBacklog),
 			},
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "true", form.Get("chartEnabled"))
 				assert.Equal(t, "true", form.Get("subtaskingEnabled"))
 				assert.Equal(t, "true", form.Get("projectLeaderCanEditProjectLeader"))
@@ -341,7 +342,7 @@ func TestProjectService_Create(t *testing.T) {
 			key:  "TEST",
 			name: "test",
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 
@@ -352,7 +353,7 @@ func TestProjectService_Create(t *testing.T) {
 			key:  "TEST",
 			name: "test",
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
@@ -376,7 +377,7 @@ func TestProjectService_Create(t *testing.T) {
 				s.method.Post = tc.mockPostFn
 			}
 
-			project, err := s.Create(tc.key, tc.name, tc.opts...)
+			project, err := s.Create(context.Background(), tc.key, tc.name, tc.opts...)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)
@@ -401,14 +402,14 @@ func TestProjectService_Update(t *testing.T) {
 		projectIDOrKey string
 		opts           []RequestOption
 
-		mockPatchFn func(spath string, form url.Values) (*http.Response, error)
+		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantErrType error
 	}{
 		"success-projectIDOrKey-key": {
 			projectIDOrKey: "TEST",
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST", spath)
 				assert.NotNil(t, form)
 
@@ -424,7 +425,7 @@ func TestProjectService_Update(t *testing.T) {
 		"success-projectIDOrKey-id": {
 			projectIDOrKey: "1234",
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/1234", spath)
 
 				return &http.Response{
@@ -461,7 +462,7 @@ func TestProjectService_Update(t *testing.T) {
 				o.WithArchived(true),
 			},
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "TEST1", form.Get("key"))
 				assert.Equal(t, "test1", form.Get("name"))
 				assert.Equal(t, "true", form.Get("chartEnabled"))
@@ -500,7 +501,7 @@ func TestProjectService_Update(t *testing.T) {
 		"error-client-network": {
 			projectIDOrKey: "TEST",
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 
@@ -510,7 +511,7 @@ func TestProjectService_Update(t *testing.T) {
 		"error-response-invalid-json": {
 			projectIDOrKey: "TEST",
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
@@ -534,7 +535,7 @@ func TestProjectService_Update(t *testing.T) {
 				s.method.Patch = tc.mockPatchFn
 			}
 
-			project, err := s.Update(tc.projectIDOrKey, tc.opts...)
+			project, err := s.Update(context.Background(), tc.projectIDOrKey, tc.opts...)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)
@@ -553,14 +554,14 @@ func TestProjectService_Delete(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 
-		mockDeleteFn func(spath string, form url.Values) (*http.Response, error)
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantErrType error
 	}{
 		"success-projectIDOrKey-key": {
 			projectIDOrKey: "TEST",
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST", spath)
 				assert.NotNil(t, form)
 
@@ -575,7 +576,7 @@ func TestProjectService_Delete(t *testing.T) {
 		"success-projectIDOrKey-id": {
 			projectIDOrKey: "1234",
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/1234", spath)
 
 				return &http.Response{
@@ -599,7 +600,7 @@ func TestProjectService_Delete(t *testing.T) {
 		"error-client-network": {
 			projectIDOrKey: "TEST",
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
 			},
 
@@ -608,7 +609,7 @@ func TestProjectService_Delete(t *testing.T) {
 		"error-response-invalid-json": {
 			projectIDOrKey: "TEST",
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
@@ -632,7 +633,7 @@ func TestProjectService_Delete(t *testing.T) {
 				s.method.Delete = tc.mockDeleteFn
 			}
 
-			project, err := s.Delete(tc.projectIDOrKey)
+			project, err := s.Delete(context.Background(), tc.projectIDOrKey)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)

--- a/project_test.go
+++ b/project_test.go
@@ -649,3 +649,63 @@ func TestProjectService_Delete(t *testing.T) {
 		})
 	}
 }
+
+// TestProjectService_contextPropagation verifies that the context passed to each
+// ProjectService method is correctly relayed to the underlying method call.
+func TestProjectService_contextPropagation(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+	sentinel := &struct{}{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+
+	o := newProjectOptionService()
+
+	cases := []struct {
+		name string
+		call func(t *testing.T, s *ProjectService)
+	}{
+		{"All", func(t *testing.T, s *ProjectService) {
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.All(ctx) //nolint:errcheck
+		}},
+		{"One", func(t *testing.T, s *ProjectService) {
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.One(ctx, "TEST") //nolint:errcheck
+		}},
+		{"Create", func(t *testing.T, s *ProjectService) {
+			s.method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Create(ctx, "KEY", "name", o.WithChartEnabled(true)) //nolint:errcheck
+		}},
+		{"Update", func(t *testing.T, s *ProjectService) {
+			s.method.Patch = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Update(ctx, "TEST") //nolint:errcheck
+		}},
+		{"Delete", func(t *testing.T, s *ProjectService) {
+			s.method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Delete(ctx, "TEST") //nolint:errcheck
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.call(t, newProjectService())
+		})
+	}
+}

--- a/user.go
+++ b/user.go
@@ -1,6 +1,7 @@
 package backlog
 
 import (
+	"context"
 	"net/url"
 	"path"
 	"strconv"
@@ -20,8 +21,8 @@ func (id UserID) String() string {
 	return strconv.Itoa(int(id))
 }
 
-func getUser(m *method, spath string) (*User, error) {
-	resp, err := m.Get(spath, nil)
+func getUser(ctx context.Context, m *method, spath string) (*User, error) {
+	resp, err := m.Get(ctx, spath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -34,8 +35,8 @@ func getUser(m *method, spath string) (*User, error) {
 	return &v, nil
 }
 
-func getUserList(m *method, spath string, query url.Values) ([]*User, error) {
-	resp, err := m.Get(spath, query)
+func getUserList(ctx context.Context, m *method, spath string, query url.Values) ([]*User, error) {
+	resp, err := m.Get(ctx, spath, query)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +49,8 @@ func getUserList(m *method, spath string, query url.Values) ([]*User, error) {
 	return v, nil
 }
 
-func addUser(m *method, spath string, form url.Values) (*User, error) {
-	resp, err := m.Post(spath, form)
+func addUser(ctx context.Context, m *method, spath string, form url.Values) (*User, error) {
+	resp, err := m.Post(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +63,8 @@ func addUser(m *method, spath string, form url.Values) (*User, error) {
 	return &v, nil
 }
 
-func updateUser(m *method, spath string, form url.Values) (*User, error) {
-	resp, err := m.Patch(spath, form)
+func updateUser(ctx context.Context, m *method, spath string, form url.Values) (*User, error) {
+	resp, err := m.Patch(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
@@ -76,8 +77,8 @@ func updateUser(m *method, spath string, form url.Values) (*User, error) {
 	return &v, nil
 }
 
-func deleteUser(m *method, spath string, form url.Values) (*User, error) {
-	resp, err := m.Delete(spath, form)
+func deleteUser(ctx context.Context, m *method, spath string, form url.Values) (*User, error) {
+	resp, err := m.Delete(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
@@ -101,34 +102,34 @@ type UserService struct {
 // All returns all users in your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-list
-func (s *UserService) All() ([]*User, error) {
-	return getUserList(s.method, "users", nil)
+func (s *UserService) All(ctx context.Context) ([]*User, error) {
+	return getUserList(ctx, s.method, "users", nil)
 }
 
 // One returns a user in your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user
-func (s *UserService) One(id int) (*User, error) {
+func (s *UserService) One(ctx context.Context, id int) (*User, error) {
 	uID := UserID(id)
 	if err := uID.validate(); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("users", uID.String())
-	return getUser(s.method, spath)
+	return getUser(ctx, s.method, spath)
 }
 
 // Own returns your own user.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-own-user
-func (s *UserService) Own() (*User, error) {
-	return getUser(s.method, "users/myself")
+func (s *UserService) Own(ctx context.Context) (*User, error) {
+	return getUser(ctx, s.method, "users/myself")
 }
 
 // Add adds a user to your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-user
-func (s *UserService) Add(userID, password, name, mailAddress string, roleType Role) (*User, error) {
+func (s *UserService) Add(ctx context.Context, userID, password, name, mailAddress string, roleType Role) (*User, error) {
 	if userID == "" {
 		return nil, newValidationError("userID must not be empty")
 	}
@@ -147,7 +148,7 @@ func (s *UserService) Add(userID, password, name, mailAddress string, roleType R
 
 	form.Set("userId", userID)
 
-	return addUser(s.method, "users", form)
+	return addUser(ctx, s.method, "users", form)
 }
 
 // Update updates a user in your space.
@@ -161,7 +162,7 @@ func (s *UserService) Add(userID, password, name, mailAddress string, roleType R
 //   - WithUserID
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-user
-func (s *UserService) Update(id int, opts ...RequestOption) (*User, error) {
+func (s *UserService) Update(ctx context.Context, id int, opts ...RequestOption) (*User, error) {
 
 	form := url.Values{}
 	validTypes := []apiParamOptionType{paramUserID, paramName, paramPassword, paramMailAddress, paramRoleType}
@@ -171,20 +172,20 @@ func (s *UserService) Update(id int, opts ...RequestOption) (*User, error) {
 	}
 
 	spath := path.Join("users", strconv.Itoa(id))
-	return updateUser(s.method, spath, form)
+	return updateUser(ctx, s.method, spath, form)
 }
 
 // Delete deletes a user from your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-user
-func (s *UserService) Delete(id int) (*User, error) {
+func (s *UserService) Delete(ctx context.Context, id int) (*User, error) {
 	uID := UserID(id)
 	if err := uID.validate(); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("users", uID.String())
-	return deleteUser(s.method, spath, nil)
+	return deleteUser(ctx, s.method, spath, nil)
 }
 
 // ProjectUserService has methods for user of project.
@@ -195,7 +196,7 @@ type ProjectUserService struct {
 // All returns all users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-user-list
-func (s *ProjectUserService) All(projectIDOrKey string, excludeGroupMembers bool) ([]*User, error) {
+func (s *ProjectUserService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*User, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -204,13 +205,13 @@ func (s *ProjectUserService) All(projectIDOrKey string, excludeGroupMembers bool
 	query.Set("excludeGroupMembers", strconv.FormatBool(excludeGroupMembers))
 
 	spath := path.Join("projects", projectIDOrKey, "users")
-	return getUserList(s.method, spath, query)
+	return getUserList(ctx, s.method, spath, query)
 }
 
 // Add adds a user to the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project-user
-func (s *ProjectUserService) Add(projectIDOrKey string, userID int) (*User, error) {
+func (s *ProjectUserService) Add(ctx context.Context, projectIDOrKey string, userID int) (*User, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -224,13 +225,13 @@ func (s *ProjectUserService) Add(projectIDOrKey string, userID int) (*User, erro
 	form.Set("userId", uID.String())
 
 	spath := path.Join("projects", projectIDOrKey, "users")
-	return addUser(s.method, spath, form)
+	return addUser(ctx, s.method, spath, form)
 }
 
 // Delete deletes a user from the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-project-user
-func (s *ProjectUserService) Delete(projectIDOrKey string, userID int) (*User, error) {
+func (s *ProjectUserService) Delete(ctx context.Context, projectIDOrKey string, userID int) (*User, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -244,13 +245,13 @@ func (s *ProjectUserService) Delete(projectIDOrKey string, userID int) (*User, e
 	form.Set("userId", uID.String())
 
 	spath := path.Join("projects", projectIDOrKey, "users")
-	return deleteUser(s.method, spath, form)
+	return deleteUser(ctx, s.method, spath, form)
 }
 
 // AddAdmin adds a admin user to the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project-administrator
-func (s *ProjectUserService) AddAdmin(projectIDOrKey string, userID int) (*User, error) {
+func (s *ProjectUserService) AddAdmin(ctx context.Context, projectIDOrKey string, userID int) (*User, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -264,25 +265,25 @@ func (s *ProjectUserService) AddAdmin(projectIDOrKey string, userID int) (*User,
 	form.Set("userId", uID.String())
 
 	spath := path.Join("projects", projectIDOrKey, "administrators")
-	return addUser(s.method, spath, form)
+	return addUser(ctx, s.method, spath, form)
 }
 
 // AdminAll returns a list of all admin users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-project-administrators
-func (s *ProjectUserService) AdminAll(projectIDOrKey string) ([]*User, error) {
+func (s *ProjectUserService) AdminAll(ctx context.Context, projectIDOrKey string) ([]*User, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("projects", projectIDOrKey, "administrators")
-	return getUserList(s.method, spath, nil)
+	return getUserList(ctx, s.method, spath, nil)
 }
 
 // DeleteAdmin removes an admin user from the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-project-administrator
-func (s *ProjectUserService) DeleteAdmin(projectIDOrKey string, userID int) (*User, error) {
+func (s *ProjectUserService) DeleteAdmin(ctx context.Context, projectIDOrKey string, userID int) (*User, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -296,5 +297,5 @@ func (s *ProjectUserService) DeleteAdmin(projectIDOrKey string, userID int) (*Us
 	form.Set("userId", uID.String())
 
 	spath := path.Join("projects", projectIDOrKey, "administrators")
-	return deleteUser(s.method, spath, form)
+	return deleteUser(ctx, s.method, spath, form)
 }

--- a/user_test.go
+++ b/user_test.go
@@ -1299,8 +1299,6 @@ func TestProjectUserService_DeleteAdmin(t *testing.T) {
 // A sentinel value is embedded in the context and its pointer identity is
 // asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
 func TestUserService_contextPropagation(t *testing.T) {
-	t.Parallel()
-
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)

--- a/user_test.go
+++ b/user_test.go
@@ -1292,3 +1292,127 @@ func TestProjectUserService_DeleteAdmin(t *testing.T) {
 		})
 	}
 }
+
+// TestUserService_contextPropagation verifies that the context passed to each
+// UserService and ProjectUserService method is correctly relayed to the
+// underlying method call.
+// A sentinel value is embedded in the context and its pointer identity is
+// asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
+func TestUserService_contextPropagation(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+	sentinel := &struct{}{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+
+	o := newUserOptionService()
+
+	cases := []struct {
+		name string
+		call func(t *testing.T)
+	}{
+		{"UserService.All", func(t *testing.T) {
+			s := newUserService()
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.All(ctx) //nolint:errcheck
+		}},
+		{"UserService.One", func(t *testing.T) {
+			s := newUserService()
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.One(ctx, 1) //nolint:errcheck
+		}},
+		{"UserService.Own", func(t *testing.T) {
+			s := newUserService()
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Own(ctx) //nolint:errcheck
+		}},
+		{"UserService.Add", func(t *testing.T) {
+			s := newUserService()
+			s.method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Add(ctx, "u", "p", "n", "m@m.com", RoleAdministrator) //nolint:errcheck
+		}},
+		{"UserService.Update", func(t *testing.T) {
+			s := newUserService()
+			s.method.Patch = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
+		}},
+		{"UserService.Delete", func(t *testing.T) {
+			s := newUserService()
+			s.method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Delete(ctx, 1) //nolint:errcheck
+		}},
+		{"ProjectUserService.All", func(t *testing.T) {
+			s := newProjectUserService()
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.All(ctx, "TEST", false) //nolint:errcheck
+		}},
+		{"ProjectUserService.Add", func(t *testing.T) {
+			s := newProjectUserService()
+			s.method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Add(ctx, "TEST", 1) //nolint:errcheck
+		}},
+		{"ProjectUserService.Delete", func(t *testing.T) {
+			s := newProjectUserService()
+			s.method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Delete(ctx, "TEST", 1) //nolint:errcheck
+		}},
+		{"ProjectUserService.AddAdmin", func(t *testing.T) {
+			s := newProjectUserService()
+			s.method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.AddAdmin(ctx, "TEST", 1) //nolint:errcheck
+		}},
+		{"ProjectUserService.AdminAll", func(t *testing.T) {
+			s := newProjectUserService()
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.AdminAll(ctx, "TEST") //nolint:errcheck
+		}},
+		{"ProjectUserService.DeleteAdmin", func(t *testing.T) {
+			s := newProjectUserService()
+			s.method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.DeleteAdmin(ctx, "TEST", 1) //nolint:errcheck
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.call(t)
+		})
+	}
+}

--- a/user_test.go
+++ b/user_test.go
@@ -2,6 +2,7 @@ package backlog
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -18,7 +19,7 @@ func TestUserService_One(t *testing.T) {
 	cases := map[string]struct {
 		id int
 
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantUser    *User
 		wantErrType error
@@ -26,7 +27,7 @@ func TestUserService_One(t *testing.T) {
 		"success-id-1": {
 			id: 1,
 
-			mockGetFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -44,7 +45,7 @@ func TestUserService_One(t *testing.T) {
 		"success-id-100": {
 			id: 100,
 
-			mockGetFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/100", spath)
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -74,7 +75,7 @@ func TestUserService_One(t *testing.T) {
 				s.method.Get = tc.mockGetFn
 			}
 
-			user, err := s.One(tc.id)
+			user, err := s.One(context.Background(), tc.id)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -102,7 +103,7 @@ func TestUserService_Add(t *testing.T) {
 		mailAddress string
 		roleType    Role
 
-		mockPostFn func(spath string, form url.Values) (*http.Response, error)
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantUser    *User
 		wantErrType error
@@ -114,7 +115,7 @@ func TestUserService_Add(t *testing.T) {
 			mailAddress: "eguchi@nulab.example",
 			roleType:    RoleAdministrator,
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users", spath)
 				assert.Equal(t, "admin", form.Get("userId"))
 				assert.Equal(t, "password", form.Get("password"))
@@ -142,7 +143,7 @@ func TestUserService_Add(t *testing.T) {
 			mailAddress: "error@example.com",
 			roleType:    RoleAdministrator,
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users", spath)
 				return nil, errors.New("network failure")
 			},
@@ -211,7 +212,7 @@ func TestUserService_Add(t *testing.T) {
 			mailAddress: "mailAdress",
 			roleType:    1,
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(testdataInvalidJSON))),
@@ -235,7 +236,7 @@ func TestUserService_Add(t *testing.T) {
 				s.method.Post = tc.mockPostFn
 			}
 
-			user, err := s.Add(tc.userID, tc.password, tc.name, tc.mailAddress, tc.roleType)
+			user, err := s.Add(context.Background(), tc.userID, tc.password, tc.name, tc.mailAddress, tc.roleType)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -257,14 +258,14 @@ func TestUserService_Add(t *testing.T) {
 
 func TestUserService_All(t *testing.T) {
 	cases := map[string]struct {
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantLen     int
 		wantFirst   *User
 		wantErrType error
 	}{
 		"success-get-users": {
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users", spath)
 				assert.Nil(t, query)
 
@@ -283,7 +284,7 @@ func TestUserService_All(t *testing.T) {
 			},
 		},
 		"error-client-network": {
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users", spath)
 				assert.Nil(t, query)
 				return nil, errors.New("error")
@@ -292,7 +293,7 @@ func TestUserService_All(t *testing.T) {
 			wantErrType: errors.New(""),
 		},
 		"error-response-invalid-json": {
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users", spath)
 				assert.Nil(t, query)
 
@@ -319,7 +320,7 @@ func TestUserService_All(t *testing.T) {
 				s.method.Get = tc.mockGetFn
 			}
 
-			users, err := s.All()
+			users, err := s.All(context.Background())
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -347,7 +348,7 @@ func TestUserService_Update(t *testing.T) {
 		id   int
 		opts []RequestOption
 
-		mockPatchFn func(spath string, form url.Values) (*http.Response, error)
+		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantUser    *User
 		wantErrType error
@@ -361,7 +362,7 @@ func TestUserService_Update(t *testing.T) {
 				o.WithRoleType(RoleAdministrator),
 			},
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
 				assert.Equal(t, "password", form.Get("password"))
 				assert.Equal(t, "admin", form.Get("name"))
@@ -389,7 +390,7 @@ func TestUserService_Update(t *testing.T) {
 		"error-response-invalid-json": {
 			id: 1234,
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1234", spath)
 
 				return &http.Response{
@@ -406,7 +407,7 @@ func TestUserService_Update(t *testing.T) {
 				o.WithName("testname"),
 			},
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
 				assert.Equal(t, "testname", form.Get("name"))
 				return nil, errors.New("error")
@@ -420,7 +421,7 @@ func TestUserService_Update(t *testing.T) {
 				o.WithPassword("testpassword"),
 			},
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
 				assert.Equal(t, "testpassword", form.Get("password"))
 				return nil, errors.New("error")
@@ -434,7 +435,7 @@ func TestUserService_Update(t *testing.T) {
 				o.WithMailAddress("test@test.com"),
 			},
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
 				assert.Equal(t, "test@test.com", form.Get("mailAddress"))
 				return nil, errors.New("error")
@@ -448,7 +449,7 @@ func TestUserService_Update(t *testing.T) {
 				o.WithRoleType(RoleAdministrator),
 			},
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
 				assert.Equal(t, strconv.Itoa(int(RoleAdministrator)), form.Get("roleType"))
 				return nil, errors.New("error")
@@ -465,7 +466,7 @@ func TestUserService_Update(t *testing.T) {
 				o.WithRoleType(RoleAdministrator),
 			},
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
 				assert.Equal(t, "testpassword1", form.Get("password"))
 				assert.Equal(t, "testname1", form.Get("name"))
@@ -510,7 +511,7 @@ func TestUserService_Update(t *testing.T) {
 				s.method.Patch = tc.mockPatchFn
 			}
 
-			user, err := s.Update(tc.id, tc.opts...)
+			user, err := s.Update(context.Background(), tc.id, tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -532,13 +533,13 @@ func TestUserService_Update(t *testing.T) {
 
 func TestUserService_Own(t *testing.T) {
 	cases := map[string]struct {
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantUser    *User
 		wantErrType error
 	}{
 		"success-get-own-user": {
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/myself", spath)
 				assert.Nil(t, query)
 				return &http.Response{
@@ -555,7 +556,7 @@ func TestUserService_Own(t *testing.T) {
 			},
 		},
 		"error-client-network": {
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/myself", spath)
 				assert.Nil(t, query)
 				return nil, errors.New("error")
@@ -564,7 +565,7 @@ func TestUserService_Own(t *testing.T) {
 			wantErrType: errors.New(""),
 		},
 		"error-response-invalid-json": {
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/myself", spath)
 				assert.Nil(t, query)
 				return &http.Response{
@@ -590,7 +591,7 @@ func TestUserService_Own(t *testing.T) {
 				s.method.Get = tc.mockGetFn
 			}
 
-			user, err := s.Own()
+			user, err := s.Own(context.Background())
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -613,14 +614,14 @@ func TestUserService_Delete(t *testing.T) {
 	cases := map[string]struct {
 		id int
 
-		mockDeleteFn func(spath string, form url.Values) (*http.Response, error)
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantErrType error
 	}{
 		"success-id-1": {
 			id: 1,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
 				assert.Nil(t, form)
 				return &http.Response{
@@ -634,7 +635,7 @@ func TestUserService_Delete(t *testing.T) {
 		"success-id-100": {
 			id: 100,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/100", spath)
 				assert.Nil(t, form)
 				return &http.Response{
@@ -653,7 +654,7 @@ func TestUserService_Delete(t *testing.T) {
 		"error-response-invalid-json": {
 			id: 1234,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1234", spath)
 				assert.Nil(t, form)
 				return &http.Response{
@@ -679,7 +680,7 @@ func TestUserService_Delete(t *testing.T) {
 				s.method.Delete = tc.mockDeleteFn
 			}
 
-			user, err := s.Delete(tc.id)
+			user, err := s.Delete(context.Background(), tc.id)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -699,7 +700,7 @@ func TestProjectUserService_All(t *testing.T) {
 		projectKey          string
 		excludeGroupMembers bool
 
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantUsers   []*User
 		wantErrType error
@@ -708,7 +709,7 @@ func TestProjectUserService_All(t *testing.T) {
 			projectKey:          "TEST",
 			excludeGroupMembers: false,
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/users", spath)
 				assert.Equal(t, "false", query.Get("excludeGroupMembers"))
 				return &http.Response{
@@ -730,7 +731,7 @@ func TestProjectUserService_All(t *testing.T) {
 			projectKey:          "TEST2",
 			excludeGroupMembers: true,
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST2/users", spath)
 				assert.Equal(t, "true", query.Get("excludeGroupMembers"))
 				return &http.Response{
@@ -752,7 +753,7 @@ func TestProjectUserService_All(t *testing.T) {
 			projectKey:          "TEST3",
 			excludeGroupMembers: false,
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST3/users", spath)
 				assert.Equal(t, "false", query.Get("excludeGroupMembers"))
 				return &http.Response{
@@ -778,7 +779,7 @@ func TestProjectUserService_All(t *testing.T) {
 		"error-response-invalid-json": {
 			projectKey: "TEST",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/users", spath)
 				assert.Equal(t, "false", query.Get("excludeGroupMembers"))
 				return &http.Response{
@@ -804,7 +805,7 @@ func TestProjectUserService_All(t *testing.T) {
 				s.method.Get = tc.mockGetFn
 			}
 
-			users, err := s.All(tc.projectKey, tc.excludeGroupMembers)
+			users, err := s.All(context.Background(), tc.projectKey, tc.excludeGroupMembers)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -829,7 +830,7 @@ func TestProjectUserService_Add(t *testing.T) {
 		projectKey string
 		userID     int
 
-		mockPostFn func(spath string, form url.Values) (*http.Response, error)
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantUser    *User
 		wantErrType error
@@ -838,7 +839,7 @@ func TestProjectUserService_Add(t *testing.T) {
 			projectKey: "TEST",
 			userID:     1,
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return &http.Response{
@@ -869,7 +870,7 @@ func TestProjectUserService_Add(t *testing.T) {
 			projectKey: "TEST2",
 			userID:     1,
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST2/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return &http.Response{
@@ -889,7 +890,7 @@ func TestProjectUserService_Add(t *testing.T) {
 			projectKey: "TEST3",
 			userID:     1,
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST3/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return &http.Response{
@@ -915,7 +916,7 @@ func TestProjectUserService_Add(t *testing.T) {
 				s.method.Post = tc.mockPostFn
 			}
 
-			user, err := s.Add(tc.projectKey, tc.userID)
+			user, err := s.Add(context.Background(), tc.projectKey, tc.userID)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -939,7 +940,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 		projectKey string
 		userID     int
 
-		mockDeleteFn func(spath string, form url.Values) (*http.Response, error)
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantUser    *User
 		wantErrType error
@@ -948,7 +949,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 			projectKey: "TEST",
 			userID:     1,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return &http.Response{
@@ -968,7 +969,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 			projectKey: "1234",
 			userID:     1,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/1234/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return &http.Response{
@@ -1000,7 +1001,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 			projectKey: "TEST2",
 			userID:     1,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST2/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return &http.Response{
@@ -1020,7 +1021,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 			projectKey: "TEST3",
 			userID:     1,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST3/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return &http.Response{
@@ -1046,7 +1047,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 				s.method.Delete = tc.mockDeleteFn
 			}
 
-			user, err := s.Delete(tc.projectKey, tc.userID)
+			user, err := s.Delete(context.Background(), tc.projectKey, tc.userID)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -1070,7 +1071,7 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 		projectKey string
 		userID     int
 
-		mockPostFn func(spath string, form url.Values) (*http.Response, error)
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantUser    *User
 		wantErrType error
@@ -1079,7 +1080,7 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 			projectKey: "TEST",
 			userID:     1,
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/administrators", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return &http.Response{
@@ -1110,7 +1111,7 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 			projectKey: "TEST2",
 			userID:     1,
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST2/administrators", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return &http.Response{
@@ -1130,7 +1131,7 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 			projectKey: "TEST3",
 			userID:     1,
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST3/administrators", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return &http.Response{
@@ -1156,7 +1157,7 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 				s.method.Post = tc.mockPostFn
 			}
 
-			user, err := s.AddAdmin(tc.projectKey, tc.userID)
+			user, err := s.AddAdmin(context.Background(), tc.projectKey, tc.userID)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -1179,14 +1180,14 @@ func TestProjectUserService_AdminAll(t *testing.T) {
 	cases := map[string]struct {
 		projectKey string
 
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantErrType error
 	}{
 		"success-projectKey-valid": {
 			projectKey: "TEST",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/administrators", spath)
 				assert.Nil(t, query)
 				return nil, errors.New("error")
@@ -1214,7 +1215,7 @@ func TestProjectUserService_AdminAll(t *testing.T) {
 				s.method.Get = tc.mockGetFn
 			}
 
-			users, err := s.AdminAll(tc.projectKey)
+			users, err := s.AdminAll(context.Background(), tc.projectKey)
 
 			assert.Error(t, err)
 			assert.IsType(t, tc.wantErrType, err)
@@ -1228,7 +1229,7 @@ func TestProjectUserService_DeleteAdmin(t *testing.T) {
 		projectKey string
 		userID     int
 
-		mockDeleteFn func(spath string, form url.Values) (*http.Response, error)
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantErrType error
 	}{
@@ -1236,7 +1237,7 @@ func TestProjectUserService_DeleteAdmin(t *testing.T) {
 			projectKey: "TEST",
 			userID:     1,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/administrators", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return nil, errors.New("error")
@@ -1260,7 +1261,7 @@ func TestProjectUserService_DeleteAdmin(t *testing.T) {
 			projectKey: "TEST2",
 			userID:     1,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST2/administrators", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return nil, errors.New("error")
@@ -1283,7 +1284,7 @@ func TestProjectUserService_DeleteAdmin(t *testing.T) {
 				s.method.Delete = tc.mockDeleteFn
 			}
 
-			user, err := s.DeleteAdmin(tc.projectKey, tc.userID)
+			user, err := s.DeleteAdmin(context.Background(), tc.projectKey, tc.userID)
 
 			assert.Error(t, err)
 			assert.IsType(t, tc.wantErrType, err)

--- a/wiki.go
+++ b/wiki.go
@@ -1,6 +1,7 @@
 package backlog
 
 import (
+	"context"
 	"net/url"
 	"path"
 	"strconv"
@@ -28,7 +29,7 @@ type WikiService struct {
 //   - WithKeyword
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-list
-func (s *WikiService) All(projectIDOrKey string, opts ...RequestOption) ([]*Wiki, error) {
+func (s *WikiService) All(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*Wiki, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -41,7 +42,7 @@ func (s *WikiService) All(projectIDOrKey string, opts ...RequestOption) ([]*Wiki
 
 	query.Set("projectIdOrKey", projectIDOrKey)
 
-	resp, err := s.method.Get("wikis", query)
+	resp, err := s.method.Get(ctx, "wikis", query)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +58,7 @@ func (s *WikiService) All(projectIDOrKey string, opts ...RequestOption) ([]*Wiki
 // Count returns the number of wikis in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-wiki-page
-func (s *WikiService) Count(projectIDOrKey string) (int, error) {
+func (s *WikiService) Count(ctx context.Context, projectIDOrKey string) (int, error) {
 	if err := validateProjectIDOrKey(projectIDOrKey); err != nil {
 		return 0, err
 	}
@@ -65,7 +66,7 @@ func (s *WikiService) Count(projectIDOrKey string) (int, error) {
 	query := url.Values{}
 	query.Set("projectIdOrKey", projectIDOrKey)
 
-	resp, err := s.method.Get("wikis/count", query)
+	resp, err := s.method.Get(ctx, "wikis/count", query)
 	if err != nil {
 		return 0, err
 	}
@@ -81,13 +82,13 @@ func (s *WikiService) Count(projectIDOrKey string) (int, error) {
 // One returns a specific wiki by ID.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page
-func (s *WikiService) One(wikiID int) (*Wiki, error) {
+func (s *WikiService) One(ctx context.Context, wikiID int) (*Wiki, error) {
 	if err := validateWikiID(wikiID); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("wikis", strconv.Itoa(wikiID))
-	resp, err := s.method.Get(spath, nil)
+	resp, err := s.method.Get(ctx, spath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +110,7 @@ func (s *WikiService) One(wikiID int) (*Wiki, error) {
 //   - WithName
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-wiki-page
-func (s *WikiService) Create(projectID int, name, content string, opts ...RequestOption) (*Wiki, error) {
+func (s *WikiService) Create(ctx context.Context, projectID int, name, content string, opts ...RequestOption) (*Wiki, error) {
 	if err := validateProjectID(projectID); err != nil {
 		return nil, err
 	}
@@ -123,7 +124,7 @@ func (s *WikiService) Create(projectID int, name, content string, opts ...Reques
 
 	form.Set("projectId", strconv.Itoa(projectID))
 
-	resp, err := s.method.Post("wikis", form)
+	resp, err := s.method.Post(ctx, "wikis", form)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +146,7 @@ func (s *WikiService) Create(projectID int, name, content string, opts ...Reques
 //   - WithName
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-wiki-page
-func (s *WikiService) Update(wikiID int, option RequestOption, opts ...RequestOption) (*Wiki, error) {
+func (s *WikiService) Update(ctx context.Context, wikiID int, option RequestOption, opts ...RequestOption) (*Wiki, error) {
 	if err := validateWikiID(wikiID); err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (s *WikiService) Update(wikiID int, option RequestOption, opts ...RequestOp
 	}
 
 	spath := path.Join("wikis", strconv.Itoa(wikiID))
-	resp, err := s.method.Patch(spath, form)
+	resp, err := s.method.Patch(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +184,7 @@ func (s *WikiService) Update(wikiID int, option RequestOption, opts ...RequestOp
 //   - WithMailNotify
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-wiki-page
-func (s *WikiService) Delete(wikiID int, opts ...RequestOption) (*Wiki, error) {
+func (s *WikiService) Delete(ctx context.Context, wikiID int, opts ...RequestOption) (*Wiki, error) {
 	if err := validateWikiID(wikiID); err != nil {
 		return nil, err
 	}
@@ -195,7 +196,7 @@ func (s *WikiService) Delete(wikiID int, opts ...RequestOption) (*Wiki, error) {
 	}
 
 	spath := path.Join("wikis", strconv.Itoa(wikiID))
-	resp, err := s.method.Delete(spath, form)
+	resp, err := s.method.Delete(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -784,3 +784,72 @@ func TestWikiService_Delete(t *testing.T) {
 		})
 	}
 }
+
+// TestWikiService_contextPropagation verifies that the context passed to each
+// WikiService method is correctly relayed to the underlying method call.
+// A sentinel value is embedded in the context and its pointer identity is
+// asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
+func TestWikiService_contextPropagation(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+	sentinel := &struct{}{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+
+	o := newWikiOptionService()
+
+	cases := []struct {
+		name string
+		call func(t *testing.T, s *WikiService)
+	}{
+		{"All", func(t *testing.T, s *WikiService) {
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.All(ctx, "TEST") //nolint:errcheck
+		}},
+		{"Count", func(t *testing.T, s *WikiService) {
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Count(ctx, "TEST") //nolint:errcheck
+		}},
+		{"One", func(t *testing.T, s *WikiService) {
+			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.One(ctx, 1) //nolint:errcheck
+		}},
+		{"Create", func(t *testing.T, s *WikiService) {
+			s.method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Create(ctx, 1, "name", "content") //nolint:errcheck
+		}},
+		{"Update", func(t *testing.T, s *WikiService) {
+			s.method.Patch = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
+		}},
+		{"Delete", func(t *testing.T, s *WikiService) {
+			s.method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s.Delete(ctx, 1) //nolint:errcheck
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.call(t, newWikiService())
+		})
+	}
+}

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -790,8 +790,6 @@ func TestWikiService_Delete(t *testing.T) {
 // A sentinel value is embedded in the context and its pointer identity is
 // asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
 func TestWikiService_contextPropagation(t *testing.T) {
-	t.Parallel()
-
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -2,6 +2,7 @@ package backlog
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -25,7 +26,7 @@ func TestWikiService_All(t *testing.T) {
 		projectIDOrKey string
 		opts           []RequestOption
 
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantErrType error
 		wantIDs     []int
@@ -34,7 +35,7 @@ func TestWikiService_All(t *testing.T) {
 		"success-projectIDOrKey-id": {
 			projectIDOrKey: "103",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis", spath)
 				assert.Equal(t, "103", query.Get("projectIdOrKey"))
 
@@ -54,7 +55,7 @@ func TestWikiService_All(t *testing.T) {
 				o.WithKeyword("test"),
 			},
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis", spath)
 				assert.Equal(t, "PRJ_KEY", query.Get("projectIdOrKey"))
 				assert.Equal(t, "test", query.Get("keyword"))
@@ -89,7 +90,7 @@ func TestWikiService_All(t *testing.T) {
 		"error-client-network": {
 			projectIDOrKey: "1",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis", spath)
 				assert.Equal(t, "1", query.Get("projectIdOrKey"))
 				return nil, errors.New("network error")
@@ -101,7 +102,7 @@ func TestWikiService_All(t *testing.T) {
 		"error-response-invalid-json": {
 			projectIDOrKey: "1",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis", spath)
 				assert.Equal(t, "1", query.Get("projectIdOrKey"))
 
@@ -128,7 +129,7 @@ func TestWikiService_All(t *testing.T) {
 				s.method.Get = tc.mockGetFn
 			}
 
-			wikis, err := s.All(tc.projectIDOrKey, tc.opts...)
+			wikis, err := s.All(context.Background(), tc.projectIDOrKey, tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -153,7 +154,7 @@ func TestWikiService_Count(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantErrType error
 		wantCount   int
@@ -161,7 +162,7 @@ func TestWikiService_Count(t *testing.T) {
 		"success-projectIDOrKey-id": {
 			projectIDOrKey: "103",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/count", spath)
 				assert.Equal(t, "103", query.Get("projectIdOrKey"))
 				return &http.Response{
@@ -175,7 +176,7 @@ func TestWikiService_Count(t *testing.T) {
 		"success-projectIDOrKey-key": {
 			projectIDOrKey: "PRJ_KEY",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/count", spath)
 				assert.Equal(t, "PRJ_KEY", query.Get("projectIdOrKey"))
 				return &http.Response{
@@ -193,7 +194,7 @@ func TestWikiService_Count(t *testing.T) {
 		"error-client-network": {
 			projectIDOrKey: "1",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/count", spath)
 				assert.Equal(t, "1", query.Get("projectIdOrKey"))
 				return nil, errors.New("network error")
@@ -204,7 +205,7 @@ func TestWikiService_Count(t *testing.T) {
 		"error-response-invalid-json": {
 			projectIDOrKey: "1",
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/count", spath)
 				assert.Equal(t, "1", query.Get("projectIdOrKey"))
 				return &http.Response{
@@ -227,7 +228,7 @@ func TestWikiService_Count(t *testing.T) {
 				s.method.Get = tc.mockGetFn
 			}
 
-			count, err := s.Count(tc.projectIDOrKey)
+			count, err := s.Count(context.Background(), tc.projectIDOrKey)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -246,7 +247,7 @@ func TestWikiService_One(t *testing.T) {
 	cases := map[string]struct {
 		wikiID int
 
-		mockGetFn func(spath string, query url.Values) (*http.Response, error)
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantErrType  error
 		wantWikiID   int
@@ -255,7 +256,7 @@ func TestWikiService_One(t *testing.T) {
 		"success-wikiID-normal": {
 			wikiID: 34,
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Nil(t, query)
 				return &http.Response{
@@ -278,7 +279,7 @@ func TestWikiService_One(t *testing.T) {
 		"error-client-network": {
 			wikiID: 1,
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1", spath)
 				assert.Nil(t, query)
 				return nil, errors.New("network error")
@@ -289,7 +290,7 @@ func TestWikiService_One(t *testing.T) {
 		"error-response-invalid-json": {
 			wikiID: 1,
 
-			mockGetFn: func(spath string, query url.Values) (*http.Response, error) {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1", spath)
 				assert.Nil(t, query)
 				return &http.Response{
@@ -312,7 +313,7 @@ func TestWikiService_One(t *testing.T) {
 				s.method.Get = tc.mockGetFn
 			}
 
-			wiki, err := s.One(tc.wikiID)
+			wiki, err := s.One(context.Background(), tc.wikiID)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -338,7 +339,7 @@ func TestWikiService_Create(t *testing.T) {
 		content   string
 		opts      []RequestOption
 
-		mockPostFn func(spath string, form url.Values) (*http.Response, error)
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantWiki    *Wiki
 		wantErrType error
@@ -348,7 +349,7 @@ func TestWikiService_Create(t *testing.T) {
 			name:      "Minimum Wiki Page",
 			content:   "This is a minimal wiki page.",
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis", spath)
 				assert.Equal(t, "56", form.Get("projectId"))
 				assert.Equal(t, "Minimum Wiki Page", form.Get("name"))
@@ -373,7 +374,7 @@ func TestWikiService_Create(t *testing.T) {
 			content:   "This is a minimal wiki page.",
 			opts:      []RequestOption{o.WithMailNotify(true)},
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis", spath)
 				assert.Equal(t, "56", form.Get("projectId"))
 				assert.Equal(t, "Minimum Wiki Page", form.Get("name"))
@@ -430,7 +431,7 @@ func TestWikiService_Create(t *testing.T) {
 			name:      "Test",
 			content:   "content",
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis", spath)
 				assert.Equal(t, "1", form.Get("projectId"))
 				assert.Equal(t, "Test", form.Get("name"))
@@ -445,7 +446,7 @@ func TestWikiService_Create(t *testing.T) {
 			name:      "Test",
 			content:   "content",
 
-			mockPostFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis", spath)
 				assert.Equal(t, "1", form.Get("projectId"))
 				assert.Equal(t, "Test", form.Get("name"))
@@ -473,7 +474,7 @@ func TestWikiService_Create(t *testing.T) {
 				s.method.Post = tc.mockPostFn
 			}
 
-			wiki, err := s.Create(tc.projectID, tc.name, tc.content, tc.opts...)
+			wiki, err := s.Create(context.Background(), tc.projectID, tc.name, tc.content, tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -500,7 +501,7 @@ func TestWikiService_Update(t *testing.T) {
 		option RequestOption
 		opts   []RequestOption
 
-		mockPatchFn func(spath string, form url.Values) (*http.Response, error)
+		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantErrType error
 		wantWiki    *Wiki
@@ -509,7 +510,7 @@ func TestWikiService_Update(t *testing.T) {
 			wikiID: 34,
 			option: o.WithName("New Page Name"),
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Equal(t, "New Page Name", form.Get("name"))
 				return &http.Response{
@@ -528,7 +529,7 @@ func TestWikiService_Update(t *testing.T) {
 			wikiID: 34,
 			option: o.WithContent("Full Options Content"),
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Equal(t, "Full Options Content", form.Get("content"))
 				return &http.Response{
@@ -550,7 +551,7 @@ func TestWikiService_Update(t *testing.T) {
 				o.WithName("Full Options Name"),
 			},
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Equal(t, "Full Options Name", form.Get("name"))
 				assert.Equal(t, "true", form.Get("mailNotify"))
@@ -574,7 +575,7 @@ func TestWikiService_Update(t *testing.T) {
 				o.WithMailNotify(true),
 			},
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Equal(t, "Full Options Name", form.Get("name"))
 				assert.Equal(t, "Full Options Content", form.Get("content"))
@@ -618,7 +619,7 @@ func TestWikiService_Update(t *testing.T) {
 			wikiID: 13,
 			option: o.WithName("New Name"),
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/13", spath)
 				assert.Equal(t, "New Name", form.Get("name"))
 				return nil, errors.New("network error")
@@ -630,7 +631,7 @@ func TestWikiService_Update(t *testing.T) {
 			wikiID: 14,
 			option: o.WithName("New Name"),
 
-			mockPatchFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/14", spath)
 				assert.Equal(t, "New Name", form.Get("name"))
 				return &http.Response{
@@ -654,7 +655,7 @@ func TestWikiService_Update(t *testing.T) {
 				s.method.Patch = tc.mockPatchFn
 			}
 
-			wiki, err := s.Update(tc.wikiID, tc.option, tc.opts...)
+			wiki, err := s.Update(context.Background(), tc.wikiID, tc.option, tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -680,7 +681,7 @@ func TestWikiService_Delete(t *testing.T) {
 		wikiID int
 		opts   []RequestOption
 
-		mockDeleteFn func(spath string, form url.Values) (*http.Response, error)
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantWikiID  int
 		wantErrType error
@@ -689,7 +690,7 @@ func TestWikiService_Delete(t *testing.T) {
 			wikiID: 34,
 			opts:   []RequestOption{o.WithMailNotify(true)},
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Equal(t, "true", form.Get("mailNotify"))
 				return &http.Response{
@@ -703,7 +704,7 @@ func TestWikiService_Delete(t *testing.T) {
 		"success-wikiID-no-option": {
 			wikiID: 1,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1", spath)
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -734,7 +735,7 @@ func TestWikiService_Delete(t *testing.T) {
 		"error-client-network": {
 			wikiID: 34,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				return nil, errors.New("network error")
 			},
@@ -744,7 +745,7 @@ func TestWikiService_Delete(t *testing.T) {
 		"error-response-invalid-json": {
 			wikiID: 34,
 
-			mockDeleteFn: func(spath string, form url.Values) (*http.Response, error) {
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -767,7 +768,7 @@ func TestWikiService_Delete(t *testing.T) {
 				s.method.Delete = tc.mockDeleteFn
 			}
 
-			wiki, err := s.Delete(tc.wikiID, tc.opts...)
+			wiki, err := s.Delete(context.Background(), tc.wikiID, tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)


### PR DESCRIPTION
## Summary
Add `context.Context` support to all service methods to allow callers to manage request timeouts and cancellations effectively.

## Key Changes
* [cite_start]**Method Signature Updates**: Added `ctx context.Context` as the first argument to all service methods[cite: 4, 7].
* [cite_start]**Request Handling**: Replaced `http.NewRequest` with `http.NewRequestWithContext` to ensure the context is correctly propagated to the underlying HTTP calls[cite: 4].
* [cite_start]**Internal Refactoring**: Updated internal `do` and `newRequest` methods to handle the context through the functional options pattern[cite: 4, 7, 8].

## Migration Guide
This is a **BREAKING CHANGE**. All service method calls must be updated to include a context.

**Before:**
```go
wikis, err := c.Wiki.All("PROJECT")
```

**After:**
```go
ctx := context.Background()
wikis, err := c.Wiki.All(ctx, "PROJECT")
```

## Impact
* **Improved Control**: Callers can now cancel long-running requests or set deadlines.
* **Standard Compliance**: Aligning the library with Go's best practices for network-related APIs.

Closes #82