### PR TITLE
refactor: move model structs to internal/model package

### DIFF
--- a/const.go
+++ b/const.go
@@ -1,30 +1,31 @@
 package backlog
 
+import "github.com/nattokin/go-backlog/internal/model"
+
 const (
 	apiVersion = "v2"
 )
 
 // Order defines the sort order (ascending or descending).
 const (
-	OrderAsc  Order = "asc"
-	OrderDesc Order = "desc"
+	OrderAsc  = model.OrderAsc
+	OrderDesc = model.OrderDesc
 )
 
 // Format defines the text formatting rule for the Backlog wiki.
 const (
-	FormatMarkdown Format = "markdown"
-	FormatBacklog  Format = "backlog"
+	FormatMarkdown = model.FormatMarkdown
+	FormatBacklog  = model.FormatBacklog
 )
 
 // Role defines the type of user role within a project.
 const (
-	_ Role = iota
-	RoleAdministrator
-	RoleNormalUser
-	RoleReporter
-	RoleViewer
-	RoleGuestReporter
-	RoleGuestViewer
+	RoleAdministrator = model.RoleAdministrator
+	RoleNormalUser    = model.RoleNormalUser
+	RoleReporter      = model.RoleReporter
+	RoleViewer        = model.RoleViewer
+	RoleGuestReporter = model.RoleGuestReporter
+	RoleGuestViewer   = model.RoleGuestViewer
 )
 
 const (

--- a/internal/model/activity.go
+++ b/internal/model/activity.go
@@ -1,0 +1,20 @@
+package model
+
+// Activity represents a recent update or change in the project or space.
+type Activity struct {
+	ID            int              `json:"id,omitempty"`
+	Project       *Project         `json:"project,omitempty"`
+	Type          int              `json:"type,omitempty"`
+	Content       *ActivityContent `json:"content,omitempty"`
+	Notifications []*Notification  `json:"notifications,omitempty"`
+	CreatedUser   *User            `json:"createdUser,omitempty"`
+}
+
+// ActivityContent represents the detailed content of an activity.
+type ActivityContent struct {
+	ID          int      `json:"id,omitempty"`
+	KeyID       int      `json:"key_id,omitempty"`
+	Summary     string   `json:"summary,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Comment     *Comment `json:"comment,omitempty"`
+}

--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -1,0 +1,197 @@
+package model
+
+import "time"
+
+// Attachment represents an attached file.
+type Attachment struct {
+	ID          int       `json:"id,omitempty"`
+	Name        string    `json:"name,omitempty"`
+	Size        int       `json:"size,omitempty"`
+	CreatedUser *User     `json:"createdUser,omitempty"`
+	Created     time.Time `json:"created,omitempty"`
+}
+
+// ChangeLog represents a history of changes made to an issue.
+type ChangeLog struct {
+	Field         string `json:"field,omitempty"`
+	NewValue      string `json:"newValue,omitempty"`
+	OriginalValue string `json:"originalValue,omitempty"`
+}
+
+// Comment represents any one comment.
+type Comment struct {
+	ID            int             `json:"id,omitempty"`
+	Content       string          `json:"content,omitempty"`
+	ChangeLogs    []*ChangeLog    `json:"changeLog,omitempty"`
+	CreatedUser   *User           `json:"createdUser,omitempty"`
+	Created       time.Time       `json:"created,omitempty"`
+	Updated       time.Time       `json:"updated,omitempty"`
+	Stars         *Star           `json:"stars,omitempty"`
+	Notifications []*Notification `json:"notifications,omitempty"`
+}
+
+// CustomField represents a custom field defined in the project.
+type CustomField struct {
+	ID                     int                `json:"id,omitempty"`
+	TypeID                 int                `json:"typeId,omitempty"`
+	Name                   string             `json:"name,omitempty"`
+	Description            string             `json:"description,omitempty"`
+	Required               bool               `json:"required,omitempty"`
+	ApplicableIssueTypeIDs []int              `json:"applicableIssueTypes,omitempty"`
+	AllowAddItem           bool               `json:"allowAddItem,omitempty"`
+	Items                  []*CustomFieldItem `json:"items,omitempty"`
+}
+
+// CustomFieldItem represents one of Items in CustomField.
+type CustomFieldItem struct {
+	ID           int    `json:"id,omitempty"`
+	Name         string `json:"name,omitempty"`
+	DisplayOrder int    `json:"displayOrder,omitempty"`
+}
+
+// DiskUsageBase represents base of disk usage.
+type DiskUsageBase struct {
+	Issue      int `json:"issue,omitempty"`
+	Wiki       int `json:"wiki,omitempty"`
+	File       int `json:"file,omitempty"`
+	Subversion int `json:"subversion,omitempty"`
+	Git        int `json:"git,omitempty"`
+	GitLFS     int `json:"gitLFS,omitempty"`
+}
+
+// Licence represents licence.
+type Licence struct {
+	Active                            bool      `json:"active,omitempty"`
+	AttachmentLimit                   int       `json:"attachmentLimit,omitempty"`
+	AttachmentLimitPerFile            int       `json:"attachmentLimitPerFile,omitempty"`
+	AttachmentNumLimit                int       `json:"attachmentNumLimit,omitempty"`
+	Attribute                         bool      `json:"attribute,omitempty"`
+	AttributeLimit                    int       `json:"attributeLimit,omitempty"`
+	Burndown                          bool      `json:"burndown,omitempty"`
+	CommentLimit                      int       `json:"commentLimit,omitempty"`
+	ComponentLimit                    int       `json:"componentLimit,omitempty"`
+	FileSharing                       bool      `json:"fileSharing,omitempty"`
+	Gantt                             bool      `json:"gantt,omitempty"`
+	Git                               bool      `json:"git,omitempty"`
+	IssueLimit                        int       `json:"issueLimit,omitempty"`
+	LicenceTypeID                     int       `json:"licenceTypeId,omitempty"`
+	LimitDate                         time.Time `json:"limitDate,omitempty"`
+	NulabAccount                      bool      `json:"nulabAccount,omitempty"`
+	ParentChildIssue                  bool      `json:"parentChildIssue,omitempty"`
+	PostIssueByMail                   bool      `json:"postIssueByMail,omitempty"`
+	ProjectGroup                      bool      `json:"projectGroup,omitempty"`
+	ProjectLimit                      int       `json:"projectLimit,omitempty"`
+	PullRequestAttachmentLimitPerFile int       `json:"pullRequestAttachmentLimitPerFile,omitempty"`
+	PullRequestAttachmentNumLimit     int       `json:"pullRequestAttachmentNumLimit,omitempty"`
+	RemoteAddress                     bool      `json:"remoteAddress,omitempty"`
+	RemoteAddressLimit                int       `json:"remoteAddressLimit,omitempty"`
+	StartedOn                         time.Time `json:"startedOn,omitempty"`
+	StorageLimit                      int64     `json:"storageLimit,omitempty"`
+	Subversion                        bool      `json:"subversion,omitempty"`
+	SubversionExternal                bool      `json:"subversionExternal,omitempty"`
+	UserLimit                         int       `json:"userLimit,omitempty"`
+	VersionLimit                      int       `json:"versionLimit,omitempty"`
+	WikiAttachment                    bool      `json:"wikiAttachment,omitempty"`
+	WikiAttachmentLimitPerFile        int       `json:"wikiAttachmentLimitPerFile,omitempty"`
+	WikiAttachmentNumLimit            int       `json:"wikiAttachmentNumLimit,omitempty"`
+}
+
+// Notification represents some notification.
+type Notification struct {
+	ID                  int          `json:"id,omitempty"`
+	AlreadyRead         bool         `json:"alreadyRead,omitempty"`
+	Reason              int          `json:"reason,omitempty"`
+	ResourceAlreadyRead bool         `json:"resourceAlreadyRead,omitempty"`
+	Project             *Project     `json:"project,omitempty"`
+	Issue               *Issue       `json:"issue,omitempty"`
+	Comment             *Comment     `json:"comment,omitempty"`
+	PullRequest         *PullRequest `json:"pullRequest,omitempty"`
+	PullRequestComment  *Comment     `json:"pullRequestComment,omitempty"`
+	Sender              *User        `json:"sender,omitempty"`
+	Created             time.Time    `json:"created,omitempty"`
+}
+
+// SharedFile represents a file shared within the project or space.
+type SharedFile struct {
+	ID          int       `json:"id,omitempty"`
+	Type        string    `json:"type,omitempty"`
+	Dir         string    `json:"dir,omitempty"`
+	Name        string    `json:"name,omitempty"`
+	Size        int       `json:"size,omitempty"`
+	CreatedUser *User     `json:"createdUser,omitempty"`
+	Created     time.Time `json:"created,omitempty"`
+	UpdatedUser *User     `json:"updatedUser,omitempty"`
+	Updated     time.Time `json:"updated,omitempty"`
+}
+
+// Star represents any Star.
+type Star struct {
+	ID        int       `json:"id,omitempty"`
+	Comment   string    `json:"comment,omitempty"`
+	URL       string    `json:"url,omitempty"`
+	Title     string    `json:"title,omitempty"`
+	Presenter *User     `json:"presenter,omitempty"`
+	Created   time.Time `json:"created,omitempty"`
+}
+
+// Status represents any status.
+type Status struct {
+	ID   int    `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// Tag represents one of tags in Wiki.
+type Tag struct {
+	ID   int    `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// Team represents team.
+type Team struct {
+	ID           int       `json:"id,omitempty"`
+	Name         string    `json:"name,omitempty"`
+	Members      []*User   `json:"members,omitempty"`
+	DisplayOrder int       `json:"displayOrder,omitempty"`
+	CreatedUser  *User     `json:"createdUser,omitempty"`
+	Created      time.Time `json:"created,omitempty"`
+	UpdatedUser  *User     `json:"updatedUser,omitempty"`
+	Updated      time.Time `json:"updated,omitempty"`
+}
+
+// Version represents any version.
+type Version struct {
+	ID             int       `json:"id,omitempty"`
+	ProjectID      int       `json:"projectId,omitempty"`
+	Name           string    `json:"name,omitempty"`
+	Description    string    `json:"description,omitempty"`
+	StartDate      time.Time `json:"startDate,omitempty"`
+	ReleaseDueDate time.Time `json:"releaseDueDate,omitempty"`
+	Archived       bool      `json:"archived,omitempty"`
+	DisplayOrder   int       `json:"displayOrder,omitempty"`
+}
+
+// WatchingItem represents an item of watching list.
+type WatchingItem struct {
+	ID                  int       `json:"id,omitempty"`
+	ResourceAlreadyRead bool      `json:"resourceAlreadyRead,omitempty"`
+	Note                string    `json:"note,omitempty"`
+	Type                string    `json:"type,omitempty"`
+	Issue               *Issue    `json:"issue,omitempty"`
+	LastContentUpdated  time.Time `json:"lastContentUpdated,omitempty"`
+	Created             time.Time `json:"created,omitempty"`
+	Updated             time.Time `json:"updated,omitempty"`
+}
+
+// Webhook represents webhook of Backlog.
+type Webhook struct {
+	ID              int       `json:"id,omitempty"`
+	Name            string    `json:"name,omitempty"`
+	Description     string    `json:"description,omitempty"`
+	HookURL         string    `json:"hookUrl,omitempty"`
+	AllEvent        bool      `json:"allEvent,omitempty"`
+	ActivityTypeIds []int     `json:"activityTypeIds,omitempty"`
+	CreatedUser     *User     `json:"createdUser,omitempty"`
+	Created         time.Time `json:"created,omitempty"`
+	UpdatedUser     *User     `json:"updatedUser,omitempty"`
+	Updated         time.Time `json:"updated,omitempty"`
+}

--- a/internal/model/issue.go
+++ b/internal/model/issue.go
@@ -1,0 +1,62 @@
+package model
+
+import "time"
+
+// Category represents an issue category.
+type Category []struct {
+	ID           int    `json:"id,omitempty"`
+	Name         string `json:"name,omitempty"`
+	DisplayOrder int    `json:"displayOrder,omitempty"`
+}
+
+// Issue represents a issue of Backlog.
+type Issue struct {
+	ID             int            `json:"id,omitempty"`
+	ProjectID      int            `json:"projectId,omitempty"`
+	IssueKey       string         `json:"issueKey,omitempty"`
+	KeyID          int            `json:"keyId,omitempty"`
+	IssueType      *IssueType     `json:"issueType,omitempty"`
+	Summary        string         `json:"summary,omitempty"`
+	Description    string         `json:"description,omitempty"`
+	Resolutions    []*Resolution  `json:"resolutions,omitempty"`
+	Priority       *Priority      `json:"priority,omitempty"`
+	Status         *Status        `json:"status,omitempty"`
+	Assignee       *User          `json:"assignee,omitempty"`
+	Category       *Category      `json:"category,omitempty"`
+	Versions       *Version       `json:"versions,omitempty"`
+	Milestone      *Version       `json:"milestone,omitempty"`
+	StartDate      time.Time      `json:"startDate,omitempty"`
+	DueDate        time.Time      `json:"dueDate,omitempty"`
+	EstimatedHours int            `json:"estimatedHours,omitempty"`
+	ActualHours    int            `json:"actualHours,omitempty"`
+	ParentIssueID  int            `json:"parentIssueId,omitempty"`
+	CreatedUser    *User          `json:"createdUser,omitempty"`
+	Created        time.Time      `json:"created,omitempty"`
+	UpdatedUser    *User          `json:"updatedUser,omitempty"`
+	Updated        time.Time      `json:"updated,omitempty"`
+	CustomFields   []*CustomField `json:"customFields,omitempty"`
+	Attachments    []*Attachment  `json:"attachments,omitempty"`
+	SharedFiles    []*SharedFile  `json:"sharedFiles,omitempty"`
+	Stars          []*Star        `json:"stars,omitempty"`
+}
+
+// IssueType represents type of Issue.
+type IssueType struct {
+	ID           int    `json:"id,omitempty"`
+	ProjectID    int    `json:"projectId,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Color        string `json:"color,omitempty"`
+	DisplayOrder int    `json:"displayOrder,omitempty"`
+}
+
+// Priority represents a priority.
+type Priority struct {
+	ID   int    `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// Resolution represents a resolution.
+type Resolution struct {
+	ID   int    `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}

--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -1,0 +1,19 @@
+package model
+
+// DiskUsageProject represents project's disk usage.
+type DiskUsageProject struct {
+	DiskUsageBase
+	ProjectID int `json:"projectId,omitempty"`
+}
+
+// Project represents a project of Backlog.
+type Project struct {
+	ID                                int    `json:"id,omitempty"`
+	ProjectKey                        string `json:"projectKey,omitempty"`
+	Name                              string `json:"name,omitempty"`
+	ChartEnabled                      bool   `json:"chartEnabled,omitempty"`
+	SubtaskingEnabled                 bool   `json:"subtaskingEnabled,omitempty"`
+	ProjectLeaderCanEditProjectLeader bool   `json:"projectLeaderCanEditProjectLeader,omitempty"`
+	TextFormattingRule                Format `json:"textFormattingRule,omitempty"`
+	Archived                          bool   `json:"archived,omitempty"`
+}

--- a/internal/model/repository.go
+++ b/internal/model/repository.go
@@ -1,0 +1,45 @@
+package model
+
+import "time"
+
+// PullRequest represents pull request of Backlog git.
+type PullRequest struct {
+	ID           int           `json:"id,omitempty"`
+	ProjectID    int           `json:"projectId,omitempty"`
+	RepositoryID int           `json:"repositoryId,omitempty"`
+	Number       int           `json:"number,omitempty"`
+	Summary      string        `json:"summary,omitempty"`
+	Description  string        `json:"description,omitempty"`
+	Base         string        `json:"base,omitempty"`
+	Branch       string        `json:"branch,omitempty"`
+	Status       *Status       `json:"status,omitempty"`
+	Assignee     *User         `json:"assignee,omitempty"`
+	Issue        *Issue        `json:"issue,omitempty"`
+	BaseCommit   interface{}   `json:"baseCommit,omitempty"`
+	BranchCommit interface{}   `json:"branchCommit,omitempty"`
+	CloseAt      time.Time     `json:"closeAt,omitempty"`
+	MergeAt      time.Time     `json:"mergeAt,omitempty"`
+	CreatedUser  *User         `json:"createdUser,omitempty"`
+	Created      time.Time     `json:"created,omitempty"`
+	UpdatedUser  *User         `json:"updatedUser,omitempty"`
+	Updated      time.Time     `json:"updated,omitempty"`
+	Attachments  []*Attachment `json:"attachments,omitempty"`
+	Stars        []*Star       `json:"stars,omitempty"`
+}
+
+// Repository represents repository of Backlog git.
+type Repository struct {
+	ID           int       `json:"id,omitempty"`
+	ProjectID    int       `json:"projectId,omitempty"`
+	Name         string    `json:"name,omitempty"`
+	Description  string    `json:"description,omitempty"`
+	HookURL      string    `json:"hookUrl,omitempty"`
+	HTTPURL      string    `json:"httpUrl,omitempty"`
+	SSHURL       string    `json:"sshUrl,omitempty"`
+	DisplayOrder int       `json:"displayOrder,omitempty"`
+	PushedAt     time.Time `json:"pushedAt,omitempty"`
+	CreatedUser  *User     `json:"createdUser,omitempty"`
+	Created      time.Time `json:"created,omitempty"`
+	UpdatedUser  *User     `json:"updatedUser,omitempty"`
+	Updated      time.Time `json:"updated,omitempty"`
+}

--- a/internal/model/space.go
+++ b/internal/model/space.go
@@ -1,0 +1,29 @@
+package model
+
+import "time"
+
+// DiskUsageSpace represents space's disk usage.
+type DiskUsageSpace struct {
+	DiskUsageBase
+	Capacity int                 `json:"capacity,omitempty"`
+	Details  []*DiskUsageProject `json:"details,omitempty"`
+}
+
+// Space represents space of Backlog.
+type Space struct {
+	SpaceKey           string    `json:"spaceKey,omitempty"`
+	Name               string    `json:"name,omitempty"`
+	OwnerID            int       `json:"ownerId,omitempty"`
+	Lang               string    `json:"lang,omitempty"`
+	Timezone           string    `json:"timezone,omitempty"`
+	ReportSendTime     string    `json:"reportSendTime,omitempty"`
+	TextFormattingRule Format    `json:"textFormattingRule,omitempty"`
+	Created            time.Time `json:"created,omitempty"`
+	Updated            time.Time `json:"updated,omitempty"`
+}
+
+// SpaceNotification represents a notification of Space.
+type SpaceNotification struct {
+	Content string    `json:"content,omitempty"`
+	Updated time.Time `json:"updated,omitempty"`
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -1,0 +1,76 @@
+package model
+
+import "fmt"
+
+// Format defines the text formatting rule for the Backlog wiki.
+const (
+	FormatMarkdown Format = "markdown"
+	FormatBacklog  Format = "backlog"
+)
+
+// Order defines the sort order (ascending or descending).
+const (
+	OrderAsc  Order = "asc"
+	OrderDesc Order = "desc"
+)
+
+// Role defines the type of user role within a project.
+const (
+	_ Role = iota
+	RoleAdministrator
+	RoleNormalUser
+	RoleReporter
+	RoleViewer
+	RoleGuestReporter
+	RoleGuestViewer
+)
+
+// Format defines the text formatting rule for the Backlog wiki.
+type Format string
+
+func (f Format) String() string {
+	switch f {
+	case FormatMarkdown:
+		return "Markdown"
+	case FormatBacklog:
+		return "Backlog"
+	default:
+		return fmt.Sprintf("unknown Format type %s", string(f))
+	}
+}
+
+// Order defines the sort order (ascending or descending).
+type Order string
+
+func (o Order) String() string {
+	switch o {
+	case OrderAsc:
+		return "Asc"
+	case OrderDesc:
+		return "Desc"
+	default:
+		return fmt.Sprintf("unknown Order type %s", string(o))
+	}
+}
+
+// Role defines the type of user role within a project.
+type Role int
+
+func (r Role) String() string {
+	switch r {
+	case RoleAdministrator:
+		return "Administrator"
+	case RoleNormalUser:
+		return "NormalUser"
+	case RoleReporter:
+		return "Reporter"
+	case RoleViewer:
+		return "Viewer"
+	case RoleGuestReporter:
+		return "GuestReporter"
+	case RoleGuestViewer:
+		return "GuestViewer"
+	default:
+		return fmt.Sprintf("unknown Role type %d", r)
+	}
+}

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -1,0 +1,11 @@
+package model
+
+// User represents user.
+type User struct {
+	ID          int    `json:"id,omitempty"`
+	UserID      string `json:"userId,omitempty"`
+	Name        string `json:"name,omitempty"`
+	RoleType    Role   `json:"roleType,omitempty"`
+	Lang        string `json:"lang,omitempty"`
+	MailAddress string `json:"mailAddress,omitempty"`
+}

--- a/internal/model/wiki.go
+++ b/internal/model/wiki.go
@@ -1,0 +1,29 @@
+package model
+
+import "time"
+
+// Wiki represents Backlog Wiki.
+type Wiki struct {
+	ID          int           `json:"id,omitempty"`
+	ProjectID   int           `json:"projectId,omitempty"`
+	Name        string        `json:"name,omitempty"`
+	Content     string        `json:"content,omitempty"`
+	Tags        []*Tag        `json:"tags,omitempty"`
+	Attachments []*Attachment `json:"attachments,omitempty"`
+	SharedFiles []*SharedFile `json:"sharedFiles,omitempty"`
+	Stars       []*Star       `json:"stars,omitempty"`
+	CreatedUser *User         `json:"createdUser,omitempty"`
+	Created     time.Time     `json:"created,omitempty"`
+	UpdatedUser *User         `json:"updatedUser,omitempty"`
+	Updated     time.Time     `json:"updated,omitempty"`
+}
+
+// WikiHistory represents a version history entry for a wiki page.
+type WikiHistory struct {
+	PageID      int       `json:"pageId,omitempty"`
+	Version     int       `json:"version,omitempty"`
+	Name        string    `json:"name,omitempty"`
+	Content     string    `json:"content,omitempty"`
+	CreatedUser *User     `json:"createdUser,omitempty"`
+	Created     time.Time `json:"created,omitempty"`
+}

--- a/internal/testutil/fixture/testdata_wiki.go
+++ b/internal/testutil/fixture/testdata_wiki.go
@@ -1,16 +1,16 @@
 package fixture
 
 import (
-	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/model"
 )
 
 type wikiFixtures struct {
 	MaximumJSON string
-	Maximum     backlog.Wiki
+	Maximum     model.Wiki
 	MinimumJSON string
-	Minimum     backlog.Wiki
+	Minimum     model.Wiki
 	ListJSON    string
-	List        []*backlog.Wiki
+	List        []*model.Wiki
 }
 
 // Wiki provides test fixtures for Wiki-related tests.
@@ -122,67 +122,67 @@ var Wiki = wikiFixtures{
     "updated": "2012-07-23T06:09:48Z"
 }
 `,
-	Maximum: backlog.Wiki{
+	Maximum: model.Wiki{
 		ID:        34,
 		ProjectID: 56,
 		Name:      "Maximum Wiki Page",
 		Content:   "This is a muximal wiki page.",
-		Tags: []*backlog.Tag{
+		Tags: []*model.Tag{
 			{ID: 12, Name: "proceedings"},
 		},
-		Attachments: []*backlog.Attachment{
+		Attachments: []*model.Attachment{
 			{
 				ID:   23,
 				Name: "test.json",
 				Size: 8857,
-				CreatedUser: &backlog.User{
+				CreatedUser: &model.User{
 					ID:          1,
 					UserID:      "admin",
 					Name:        "admin",
-					RoleType:    backlog.RoleAdministrator,
+					RoleType:    model.RoleAdministrator,
 					Lang:        "ja",
 					MailAddress: "eguchi@nulab.example",
 				},
 				Created: mustTime("2014-01-06T11:10:45Z"),
 			},
 		},
-		SharedFiles: []*backlog.SharedFile{
+		SharedFiles: []*model.SharedFile{
 			{
 				ID:   454403,
 				Type: "file",
 				Dir:  "/icon/",
 				Name: "01_buz.png",
 				Size: 2735,
-				CreatedUser: &backlog.User{
+				CreatedUser: &model.User{
 					ID:          5686,
 					UserID:      "takada",
 					Name:        "takada",
-					RoleType:    backlog.RoleNormalUser,
+					RoleType:    model.RoleNormalUser,
 					Lang:        "ja",
 					MailAddress: "takada@nulab.example",
 				},
 				Created: mustTime("2009-02-27T03:26:15Z"),
-				UpdatedUser: &backlog.User{
+				UpdatedUser: &model.User{
 					ID:          5686,
 					UserID:      "takada",
 					Name:        "takada",
-					RoleType:    backlog.RoleNormalUser,
+					RoleType:    model.RoleNormalUser,
 					Lang:        "ja",
 					MailAddress: "takada@nulab.example",
 				},
 				Updated: mustTime("2009-03-03T16:57:47Z"),
 			},
 		},
-		Stars: []*backlog.Star{
+		Stars: []*model.Star{
 			{
 				ID:    75,
 				URL:   "https://xx.backlogtool.com/view/BLG-1",
 				Title: "[BLG-1] first issue | Show issue - Backlog",
-				Presenter: &backlog.User{
+				Presenter: &model.User{
 					ID:          1,
 					UserID:      "admin",
 					Name:        "admin",
-					RoleType:    backlog.RoleAdministrator,
+					RoleType:    model.RoleAdministrator,
 					Lang:        "ja",
 					MailAddress: "eguchi@nulab.example",
 				},
@@ -193,31 +193,31 @@ var Wiki = wikiFixtures{
 				Comment: "ok",
 				URL:     "https://xx.backlogtool.com/view/BLG-1",
 				Title:   "[BLG-1] first issue | Show issue - Backlog",
-				Presenter: &backlog.User{
+				Presenter: &model.User{
 					ID:          1,
 					UserID:      "admin",
 					Name:        "admin",
-					RoleType:    backlog.RoleAdministrator,
+					RoleType:    model.RoleAdministrator,
 					Lang:        "ja",
 					MailAddress: "eguchi@nulab.example",
 				},
 				Created: mustTime("2014-01-23T10:55:19Z"),
 			},
 		},
-		CreatedUser: &backlog.User{
+		CreatedUser: &model.User{
 			ID:          1,
 			UserID:      "admin",
 			Name:        "admin",
-			RoleType:    backlog.RoleAdministrator,
+			RoleType:    model.RoleAdministrator,
 			Lang:        "ja",
 			MailAddress: "eguchi@nulab.example",
 		},
 		Created: mustTime("2012-07-23T06:09:48Z"),
-		UpdatedUser: &backlog.User{
+		UpdatedUser: &model.User{
 			ID:          1,
 			UserID:      "admin",
 			Name:        "admin",
-			RoleType:    backlog.RoleAdministrator,
+			RoleType:    model.RoleAdministrator,
 			Lang:        "ja",
 			MailAddress: "eguchi@nulab.example",
 		},
@@ -258,31 +258,31 @@ var Wiki = wikiFixtures{
     "updated": "2012-07-23T06:09:48Z"
 }
 `,
-	Minimum: backlog.Wiki{
+	Minimum: model.Wiki{
 		ID:        34,
 		ProjectID: 56,
 		Name:      "Minimum Wiki Page",
 		Content:   "This is a minimal wiki page.",
-		Tags: []*backlog.Tag{
+		Tags: []*model.Tag{
 			{ID: 12, Name: "proceedings"},
 		},
-		Attachments: []*backlog.Attachment{},
-		SharedFiles: []*backlog.SharedFile{},
-		Stars:       []*backlog.Star{},
-		CreatedUser: &backlog.User{
+		Attachments: []*model.Attachment{},
+		SharedFiles: []*model.SharedFile{},
+		Stars:       []*model.Star{},
+		CreatedUser: &model.User{
 			ID:          1,
 			UserID:      "admin",
 			Name:        "admin",
-			RoleType:    backlog.RoleAdministrator,
+			RoleType:    model.RoleAdministrator,
 			Lang:        "ja",
 			MailAddress: "eguchi@nulab.example",
 		},
 		Created: mustTime("2012-07-23T06:09:48Z"),
-		UpdatedUser: &backlog.User{
+		UpdatedUser: &model.User{
 			ID:          1,
 			UserID:      "admin",
 			Name:        "admin",
-			RoleType:    backlog.RoleAdministrator,
+			RoleType:    model.RoleAdministrator,
 			Lang:        "ja",
 			MailAddress: "eguchi@nulab.example",
 		},
@@ -350,26 +350,26 @@ var Wiki = wikiFixtures{
     }
 ]
 `,
-	List: []*backlog.Wiki{
+	List: []*model.Wiki{
 		{
 			ID:        112,
 			ProjectID: 56,
 			Name:      "test1",
-			Tags:      []*backlog.Tag{{ID: 12, Name: "proceedings"}},
-			CreatedUser: &backlog.User{
+			Tags:      []*model.Tag{{ID: 12, Name: "proceedings"}},
+			CreatedUser: &model.User{
 				ID:          1,
 				UserID:      "admin",
 				Name:        "admin",
-				RoleType:    backlog.RoleAdministrator,
+				RoleType:    model.RoleAdministrator,
 				Lang:        "ja",
 				MailAddress: "eguchi@nulab.example",
 			},
 			Created: mustTime("2013-05-30T09:11:36Z"),
-			UpdatedUser: &backlog.User{
+			UpdatedUser: &model.User{
 				ID:          1,
 				UserID:      "admin",
 				Name:        "admin",
-				RoleType:    backlog.RoleAdministrator,
+				RoleType:    model.RoleAdministrator,
 				Lang:        "ja",
 				MailAddress: "eguchi@nulab.example",
 			},
@@ -379,21 +379,21 @@ var Wiki = wikiFixtures{
 			ID:        115,
 			ProjectID: 56,
 			Name:      "test2",
-			Tags:      []*backlog.Tag{{ID: 12, Name: "proceedings"}},
-			CreatedUser: &backlog.User{
+			Tags:      []*model.Tag{{ID: 12, Name: "proceedings"}},
+			CreatedUser: &model.User{
 				ID:          1,
 				UserID:      "admin",
 				Name:        "admin",
-				RoleType:    backlog.RoleAdministrator,
+				RoleType:    model.RoleAdministrator,
 				Lang:        "ja",
 				MailAddress: "eguchi@nulab.example",
 			},
 			Created: mustTime("2013-05-30T09:11:36Z"),
-			UpdatedUser: &backlog.User{
+			UpdatedUser: &model.User{
 				ID:          1,
 				UserID:      "admin",
 				Name:        "admin",
-				RoleType:    backlog.RoleAdministrator,
+				RoleType:    model.RoleAdministrator,
 				Lang:        "ja",
 				MailAddress: "eguchi@nulab.example",
 			},

--- a/models.go
+++ b/models.go
@@ -1,450 +1,77 @@
 package backlog
 
 import (
-	"fmt"
-	"time"
+	"github.com/nattokin/go-backlog/internal/model"
 )
 
-// Activity represents a recent update or change in the project or space.
-type Activity struct {
-	ID            int              `json:"id,omitempty"`
-	Project       *Project         `json:"project,omitempty"`
-	Type          int              `json:"type,omitempty"`
-	Content       *ActivityContent `json:"content,omitempty"`
-	Notifications []*Notification  `json:"notifications,omitempty"`
-	CreatedUser   *User            `json:"createdUser,omitempty"`
-}
+type Activity = model.Activity
 
-// ActivityContent represents the detailed content of an activity.
-type ActivityContent struct {
-	ID          int      `json:"id,omitempty"`
-	KeyID       int      `json:"key_id,omitempty"`
-	Summary     string   `json:"summary,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Comment     *Comment `json:"comment,omitempty"`
-}
+type ActivityContent = model.ActivityContent
 
-// Attachment represents an attached file.
-type Attachment struct {
-	ID          int       `json:"id,omitempty"`
-	Name        string    `json:"name,omitempty"`
-	Size        int       `json:"size,omitempty"`
-	CreatedUser *User     `json:"createdUser,omitempty"`
-	Created     time.Time `json:"created,omitempty"`
-}
+type Attachment = model.Attachment
 
-// Category represents an issue category.
-type Category []struct {
-	ID           int    `json:"id,omitempty"`
-	Name         string `json:"name,omitempty"`
-	DisplayOrder int    `json:"displayOrder,omitempty"`
-}
+type Category = model.Category
 
-// ChangeLog represents a history of changes made to an issue.
-type ChangeLog struct {
-	Field         string `json:"field,omitempty"`
-	NewValue      string `json:"newValue,omitempty"`
-	OriginalValue string `json:"originalValue,omitempty"`
-}
+type ChangeLog model.ChangeLog
 
-// Comment represents any one comment.
-type Comment struct {
-	ID            int             `json:"id,omitempty"`
-	Content       string          `json:"content,omitempty"`
-	ChangeLogs    []*ChangeLog    `json:"changeLog,omitempty"`
-	CreatedUser   *User           `json:"createdUser,omitempty"`
-	Created       time.Time       `json:"created,omitempty"`
-	Updated       time.Time       `json:"updated,omitempty"`
-	Stars         *Star           `json:"stars,omitempty"`
-	Notifications []*Notification `json:"notifications,omitempty"`
-}
+type Comment = model.Comment
 
-// CustomField represents a custom field defined in the project.
-type CustomField struct {
-	ID                     int                `json:"id,omitempty"`
-	TypeID                 int                `json:"typeId,omitempty"`
-	Name                   string             `json:"name,omitempty"`
-	Description            string             `json:"description,omitempty"`
-	Required               bool               `json:"required,omitempty"`
-	ApplicableIssueTypeIDs []int              `json:"applicableIssueTypes,omitempty"`
-	AllowAddItem           bool               `json:"allowAddItem,omitempty"`
-	Items                  []*CustomFieldItem `json:"items,omitempty"`
-}
+type CustomField = model.CustomField
 
-// CustomFieldItem represents one of Items in CustomField.
-type CustomFieldItem struct {
-	ID           int    `json:"id,omitempty"`
-	Name         string `json:"name,omitempty"`
-	DisplayOrder int    `json:"displayOrder,omitempty"`
-}
+type CustomFieldItem model.CustomFieldItem
 
-// DiskUsageBase represents base of disk usage.
-type DiskUsageBase struct {
-	Issue      int `json:"issue,omitempty"`
-	Wiki       int `json:"wiki,omitempty"`
-	File       int `json:"file,omitempty"`
-	Subversion int `json:"subversion,omitempty"`
-	Git        int `json:"git,omitempty"`
-	GitLFS     int `json:"gitLFS,omitempty"`
-}
+type DiskUsageBase = model.DiskUsageBase
 
-// DiskUsageSpace represents space's disk usage.
-type DiskUsageSpace struct {
-	DiskUsageBase
-	Capacity int                 `json:"capacity,omitempty"`
-	Details  []*DiskUsageProject `json:"details,omitempty"`
-}
+type DiskUsageSpace = model.DiskUsageSpace
 
-// DiskUsageProject represents project's disk usage.
-type DiskUsageProject struct {
-	DiskUsageBase
-	ProjectID int `json:"projectId,omitempty"`
-}
+type DiskUsageProject = model.DiskUsageProject
 
-// Licence represents licence.
-type Licence struct {
-	Active                            bool      `json:"active,omitempty"`
-	AttachmentLimit                   int       `json:"attachmentLimit,omitempty"`
-	AttachmentLimitPerFile            int       `json:"attachmentLimitPerFile,omitempty"`
-	AttachmentNumLimit                int       `json:"attachmentNumLimit,omitempty"`
-	Attribute                         bool      `json:"attribute,omitempty"`
-	AttributeLimit                    int       `json:"attributeLimit,omitempty"`
-	Burndown                          bool      `json:"burndown,omitempty"`
-	CommentLimit                      int       `json:"commentLimit,omitempty"`
-	ComponentLimit                    int       `json:"componentLimit,omitempty"`
-	FileSharing                       bool      `json:"fileSharing,omitempty"`
-	Gantt                             bool      `json:"gantt,omitempty"`
-	Git                               bool      `json:"git,omitempty"`
-	IssueLimit                        int       `json:"issueLimit,omitempty"`
-	LicenceTypeID                     int       `json:"licenceTypeId,omitempty"`
-	LimitDate                         time.Time `json:"limitDate,omitempty"`
-	NulabAccount                      bool      `json:"nulabAccount,omitempty"`
-	ParentChildIssue                  bool      `json:"parentChildIssue,omitempty"`
-	PostIssueByMail                   bool      `json:"postIssueByMail,omitempty"`
-	ProjectGroup                      bool      `json:"projectGroup,omitempty"`
-	ProjectLimit                      int       `json:"projectLimit,omitempty"`
-	PullRequestAttachmentLimitPerFile int       `json:"pullRequestAttachmentLimitPerFile,omitempty"`
-	PullRequestAttachmentNumLimit     int       `json:"pullRequestAttachmentNumLimit,omitempty"`
-	RemoteAddress                     bool      `json:"remoteAddress,omitempty"`
-	RemoteAddressLimit                int       `json:"remoteAddressLimit,omitempty"`
-	StartedOn                         time.Time `json:"startedOn,omitempty"`
-	StorageLimit                      int64     `json:"storageLimit,omitempty"`
-	Subversion                        bool      `json:"subversion,omitempty"`
-	SubversionExternal                bool      `json:"subversionExternal,omitempty"`
-	UserLimit                         int       `json:"userLimit,omitempty"`
-	VersionLimit                      int       `json:"versionLimit,omitempty"`
-	WikiAttachment                    bool      `json:"wikiAttachment,omitempty"`
-	WikiAttachmentLimitPerFile        int       `json:"wikiAttachmentLimitPerFile,omitempty"`
-	WikiAttachmentNumLimit            int       `json:"wikiAttachmentNumLimit,omitempty"`
-}
+type Licence = model.Licence
 
-// Notification represents some notification.
-type Notification struct {
-	ID                  int          `json:"id,omitempty"`
-	AlreadyRead         bool         `json:"alreadyRead,omitempty"`
-	Reason              int          `json:"reason,omitempty"`
-	ResourceAlreadyRead bool         `json:"resourceAlreadyRead,omitempty"`
-	Project             *Project     `json:"project,omitempty"`
-	Issue               *Issue       `json:"issue,omitempty"`
-	Comment             *Comment     `json:"comment,omitempty"`
-	PullRequest         *PullRequest `json:"pullRequest,omitempty"`
-	PullRequestComment  *Comment     `json:"pullRequestComment,omitempty"`
-	Sender              *User        `json:"sender,omitempty"`
-	Created             time.Time    `json:"created,omitempty"`
-}
+type Notification = model.Notification
 
-// Issue represents a issue of Backlog.
-type Issue struct {
-	ID             int            `json:"id,omitempty"`
-	ProjectID      int            `json:"projectId,omitempty"`
-	IssueKey       string         `json:"issueKey,omitempty"`
-	KeyID          int            `json:"keyId,omitempty"`
-	IssueType      *IssueType     `json:"issueType,omitempty"`
-	Summary        string         `json:"summary,omitempty"`
-	Description    string         `json:"description,omitempty"`
-	Resolutions    []*Resolution  `json:"resolutions,omitempty"`
-	Priority       *Priority      `json:"priority,omitempty"`
-	Status         *Status        `json:"status,omitempty"`
-	Assignee       *User          `json:"assignee,omitempty"`
-	Category       *Category      `json:"category,omitempty"`
-	Versions       *Version       `json:"versions,omitempty"`
-	Milestone      *Version       `json:"milestone,omitempty"`
-	StartDate      time.Time      `json:"startDate,omitempty"`
-	DueDate        time.Time      `json:"dueDate,omitempty"`
-	EstimatedHours int            `json:"estimatedHours,omitempty"`
-	ActualHours    int            `json:"actualHours,omitempty"`
-	ParentIssueID  int            `json:"parentIssueId,omitempty"`
-	CreatedUser    *User          `json:"createdUser,omitempty"`
-	Created        time.Time      `json:"created,omitempty"`
-	UpdatedUser    *User          `json:"updatedUser,omitempty"`
-	Updated        time.Time      `json:"updated,omitempty"`
-	CustomFields   []*CustomField `json:"customFields,omitempty"`
-	Attachments    []*Attachment  `json:"attachments,omitempty"`
-	SharedFiles    []*SharedFile  `json:"sharedFiles,omitempty"`
-	Stars          []*Star        `json:"stars,omitempty"`
-}
+type Issue = model.Issue
 
-// IssueType represents type of Issue.
-type IssueType struct {
-	ID           int    `json:"id,omitempty"`
-	ProjectID    int    `json:"projectId,omitempty"`
-	Name         string `json:"name,omitempty"`
-	Color        string `json:"color,omitempty"`
-	DisplayOrder int    `json:"displayOrder,omitempty"`
-}
+type IssueType = model.IssueType
 
-// Priority represents a priority.
-type Priority struct {
-	ID   int    `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-}
+type Priority = model.Priority
 
-// Project represents a project of Backlog.
-type Project struct {
-	ID                                int    `json:"id,omitempty"`
-	ProjectKey                        string `json:"projectKey,omitempty"`
-	Name                              string `json:"name,omitempty"`
-	ChartEnabled                      bool   `json:"chartEnabled,omitempty"`
-	SubtaskingEnabled                 bool   `json:"subtaskingEnabled,omitempty"`
-	ProjectLeaderCanEditProjectLeader bool   `json:"projectLeaderCanEditProjectLeader,omitempty"`
-	TextFormattingRule                Format `json:"textFormattingRule,omitempty"`
-	Archived                          bool   `json:"archived,omitempty"`
-}
+type Project = model.Project
 
-// PullRequest represents pull request of Backlog git.
-type PullRequest struct {
-	ID           int           `json:"id,omitempty"`
-	ProjectID    int           `json:"projectId,omitempty"`
-	RepositoryID int           `json:"repositoryId,omitempty"`
-	Number       int           `json:"number,omitempty"`
-	Summary      string        `json:"summary,omitempty"`
-	Description  string        `json:"description,omitempty"`
-	Base         string        `json:"base,omitempty"`
-	Branch       string        `json:"branch,omitempty"`
-	Status       *Status       `json:"status,omitempty"`
-	Assignee     *User         `json:"assignee,omitempty"`
-	Issue        *Issue        `json:"issue,omitempty"`
-	BaseCommit   interface{}   `json:"baseCommit,omitempty"`
-	BranchCommit interface{}   `json:"branchCommit,omitempty"`
-	CloseAt      time.Time     `json:"closeAt,omitempty"`
-	MergeAt      time.Time     `json:"mergeAt,omitempty"`
-	CreatedUser  *User         `json:"createdUser,omitempty"`
-	Created      time.Time     `json:"created,omitempty"`
-	UpdatedUser  *User         `json:"updatedUser,omitempty"`
-	Updated      time.Time     `json:"updated,omitempty"`
-	Attachments  []*Attachment `json:"attachments,omitempty"`
-	Stars        []*Star       `json:"stars,omitempty"`
-}
+type PullRequest = model.PullRequest
 
-// Repository represents repository of Backlog git.
-type Repository struct {
-	ID           int       `json:"id,omitempty"`
-	ProjectID    int       `json:"projectId,omitempty"`
-	Name         string    `json:"name,omitempty"`
-	Description  string    `json:"description,omitempty"`
-	HookURL      string    `json:"hookUrl,omitempty"`
-	HTTPURL      string    `json:"httpUrl,omitempty"`
-	SSHURL       string    `json:"sshUrl,omitempty"`
-	DisplayOrder int       `json:"displayOrder,omitempty"`
-	PushedAt     time.Time `json:"pushedAt,omitempty"`
-	CreatedUser  *User     `json:"createdUser,omitempty"`
-	Created      time.Time `json:"created,omitempty"`
-	UpdatedUser  *User     `json:"updatedUser,omitempty"`
-	Updated      time.Time `json:"updated,omitempty"`
-}
+type Repository model.Repository
 
-// Resolution represents a resolution.
-type Resolution struct {
-	ID   int    `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-}
+type Resolution = model.Resolution
 
-// SharedFile represents a file shared within the project or space.
-type SharedFile struct {
-	ID          int       `json:"id,omitempty"`
-	Type        string    `json:"type,omitempty"`
-	Dir         string    `json:"dir,omitempty"`
-	Name        string    `json:"name,omitempty"`
-	Size        int       `json:"size,omitempty"`
-	CreatedUser *User     `json:"createdUser,omitempty"`
-	Created     time.Time `json:"created,omitempty"`
-	UpdatedUser *User     `json:"updatedUser,omitempty"`
-	Updated     time.Time `json:"updated,omitempty"`
-}
+type SharedFile = model.SharedFile
 
-// Space represents space of Backlog.
-type Space struct {
-	SpaceKey           string    `json:"spaceKey,omitempty"`
-	Name               string    `json:"name,omitempty"`
-	OwnerID            int       `json:"ownerId,omitempty"`
-	Lang               string    `json:"lang,omitempty"`
-	Timezone           string    `json:"timezone,omitempty"`
-	ReportSendTime     string    `json:"reportSendTime,omitempty"`
-	TextFormattingRule Format    `json:"textFormattingRule,omitempty"`
-	Created            time.Time `json:"created,omitempty"`
-	Updated            time.Time `json:"updated,omitempty"`
-}
+type Space = model.Space
 
-// SpaceNotification represents a notification of Space.
-type SpaceNotification struct {
-	Content string    `json:"content,omitempty"`
-	Updated time.Time `json:"updated,omitempty"`
-}
+type SpaceNotification = model.SpaceNotification
 
-// Star represents any Star.
-type Star struct {
-	ID        int       `json:"id,omitempty"`
-	Comment   string    `json:"comment,omitempty"`
-	URL       string    `json:"url,omitempty"`
-	Title     string    `json:"title,omitempty"`
-	Presenter *User     `json:"presenter,omitempty"`
-	Created   time.Time `json:"created,omitempty"`
-}
+type Star = model.Star
 
-// Status represents any status.
-type Status struct {
-	ID   int    `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-}
+type Status = model.Status
 
-// Tag represents one of tags in Wiki.
-type Tag struct {
-	ID   int    `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-}
+type Tag = model.Tag
 
-// Team represents team.
-type Team struct {
-	ID           int       `json:"id,omitempty"`
-	Name         string    `json:"name,omitempty"`
-	Members      []*User   `json:"members,omitempty"`
-	DisplayOrder int       `json:"displayOrder,omitempty"`
-	CreatedUser  *User     `json:"createdUser,omitempty"`
-	Created      time.Time `json:"created,omitempty"`
-	UpdatedUser  *User     `json:"updatedUser,omitempty"`
-	Updated      time.Time `json:"updated,omitempty"`
-}
+type Team = model.Team
 
-// User represents user.
-type User struct {
-	ID          int    `json:"id,omitempty"`
-	UserID      string `json:"userId,omitempty"`
-	Name        string `json:"name,omitempty"`
-	RoleType    Role   `json:"roleType,omitempty"`
-	Lang        string `json:"lang,omitempty"`
-	MailAddress string `json:"mailAddress,omitempty"`
-}
+type User = model.User
 
-// Version represents any version.
-type Version struct {
-	ID             int       `json:"id,omitempty"`
-	ProjectID      int       `json:"projectId,omitempty"`
-	Name           string    `json:"name,omitempty"`
-	Description    string    `json:"description,omitempty"`
-	StartDate      time.Time `json:"startDate,omitempty"`
-	ReleaseDueDate time.Time `json:"releaseDueDate,omitempty"`
-	Archived       bool      `json:"archived,omitempty"`
-	DisplayOrder   int       `json:"displayOrder,omitempty"`
-}
+type Version = model.Version
 
-// WatchingItem represents an item of watching list.
-type WatchingItem struct {
-	ID                  int       `json:"id,omitempty"`
-	ResourceAlreadyRead bool      `json:"resourceAlreadyRead,omitempty"`
-	Note                string    `json:"note,omitempty"`
-	Type                string    `json:"type,omitempty"`
-	Issue               *Issue    `json:"issue,omitempty"`
-	LastContentUpdated  time.Time `json:"lastContentUpdated,omitempty"`
-	Created             time.Time `json:"created,omitempty"`
-	Updated             time.Time `json:"updated,omitempty"`
-}
+type WatchingItem = model.WatchingItem
 
-// Webhook represents webhook of Backlog.
-type Webhook struct {
-	ID              int       `json:"id,omitempty"`
-	Name            string    `json:"name,omitempty"`
-	Description     string    `json:"description,omitempty"`
-	HookURL         string    `json:"hookUrl,omitempty"`
-	AllEvent        bool      `json:"allEvent,omitempty"`
-	ActivityTypeIds []int     `json:"activityTypeIds,omitempty"`
-	CreatedUser     *User     `json:"createdUser,omitempty"`
-	Created         time.Time `json:"created,omitempty"`
-	UpdatedUser     *User     `json:"updatedUser,omitempty"`
-	Updated         time.Time `json:"updated,omitempty"`
-}
+type Webhook = model.Webhook
 
-// Wiki represents Backlog Wiki.
-type Wiki struct {
-	ID          int           `json:"id,omitempty"`
-	ProjectID   int           `json:"projectId,omitempty"`
-	Name        string        `json:"name,omitempty"`
-	Content     string        `json:"content,omitempty"`
-	Tags        []*Tag        `json:"tags,omitempty"`
-	Attachments []*Attachment `json:"attachments,omitempty"`
-	SharedFiles []*SharedFile `json:"sharedFiles,omitempty"`
-	Stars       []*Star       `json:"stars,omitempty"`
-	CreatedUser *User         `json:"createdUser,omitempty"`
-	Created     time.Time     `json:"created,omitempty"`
-	UpdatedUser *User         `json:"updatedUser,omitempty"`
-	Updated     time.Time     `json:"updated,omitempty"`
-}
+type Wiki = model.Wiki
 
-// WikiHistory represents a version history entry for a wiki page.
-type WikiHistory struct {
-	PageID      int       `json:"pageId,omitempty"`
-	Version     int       `json:"version,omitempty"`
-	Name        string    `json:"name,omitempty"`
-	Content     string    `json:"content,omitempty"`
-	CreatedUser *User     `json:"createdUser,omitempty"`
-	Created     time.Time `json:"created,omitempty"`
-}
+type WikiHistory = model.WikiHistory
 
-// Format defines the text formatting rule for the Backlog wiki.
-type Format string
+type Format = model.Format
 
-func (f Format) String() string {
-	switch f {
-	case FormatMarkdown:
-		return "Markdown"
-	case FormatBacklog:
-		return "Backlog"
-	default:
-		return fmt.Sprintf("unknown Format type %s", string(f))
-	}
-}
+type Order = model.Order
 
-// Order defines the sort order (ascending or descending).
-type Order string
-
-func (o Order) String() string {
-	switch o {
-	case OrderAsc:
-		return "Asc"
-	case OrderDesc:
-		return "Desc"
-	default:
-		return fmt.Sprintf("unknown Order type %s", string(o))
-	}
-}
-
-// Role defines the type of user role within a project.
-type Role int
-
-func (r Role) String() string {
-	switch r {
-	case RoleAdministrator:
-		return "Administrator"
-	case RoleNormalUser:
-		return "NormalUser"
-	case RoleReporter:
-		return "Reporter"
-	case RoleViewer:
-		return "Viewer"
-	case RoleGuestReporter:
-		return "GuestReporter"
-	case RoleGuestViewer:
-		return "GuestViewer"
-	default:
-		return fmt.Sprintf("unknown Role type %d", r)
-	}
-}
+type Role = model.Role


### PR DESCRIPTION
## Summary

Move all model structs from `models.go` into a new `internal/model` package as the first step of #149. The root `models.go` is replaced with type aliases so the public API is unchanged.

## Changes

- Add `internal/model/` with the following files:
  - `common.go` — `Attachment`,`Star`, `SharedFile`, `Notification`, `Comment`, `ChangeLog`, `Tag`,`Team`, `Status`, `Priority`, `Version`, `Licence`
  - `types.go` — `Format`, `Order`, `Role` type definitions, `String()` methods, and related constants
  - `activity.go` — `Activity`, `ActivityContent`
  - `issue.go` — `Issue`, `IssueType`, `Resolution`, `CustomField`, `CustomFieldItem`, `WatchingItem`
  - `project.go` — `Project`, `DiskUsageBase`, `DiskUsageSpace`, `DiskUsageProject`
  - `repository.go` — `PullRequest`, `Repository`
  - `space.go` — `Space`, `SpaceNotification`
  - `user.go` — `User`
  - `wiki.go` — `Wiki`, `WikiHistory`
- Replace `models.go` with type aliases (`type Wiki = model.Wiki`, etc.)
- Move `FormatMarkdown`, `FormatBacklog`, `OrderAsc`, `OrderDesc`, `Role*` constants from `const.go` into `internal/model/types.go`
- Doc comments are kept on the alias side (root `models.go`); `internal/model` structs are intentionally left without doc comments to avoid duplication

## Notes

- No public API change. All existing types remain accessible as `backlog.Wiki` etc.
- Tests pass without modification.

Part of #149