### PR TITLE
refactor: move core HTTP client to internal/core

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-func getActivityList(ctx context.Context, base *OptionService, m *core.Method, spath string, opts ...RequestOption) ([]*Activity, error) {
+func getActivityList(ctx context.Context, m *core.Method, spath string, opts ...RequestOption) ([]*Activity, error) {
 	query := url.Values{}
 	validOptionKeys := []apiParamOptionType{paramActivityTypeIDs, paramMinID, paramMaxID, paramCount, paramOrder}
 	if err := applyOptions(query, validOptionKeys, opts...); err != nil {
@@ -53,7 +53,7 @@ func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string
 	}
 
 	spath := path.Join("projects", projectIDOrKey, "activities")
-	return getActivityList(ctx, s.Option.base, s.method, spath, opts...)
+	return getActivityList(ctx, s.method, spath, opts...)
 }
 
 // SpaceActivityService handles communication with the space activities-related methods of the Backlog API.
@@ -75,7 +75,7 @@ type SpaceActivityService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-recent-updates
 func (s *SpaceActivityService) List(ctx context.Context, opts ...RequestOption) ([]*Activity, error) {
-	return getActivityList(ctx, s.Option.base, s.method, "space/activities", opts...)
+	return getActivityList(ctx, s.method, "space/activities", opts...)
 }
 
 // UserActivityService handles communication with the user activities-related methods of the Backlog API.
@@ -103,5 +103,5 @@ func (s *UserActivityService) List(ctx context.Context, userID int, opts ...Requ
 	}
 
 	spath := path.Join("users", strconv.Itoa(userID), "activities")
-	return getActivityList(ctx, s.Option.base, s.method, spath, opts...)
+	return getActivityList(ctx, s.method, spath, opts...)
 }

--- a/activity.go
+++ b/activity.go
@@ -5,9 +5,11 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/core"
 )
 
-func getActivityList(ctx context.Context, base *OptionService, m *method, spath string, opts ...RequestOption) ([]*Activity, error) {
+func getActivityList(ctx context.Context, base *OptionService, m *core.Method, spath string, opts ...RequestOption) ([]*Activity, error) {
 	query := url.Values{}
 	validOptionKeys := []apiParamOptionType{paramActivityTypeIDs, paramMinID, paramMaxID, paramCount, paramOrder}
 	if err := applyOptions(query, validOptionKeys, opts...); err != nil {
@@ -20,7 +22,7 @@ func getActivityList(ctx context.Context, base *OptionService, m *method, spath 
 	}
 
 	v := []*Activity{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -29,7 +31,7 @@ func getActivityList(ctx context.Context, base *OptionService, m *method, spath 
 
 // ProjectActivityService handles communication with the project activities-related methods of the Backlog API.
 type ProjectActivityService struct {
-	method *method
+	method *core.Method
 
 	Option *ActivityOptionService
 }
@@ -56,7 +58,7 @@ func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string
 
 // SpaceActivityService handles communication with the space activities-related methods of the Backlog API.
 type SpaceActivityService struct {
-	method *method
+	method *core.Method
 
 	Option *ActivityOptionService
 }
@@ -78,7 +80,7 @@ func (s *SpaceActivityService) List(ctx context.Context, opts ...RequestOption) 
 
 // UserActivityService handles communication with the user activities-related methods of the Backlog API.
 type UserActivityService struct {
-	method *method
+	method *core.Method
 
 	Option *ActivityOptionService
 }

--- a/attachment.go
+++ b/attachment.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/core"
 )
 
 func validateAttachmentID(attachmentID int) error {
@@ -18,7 +20,7 @@ func validateAttachmentID(attachmentID int) error {
 
 // SpaceAttachmentService handles communication with the space attachment-related methods of the Backlog API.
 type SpaceAttachmentService struct {
-	method *method
+	method *core.Method
 }
 
 // Upload uploads any file to the space.
@@ -33,35 +35,35 @@ func (s *SpaceAttachmentService) Upload(ctx context.Context, fileName string, r 
 	}
 
 	v := Attachment{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
 	return &v, nil
 }
 
-func listAttachments(ctx context.Context, m *method, spath string) ([]*Attachment, error) {
+func listAttachments(ctx context.Context, m *core.Method, spath string) ([]*Attachment, error) {
 	resp, err := m.Get(ctx, spath, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	v := []*Attachment{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
 	return v, nil
 }
 
-func removeAttachment(ctx context.Context, m *method, spath string) (*Attachment, error) {
+func removeAttachment(ctx context.Context, m *core.Method, spath string) (*Attachment, error) {
 	resp, err := m.Delete(ctx, spath, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	v := Attachment{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -70,7 +72,7 @@ func removeAttachment(ctx context.Context, m *method, spath string) (*Attachment
 
 // WikiAttachmentService handles communication with the wiki attachment-related methods of the Backlog API.
 type WikiAttachmentService struct {
-	method *method
+	method *core.Method
 }
 
 // Attach attaches files uploaded to the space to the specified wiki.
@@ -99,7 +101,7 @@ func (s *WikiAttachmentService) Attach(ctx context.Context, wikiID int, attachme
 	}
 
 	v := []*Attachment{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -135,7 +137,7 @@ func (s *WikiAttachmentService) Remove(ctx context.Context, wikiID, attachmentID
 
 // IssueAttachmentService handles communication with the issue attachment-related methods of the Backlog API.
 type IssueAttachmentService struct {
-	method *method
+	method *core.Method
 }
 
 // List returns a list of all attachments in the issue.
@@ -167,7 +169,7 @@ func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string
 
 // PullRequestAttachmentService handles communication with the pull request attachment-related methods of the Backlog API.
 type PullRequestAttachmentService struct {
-	method *method
+	method *core.Method
 }
 
 // List returns a list of all attachments in the pull request.

--- a/category.go
+++ b/category.go
@@ -1,8 +1,10 @@
 package backlog
 
+import "github.com/nattokin/go-backlog/internal/core"
+
 // CategoryService handles communication with the category-related methods of the Backlog API.
 //
 //nolint:unused // API not implemented yet
 type CategoryService struct {
-	method *method
+	method *core.Method
 }

--- a/client.go
+++ b/client.go
@@ -1,8 +1,6 @@
 package backlog
 
 import (
-	"net/http"
-
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
@@ -10,12 +8,7 @@ import (
 //  Doer interface (HTTP abstraction)
 // ──────────────────────────────────────────────────────────────
 
-// Doer defines the minimal interface required to perform HTTP requests.
-// It is compatible with *http.Client and allows injection of mock clients
-// for unit or integration testing.
-type Doer interface {
-	Do(req *http.Request) (*http.Response, error)
-}
+type Doer = core.Doer
 
 // ──────────────────────────────────────────────────────────────
 //  Client structure and initialization

--- a/client.go
+++ b/client.go
@@ -1,15 +1,9 @@
 package backlog
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"errors"
-	"io"
 	"net/http"
-	"net/url"
-	"path"
-	"strings"
+
+	"github.com/nattokin/go-backlog/internal/core"
 )
 
 // ──────────────────────────────────────────────────────────────
@@ -30,11 +24,7 @@ type Doer interface {
 // Client represents a Backlog API client.
 // It wraps an underlying HTTP Doer and provides typed services for API access.
 type Client struct {
-	baseURL *url.URL
-	token   string
-	doer    Doer
-	wrapper wrapper
-	method  *method
+	core *core.Client
 
 	// Service endpoints
 	Issue       *IssueService
@@ -43,21 +33,6 @@ type Client struct {
 	Space       *SpaceService
 	User        *UserService
 	Wiki        *WikiService
-}
-
-// ──────────────────────────────────────────────────────────────
-//  HTTP method function set
-// ──────────────────────────────────────────────────────────────
-
-// method holds injected HTTP operation functions.
-// Each function delegates to Client.do() but can be replaced in tests
-// for fine-grained unit testing of individual services.
-type method struct {
-	Get    func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
-	Post   func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
-	Patch  func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
-	Delete func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
-	Upload func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -71,186 +46,16 @@ type method struct {
 // such as:
 //   - WithDoer
 func NewClient(baseURL, token string, opts ...*ClientOption) (*Client, error) {
-	if token == "" {
-		return nil, newInternalClientError("missing token")
-	}
-	if baseURL == "" {
-		return nil, newInternalClientError("missing baseURL")
-	}
-
-	u, err := url.ParseRequestURI(baseURL)
+	core, err := core.NewClient(baseURL, token, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	config := &clientConfig{}
-	for _, option := range opts {
-		if option != nil {
-			option.set(config)
-		}
-	}
-
-	if config.Doer == nil {
-		config.Doer = http.DefaultClient
-	}
-
 	c := &Client{
-		baseURL: u,
-		doer:    config.Doer,
-		token:   token,
-		wrapper: &defaultWrapper{},
-	}
-
-	// --- Inject HTTP method wrappers ------------------------------------------
-	c.method = &method{
-		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-			return c.do(ctx, http.MethodGet, spath, withQuery(query))
-		},
-		Post: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-			header := http.Header{}
-			header.Set("Content-Type", "application/x-www-form-urlencoded")
-			if form == nil {
-				form = url.Values{}
-			}
-			return c.do(ctx, http.MethodPost, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
-		},
-		Patch: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-			header := http.Header{}
-			header.Set("Content-Type", "application/x-www-form-urlencoded")
-			if form == nil {
-				form = url.Values{}
-			}
-			return c.do(ctx, http.MethodPatch, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
-		},
-		Delete: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-			header := http.Header{}
-			header.Set("Content-Type", "application/x-www-form-urlencoded")
-			if form == nil {
-				form = url.Values{}
-			}
-			return c.do(ctx, http.MethodDelete, spath, withHeader(header), withBody(strings.NewReader(form.Encode())))
-		},
-		Upload: func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
-			if fileName == "" {
-				return nil, newInternalClientError("fileName is required")
-			}
-			var buf bytes.Buffer
-			mw := c.wrapper.NewMultipartWriter(&buf)
-
-			fw, err := mw.CreateFormFile("file", fileName)
-			if err != nil {
-				return nil, err
-			}
-			if err = c.wrapper.Copy(fw, r); err != nil {
-				return nil, err
-			}
-			if err := mw.Close(); err != nil {
-				return nil, err
-			}
-
-			header := http.Header{}
-			header.Set("Content-Type", mw.FormDataContentType())
-
-			return c.do(ctx, http.MethodPost, spath, withHeader(header), withBody(&buf))
-		},
+		core: core,
 	}
 
 	initServices(c)
 
 	return c, nil
-}
-
-// ──────────────────────────────────────────────────────────────
-//  HTTP request creation and execution
-// ──────────────────────────────────────────────────────────────
-
-// newRequest builds a new HTTP request with token-based authentication.
-func (c *Client) newRequest(ctx context.Context, method, spath string, opts ...*httpRequestOption) (*http.Request, error) {
-	if spath == "" {
-		return nil, errors.New("spath must not be empty")
-	}
-
-	config := &httpRequestConfig{}
-	for _, option := range opts {
-		if option != nil {
-			option.set(config)
-		}
-	}
-
-	u := *c.baseURL
-	u.Path = path.Join(u.Path, "api", apiVersion, spath)
-	if config.Query != nil {
-		u.RawQuery = config.Query.Encode()
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, u.String(), config.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if config.Header != nil {
-		req.Header = config.Header.Clone()
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-
-	return req, nil
-}
-
-// do executes the given HTTP request using the injected Doer.
-// All HTTP calls pass through this function, ensuring consistent error handling.
-func (c *Client) do(ctx context.Context, method, spath string, opts ...*httpRequestOption) (*http.Response, error) {
-	req, err := c.newRequest(ctx, method, spath, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.doer.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	return checkResponse(resp)
-}
-
-// ──────────────────────────────────────────────────────────────
-//  Response helpers
-// ──────────────────────────────────────────────────────────────
-
-// checkResponse validates an HTTP response and decodes API errors if present.
-// It closes the response body in error cases to avoid leaks.
-func checkResponse(r *http.Response) (*http.Response, error) {
-	sc := r.StatusCode
-
-	if 200 <= sc && sc <= 299 {
-		if sc == http.StatusNoContent {
-			if r.Body != nil {
-				r.Body.Close()
-			}
-			return nil, nil
-		}
-		return r, nil
-	}
-
-	defer func() {
-		if r.Body != nil {
-			r.Body.Close()
-		}
-	}()
-
-	e := &APIResponseError{StatusCode: sc}
-
-	if r.Body != nil {
-		if err := json.NewDecoder(r.Body).Decode(e); err == nil {
-			return nil, e
-		}
-	}
-
-	return nil, e
-}
-
-// decodeResponse decodes the JSON body of resp into v and closes the body.
-func decodeResponse(resp *http.Response, v any) error {
-	defer resp.Body.Close()
-
-	return json.NewDecoder(resp.Body).Decode(v)
 }

--- a/client_option.go
+++ b/client_option.go
@@ -1,10 +1,6 @@
 package backlog
 
-import (
-	"io"
-	"net/http"
-	"net/url"
-)
+import "github.com/nattokin/go-backlog/internal/core"
 
 // ──────────────────────────────────────────────────────────────
 //  Client options
@@ -12,62 +8,12 @@ import (
 
 // ClientOption defines a functional option for configuring a Client.
 // It is used to change the default behavior of the Client.
-type ClientOption struct {
-	set func(config *clientConfig)
-}
-
-// clientConfig holds the internal configuration settings for the Client.
-type clientConfig struct {
-	// Doer is the HTTP client used to make requests.
-	Doer Doer
-}
+type ClientOption = core.ClientOption
 
 // WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.
 // This is useful for providing a custom *http.Client or a mock implementation during testing.
 //
 // If this option is not provided, http.DefaultClient is used by default.
 func WithDoer(doer Doer) *ClientOption {
-	return &ClientOption{
-		set: func(config *clientConfig) {
-			config.Doer = doer
-		},
-	}
-}
-
-// ──────────────────────────────────────────────────────────────
-//  Http request otions
-// ──────────────────────────────────────────────────────────────
-
-type httpRequestOption struct {
-	set func(config *httpRequestConfig)
-}
-
-type httpRequestConfig struct {
-	Header http.Header
-	Body   io.Reader
-	Query  url.Values
-}
-
-func withHeader(header http.Header) *httpRequestOption {
-	return &httpRequestOption{
-		set: func(config *httpRequestConfig) {
-			config.Header = header
-		},
-	}
-}
-
-func withBody(body io.Reader) *httpRequestOption {
-	return &httpRequestOption{
-		set: func(config *httpRequestConfig) {
-			config.Body = body
-		},
-	}
-}
-
-func withQuery(query url.Values) *httpRequestOption {
-	return &httpRequestOption{
-		set: func(config *httpRequestConfig) {
-			config.Query = query
-		},
-	}
+	return core.WithDoer(doer)
 }

--- a/client_option.go
+++ b/client_option.go
@@ -6,8 +6,6 @@ import "github.com/nattokin/go-backlog/internal/core"
 //  Client options
 // ──────────────────────────────────────────────────────────────
 
-// ClientOption defines a functional option for configuring a Client.
-// It is used to change the default behavior of the Client.
 type ClientOption = core.ClientOption
 
 // WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.

--- a/client_test.go
+++ b/client_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nattokin/go-backlog/internal/core"
 )
 
 func TestNewClient_validation(t *testing.T) {
@@ -66,8 +68,8 @@ func TestNewClient_validation(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.NotNil(t, c)
-			assert.Equal(t, tc.baseURL, c.baseURL.String())
-			assert.Equal(t, tc.token, c.token)
+			assert.Equal(t, tc.baseURL, c.core.BaseURL.String())
+			assert.Equal(t, tc.token, c.core.Token)
 		})
 	}
 }
@@ -86,8 +88,8 @@ func TestNewClient_initialization(t *testing.T) {
 		require.NoError(t, err)
 
 		{
-			req, _ := c.newRequest(context.Background(), http.MethodGet, "test")
-			res, err := c.doer.Do(req)
+			req, _ := c.core.NewRequest(context.Background(), http.MethodGet, "test")
+			res, err := c.core.Doer.Do(req)
 			require.Error(t, err)
 			assert.Nil(t, res)
 			assert.Equal(t, "mockDoer error", err.Error())
@@ -102,9 +104,9 @@ func TestNewClient_initialization(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, c)
 
-		assert.Equal(t, token, c.token)
-		assert.Equal(t, http.DefaultClient, c.doer)
-		assert.IsType(t, &defaultWrapper{}, c.wrapper)
+		assert.Equal(t, token, c.core.Token)
+		assert.Equal(t, http.DefaultClient, c.core.Doer)
+		assert.IsType(t, &core.DefaultWrapper{}, c.core.Wrapper)
 
 		// Service initialization
 		assert.NotNil(t, c.Wiki)
@@ -228,7 +230,7 @@ func TestClient_do(t *testing.T) {
 				doFunc: tc.doFunc,
 			})
 
-			res, err := c.do(
+			res, err := c.core.Do(
 				context.Background(),
 				http.MethodGet,
 				"test",
@@ -349,13 +351,13 @@ func TestClient_newRequest(t *testing.T) {
 			t.Parallel()
 
 			c := newClientMock(t, "https://test.com", "test", nil)
-			request, err := c.newRequest(
+			request, err := c.core.NewRequest(
 				context.Background(),
 				tc.method,
 				tc.spath,
-				withHeader(tc.header),
-				withBody(tc.body),
-				withQuery(tc.query),
+				core.WithHeader(tc.header),
+				core.WithBody(tc.body),
+				core.WithQuery(tc.query),
 			)
 
 			if tc.wantError {
@@ -379,7 +381,7 @@ func TestClient_method(t *testing.T) {
 	}{
 		"GET": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Get(context.Background(), "/path1", nil)
+				return c.core.Method.Get(context.Background(), "/path1", nil)
 			},
 			check: func(t *testing.T, captured *httpCapture) {
 				assert.Equal(t, "GET", captured.Method)
@@ -395,7 +397,7 @@ func TestClient_method(t *testing.T) {
 			call: func(c *Client) (*http.Response, error) {
 				form := url.Values{}
 				form.Add("k", "v")
-				return c.method.Post(context.Background(), "/path2", form)
+				return c.core.Method.Post(context.Background(), "/path2", form)
 			},
 			check: func(t *testing.T, captured *httpCapture) {
 				assert.Equal(t, "POST", captured.Method)
@@ -411,7 +413,7 @@ func TestClient_method(t *testing.T) {
 			call: func(c *Client) (*http.Response, error) {
 				form := url.Values{}
 				form.Add("id", "123")
-				return c.method.Patch(context.Background(), "/path3", form)
+				return c.core.Method.Patch(context.Background(), "/path3", form)
 			},
 			check: func(t *testing.T, captured *httpCapture) {
 				assert.Equal(t, "PATCH", captured.Method)
@@ -426,7 +428,7 @@ func TestClient_method(t *testing.T) {
 			call: func(c *Client) (*http.Response, error) {
 				form := url.Values{}
 				form.Add("id", "321")
-				return c.method.Delete(context.Background(), "/path4", form)
+				return c.core.Method.Delete(context.Background(), "/path4", form)
 			},
 			check: func(t *testing.T, captured *httpCapture) {
 				assert.Equal(t, "DELETE", captured.Method)
@@ -440,7 +442,7 @@ func TestClient_method(t *testing.T) {
 		"UPLOAD": {
 			call: func(c *Client) (*http.Response, error) {
 				buf := bytes.NewBufferString("dummyfiledata")
-				return c.method.Upload(context.Background(), "/upload-path", "file.txt", buf)
+				return c.core.Method.Upload(context.Background(), "/upload-path", "file.txt", buf)
 			},
 			check: func(t *testing.T, captured *httpCapture) {
 				assert.Equal(t, "POST", captured.Method)
@@ -474,40 +476,40 @@ func TestClient_method(t *testing.T) {
 		// エラーケースは変更なし
 		"GET newRequest error": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Get(context.Background(), "", url.Values{})
+				return c.core.Method.Get(context.Background(), "", url.Values{})
 			},
 			wantErr: true,
 		},
 
 		"POST newRequest error": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Post(context.Background(), "", nil)
+				return c.core.Method.Post(context.Background(), "", nil)
 			},
 			wantErr: true,
 		},
 
 		"PATCH empty params": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Patch(context.Background(), "spath", nil)
+				return c.core.Method.Patch(context.Background(), "spath", nil)
 			},
 		},
 
 		"PATCH newRequest error": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Patch(context.Background(), "", nil)
+				return c.core.Method.Patch(context.Background(), "", nil)
 			},
 			wantErr: true,
 		},
 
 		"DELETE empty params": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Delete(context.Background(), "spath", nil)
+				return c.core.Method.Delete(context.Background(), "spath", nil)
 			},
 		},
 
 		"DELETE newRequest error": {
 			call: func(c *Client) (*http.Response, error) {
-				return c.method.Delete(context.Background(), "", nil)
+				return c.core.Method.Delete(context.Background(), "", nil)
 			},
 			wantErr: true,
 		},
@@ -562,7 +564,7 @@ func TestClient_methodUpload_errors(t *testing.T) {
 			fileName: "filename",
 			fileData: "dummy",
 			setup: func(c *Client) {
-				c.wrapper = mockWrapper{createErr: errors.New("mock createFormFile error")}
+				c.core.Wrapper = mockWrapper{createErr: errors.New("mock createFormFile error")}
 			},
 		},
 
@@ -571,7 +573,7 @@ func TestClient_methodUpload_errors(t *testing.T) {
 			fileName: "filename",
 			fileData: "dummy",
 			setup: func(c *Client) {
-				c.wrapper = mockWrapper{closeErr: errors.New("mock close error")}
+				c.core.Wrapper = mockWrapper{closeErr: errors.New("mock close error")}
 			},
 		},
 
@@ -580,7 +582,7 @@ func TestClient_methodUpload_errors(t *testing.T) {
 			fileName: "filename",
 			fileData: "dummy",
 			setup: func(c *Client) {
-				c.wrapper = mockWrapper{copyErr: errors.New("mock copy error")}
+				c.core.Wrapper = mockWrapper{copyErr: errors.New("mock copy error")}
 			},
 		},
 	}
@@ -597,7 +599,7 @@ func TestClient_methodUpload_errors(t *testing.T) {
 
 			f := io.NopCloser(bytes.NewBufferString(tc.fileData))
 
-			resp, err := c.method.Upload(context.Background(), tc.spath, tc.fileName, f)
+			resp, err := c.core.Method.Upload(context.Background(), tc.spath, tc.fileName, f)
 
 			assert.Error(t, err)
 			assert.Nil(t, resp)
@@ -683,7 +685,7 @@ func Test_checkResponse(t *testing.T) {
 			}
 
 			// Use the exported function from backlog package
-			r, err := checkResponse(resp)
+			r, err := core.CheckResponse(resp)
 
 			// 1. Validate response pointer
 			if tc.wantNilResponse {

--- a/const.go
+++ b/const.go
@@ -2,10 +2,6 @@ package backlog
 
 import "github.com/nattokin/go-backlog/internal/model"
 
-const (
-	apiVersion = "v2"
-)
-
 // Order defines the sort order (ascending or descending).
 const (
 	OrderAsc  = model.OrderAsc

--- a/customfield.go
+++ b/customfield.go
@@ -1,8 +1,10 @@
 package backlog
 
+import "github.com/nattokin/go-backlog/internal/core"
+
 // CustomFieldService handles communication with the custom field-related methods of the Backlog API.
 //
 //nolint:unused // API not implemented yet
 type CustomFieldService struct {
-	method *method
+	method *core.Method
 }

--- a/error.go
+++ b/error.go
@@ -3,58 +3,15 @@ package backlog
 import (
 	"fmt"
 	"strings"
+
+	"github.com/nattokin/go-backlog/internal/core"
 )
 
-// Error represents one of Backlog API response errors.
-type Error struct {
-	// Message is the detailed error message from the API.
-	Message  string `json:"message,omitempty"`
-	Code     int    `json:"code,omitempty"`
-	MoreInfo string `json:"moreInfo,omitempty"`
-}
+type Error = core.Error
 
-// Error returns the API error message.
-func (e *Error) Error() string {
-	msg := fmt.Sprintf("Message:%s, Code:%d", e.Message, e.Code)
+type InternalClientError = core.InternalClientError
 
-	if e.MoreInfo == "" {
-		return msg
-	}
-
-	return msg + ", MoreInfo:" + e.MoreInfo
-}
-
-// InternalClientError represents client-side configuration or usage errors.
-// It is distinct from API-level errors and indicates issues like missing token
-// or malformed base URL.
-type InternalClientError struct {
-	msg string
-}
-
-func (e *InternalClientError) Error() string {
-	return e.msg
-}
-
-func newInternalClientError(msg string) *InternalClientError {
-	return &InternalClientError{msg: msg}
-}
-
-// APIResponseError represents Error Response of Backlog API.
-type APIResponseError struct {
-	StatusCode int      `json:"-"` // HTTP status code (4xx or 5xx)
-	Errors     []*Error `json:"errors,omitempty"`
-}
-
-// Error returns all error messages in APIResponseError.
-func (e *APIResponseError) Error() string {
-	msgs := make([]string, len(e.Errors))
-
-	for i, err := range e.Errors {
-		msgs[i] = err.Error()
-	}
-
-	return fmt.Sprintf("Status Code:%d\n%s", e.StatusCode, strings.Join(msgs, "\n"))
-}
+type APIResponseError = core.APIResponseError
 
 // InvalidOptionKeyError represents an error for an invalid option value.
 type InvalidOptionKeyError struct {

--- a/error_test.go
+++ b/error_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nattokin/go-backlog/internal/core"
 )
 
 func TestError_Error(t *testing.T) {
@@ -85,7 +87,7 @@ func TestAPIResponseError_errorsAs(t *testing.T) {
 		StatusCode: 404,
 		Body:       nil,
 	}
-	_, err := checkResponse(resp)
+	_, err := core.CheckResponse(resp)
 	require.Error(t, err)
 
 	wrapped := fmt.Errorf("wrap: %w", err)
@@ -131,7 +133,7 @@ func TestInvalidOptionKeyError_errorsAs_form(t *testing.T) {
 // TestInternalClientError_errorsAs verifies that InternalClientError can be
 // unwrapped with errors.As by callers.
 func TestInternalClientError_errorsAs(t *testing.T) {
-	err := newInternalClientError("missing token")
+	err := core.NewInternalClientError("missing token")
 	wrapped := fmt.Errorf("wrap: %w", err)
 
 	var target *InternalClientError

--- a/helper_test.go
+++ b/helper_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/nattokin/go-backlog/internal/core"
 )
 
 //
@@ -184,8 +186,8 @@ func newPullRequestAttachmentService() *PullRequestAttachmentService {
 
 // newClientMethod creates and returns a mock implementation of the `method` struct.
 // Each API function (Get, Post, Patch, Delete) returns a default "not implemented" error.
-func newClientMethod() *method {
-	return &method{
+func newClientMethod() *core.Method {
+	return &core.Method{
 		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 			return nil, errors.New("default mock not implemented")
 		},

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -32,8 +32,6 @@ type Doer interface {
 //  Client structure and initialization
 // ──────────────────────────────────────────────────────────────
 
-// Client represents a Backlog API client.
-// It wraps an underlying HTTP Doer and provides typed services for API access.
 type Client struct {
 	BaseURL *url.URL
 	Token   string
@@ -94,56 +92,11 @@ func NewClient(baseURL, token string, opts ...*ClientOption) (*Client, error) {
 
 	// --- Inject HTTP Method Wrappers ------------------------------------------
 	c.Method = &Method{
-		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-			return c.Do(ctx, http.MethodGet, spath, WithQuery(query))
-		},
-		Post: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-			header := http.Header{}
-			header.Set("Content-Type", "application/x-www-form-urlencoded")
-			if form == nil {
-				form = url.Values{}
-			}
-			return c.Do(ctx, http.MethodPost, spath, WithHeader(header), WithBody(strings.NewReader(form.Encode())))
-		},
-		Patch: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-			header := http.Header{}
-			header.Set("Content-Type", "application/x-www-form-urlencoded")
-			if form == nil {
-				form = url.Values{}
-			}
-			return c.Do(ctx, http.MethodPatch, spath, WithHeader(header), WithBody(strings.NewReader(form.Encode())))
-		},
-		Delete: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-			header := http.Header{}
-			header.Set("Content-Type", "application/x-www-form-urlencoded")
-			if form == nil {
-				form = url.Values{}
-			}
-			return c.Do(ctx, http.MethodDelete, spath, WithHeader(header), WithBody(strings.NewReader(form.Encode())))
-		},
-		Upload: func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
-			if fileName == "" {
-				return nil, NewInternalClientError("fileName is required")
-			}
-			var buf bytes.Buffer
-			mw := c.Wrapper.NewMultipartWriter(&buf)
-
-			fw, err := mw.CreateFormFile("file", fileName)
-			if err != nil {
-				return nil, err
-			}
-			if err = c.Wrapper.Copy(fw, r); err != nil {
-				return nil, err
-			}
-			if err := mw.Close(); err != nil {
-				return nil, err
-			}
-
-			header := http.Header{}
-			header.Set("Content-Type", mw.FormDataContentType())
-
-			return c.Do(ctx, http.MethodPost, spath, WithHeader(header), WithBody(&buf))
-		},
+		Get:    c.Get,
+		Post:   c.Post,
+		Patch:  c.Patch,
+		Delete: c.Delete,
+		Upload: c.Upload,
 	}
 
 	return c, nil
@@ -153,8 +106,8 @@ func NewClient(baseURL, token string, opts ...*ClientOption) (*Client, error) {
 //  HTTP request creation and execution
 // ──────────────────────────────────────────────────────────────
 
-// newRequest builds a new HTTP request with Token-based authentication.
-func (c *Client) NewRequest(ctx context.Context, Method, spath string, opts ...*httpRequestOption) (*http.Request, error) {
+// NewRequest builds a new HTTP request with Token-based authentication.
+func (c *Client) NewRequest(ctx context.Context, Method, spath string, opts ...*HttpRequestOption) (*http.Request, error) {
 	if spath == "" {
 		return nil, errors.New("spath must not be empty")
 	}
@@ -185,9 +138,9 @@ func (c *Client) NewRequest(ctx context.Context, Method, spath string, opts ...*
 	return req, nil
 }
 
-// do executes the given HTTP request using the injected Doer.
+// Do executes the given HTTP request using the injected Doer.
 // All HTTP calls pass through this function, ensuring consistent error handling.
-func (c *Client) Do(ctx context.Context, Method, spath string, opts ...*httpRequestOption) (*http.Response, error) {
+func (c *Client) Do(ctx context.Context, Method, spath string, opts ...*HttpRequestOption) (*http.Response, error) {
 	req, err := c.NewRequest(ctx, Method, spath, opts...)
 	if err != nil {
 		return nil, err
@@ -199,6 +152,61 @@ func (c *Client) Do(ctx context.Context, Method, spath string, opts ...*httpRequ
 	}
 
 	return CheckResponse(resp)
+}
+
+func (c *Client) Get(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+	return c.Do(ctx, http.MethodGet, spath, WithQuery(query))
+}
+
+func (c *Client) Post(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+	header := http.Header{}
+	header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if form == nil {
+		form = url.Values{}
+	}
+	return c.Do(ctx, http.MethodPost, spath, WithHeader(header), WithBody(strings.NewReader(form.Encode())))
+}
+
+func (c *Client) Patch(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+	header := http.Header{}
+	header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if form == nil {
+		form = url.Values{}
+	}
+	return c.Do(ctx, http.MethodPatch, spath, WithHeader(header), WithBody(strings.NewReader(form.Encode())))
+}
+
+func (c *Client) Delete(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+	header := http.Header{}
+	header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if form == nil {
+		form = url.Values{}
+	}
+	return c.Do(ctx, http.MethodDelete, spath, WithHeader(header), WithBody(strings.NewReader(form.Encode())))
+}
+
+func (c *Client) Upload(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
+	if fileName == "" {
+		return nil, NewInternalClientError("fileName is required")
+	}
+	var buf bytes.Buffer
+	mw := c.Wrapper.NewMultipartWriter(&buf)
+
+	fw, err := mw.CreateFormFile("file", fileName)
+	if err != nil {
+		return nil, err
+	}
+	if err = c.Wrapper.Copy(fw, r); err != nil {
+		return nil, err
+	}
+	if err := mw.Close(); err != nil {
+		return nil, err
+	}
+
+	header := http.Header{}
+	header.Set("Content-Type", mw.FormDataContentType())
+
+	return c.Do(ctx, http.MethodPost, spath, WithHeader(header), WithBody(&buf))
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -106,7 +106,6 @@ func NewClient(baseURL, token string, opts ...*ClientOption) (*Client, error) {
 //  HTTP request creation and execution
 // ──────────────────────────────────────────────────────────────
 
-// NewRequest builds a new HTTP request with Token-based authentication.
 func (c *Client) NewRequest(ctx context.Context, Method, spath string, opts ...*HttpRequestOption) (*http.Request, error) {
 	if spath == "" {
 		return nil, errors.New("spath must not be empty")

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -1,0 +1,296 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+)
+
+const (
+	apiVersion = "v2"
+)
+
+// ──────────────────────────────────────────────────────────────
+//  Doer interface (HTTP abstraction)
+// ──────────────────────────────────────────────────────────────
+
+// Doer defines the minimal interface required to perform HTTP requests.
+// It is compatible with *http.Client and allows injection of mock clients
+// for unit or integration testing.
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Client structure and initialization
+// ──────────────────────────────────────────────────────────────
+
+// Client represents a Backlog API client.
+// It wraps an underlying HTTP Doer and provides typed services for API access.
+type Client struct {
+	BaseURL *url.URL
+	Token   string
+	Doer    Doer
+	Wrapper Wrapper
+	Method  *Method
+}
+
+// ──────────────────────────────────────────────────────────────
+//  HTTP Method function set
+// ──────────────────────────────────────────────────────────────
+
+// Method holds injected HTTP operation functions.
+// Each function delegates to Client.do() but can be replaced in tests
+// for fine-grained unit testing of individual services.
+type Method struct {
+	Get    func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+	Post   func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+	Patch  func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+	Delete func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+	Upload func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Client constructor
+// ──────────────────────────────────────────────────────────────
+
+func NewClient(baseURL, token string, opts ...*ClientOption) (*Client, error) {
+	if token == "" {
+		return nil, NewInternalClientError("missing token")
+	}
+	if baseURL == "" {
+		return nil, NewInternalClientError("missing baseURL")
+	}
+
+	u, err := url.ParseRequestURI(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &clientConfig{}
+	for _, option := range opts {
+		if option != nil {
+			option.set(config)
+		}
+	}
+
+	if config.Doer == nil {
+		config.Doer = http.DefaultClient
+	}
+
+	c := &Client{
+		BaseURL: u,
+		Doer:    config.Doer,
+		Token:   token,
+		Wrapper: &DefaultWrapper{},
+	}
+
+	// --- Inject HTTP Method Wrappers ------------------------------------------
+	c.Method = &Method{
+		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+			return c.Do(ctx, http.MethodGet, spath, WithQuery(query))
+		},
+		Post: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+			header := http.Header{}
+			header.Set("Content-Type", "application/x-www-form-urlencoded")
+			if form == nil {
+				form = url.Values{}
+			}
+			return c.Do(ctx, http.MethodPost, spath, WithHeader(header), WithBody(strings.NewReader(form.Encode())))
+		},
+		Patch: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+			header := http.Header{}
+			header.Set("Content-Type", "application/x-www-form-urlencoded")
+			if form == nil {
+				form = url.Values{}
+			}
+			return c.Do(ctx, http.MethodPatch, spath, WithHeader(header), WithBody(strings.NewReader(form.Encode())))
+		},
+		Delete: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+			header := http.Header{}
+			header.Set("Content-Type", "application/x-www-form-urlencoded")
+			if form == nil {
+				form = url.Values{}
+			}
+			return c.Do(ctx, http.MethodDelete, spath, WithHeader(header), WithBody(strings.NewReader(form.Encode())))
+		},
+		Upload: func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
+			if fileName == "" {
+				return nil, NewInternalClientError("fileName is required")
+			}
+			var buf bytes.Buffer
+			mw := c.Wrapper.NewMultipartWriter(&buf)
+
+			fw, err := mw.CreateFormFile("file", fileName)
+			if err != nil {
+				return nil, err
+			}
+			if err = c.Wrapper.Copy(fw, r); err != nil {
+				return nil, err
+			}
+			if err := mw.Close(); err != nil {
+				return nil, err
+			}
+
+			header := http.Header{}
+			header.Set("Content-Type", mw.FormDataContentType())
+
+			return c.Do(ctx, http.MethodPost, spath, WithHeader(header), WithBody(&buf))
+		},
+	}
+
+	return c, nil
+}
+
+// ──────────────────────────────────────────────────────────────
+//  HTTP request creation and execution
+// ──────────────────────────────────────────────────────────────
+
+// newRequest builds a new HTTP request with Token-based authentication.
+func (c *Client) NewRequest(ctx context.Context, Method, spath string, opts ...*httpRequestOption) (*http.Request, error) {
+	if spath == "" {
+		return nil, errors.New("spath must not be empty")
+	}
+
+	config := &httpRequestConfig{}
+	for _, option := range opts {
+		if option != nil {
+			option.set(config)
+		}
+	}
+
+	u := *c.BaseURL
+	u.Path = path.Join(u.Path, "api", apiVersion, spath)
+	if config.Query != nil {
+		u.RawQuery = config.Query.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, Method, u.String(), config.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if config.Header != nil {
+		req.Header = config.Header.Clone()
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+
+	return req, nil
+}
+
+// do executes the given HTTP request using the injected Doer.
+// All HTTP calls pass through this function, ensuring consistent error handling.
+func (c *Client) Do(ctx context.Context, Method, spath string, opts ...*httpRequestOption) (*http.Response, error) {
+	req, err := c.NewRequest(ctx, Method, spath, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Doer.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return CheckResponse(resp)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Response helpers
+// ──────────────────────────────────────────────────────────────
+
+// CheckResponse validates an HTTP response and decodes API errors if present.
+// It closes the response body in error cases to avoid leaks.
+func CheckResponse(r *http.Response) (*http.Response, error) {
+	sc := r.StatusCode
+
+	if 200 <= sc && sc <= 299 {
+		if sc == http.StatusNoContent {
+			if r.Body != nil {
+				r.Body.Close()
+			}
+			return nil, nil
+		}
+		return r, nil
+	}
+
+	defer func() {
+		if r.Body != nil {
+			r.Body.Close()
+		}
+	}()
+
+	e := &APIResponseError{StatusCode: sc}
+
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(e); err == nil {
+			return nil, e
+		}
+	}
+
+	return nil, e
+}
+
+// DecodeResponse decodes the JSON body of resp into v and closes the body.
+func DecodeResponse(resp *http.Response, v any) error {
+	defer resp.Body.Close()
+
+	return json.NewDecoder(resp.Body).Decode(v)
+}
+
+// Error represents one of Backlog API response errors.
+type Error struct {
+	// Message is the detailed error message from the API.
+	Message  string `json:"message,omitempty"`
+	Code     int    `json:"code,omitempty"`
+	MoreInfo string `json:"moreInfo,omitempty"`
+}
+
+// Error returns the API error message.
+func (e *Error) Error() string {
+	msg := fmt.Sprintf("Message:%s, Code:%d", e.Message, e.Code)
+
+	if e.MoreInfo == "" {
+		return msg
+	}
+
+	return msg + ", MoreInfo:" + e.MoreInfo
+}
+
+// InternalClientError represents client-side configuration or usage errors.
+// It is distinct from API-level errors and indicates issues like missing Token
+// or malformed base URL.
+type InternalClientError struct {
+	msg string
+}
+
+func (e *InternalClientError) Error() string {
+	return e.msg
+}
+
+func NewInternalClientError(msg string) *InternalClientError {
+	return &InternalClientError{msg: msg}
+}
+
+// APIResponseError represents Error Response of Backlog API.
+type APIResponseError struct {
+	StatusCode int      `json:"-"` // HTTP status code (4xx or 5xx)
+	Errors     []*Error `json:"errors,omitempty"`
+}
+
+// Error returns all error messages in APIResponseError.
+func (e *APIResponseError) Error() string {
+	msgs := make([]string, len(e.Errors))
+
+	for i, err := range e.Errors {
+		msgs[i] = err.Error()
+	}
+
+	return fmt.Sprintf("Status Code:%d\n%s", e.StatusCode, strings.Join(msgs, "\n"))
+}

--- a/internal/core/client_option.go
+++ b/internal/core/client_option.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// ──────────────────────────────────────────────────────────────
+//  Client options
+// ──────────────────────────────────────────────────────────────
+
+// ClientOption defines a functional option for configuring a Client.
+// It is used to change the default behavior of the Client.
+type ClientOption struct {
+	set func(config *clientConfig)
+}
+
+// clientConfig holds the internal configuration settings for the Client.
+type clientConfig struct {
+	// Doer is the HTTP client used to make requests.
+	Doer Doer
+}
+
+// WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.
+// This is useful for providing a custom *http.Client or a mock implementation during testing.
+//
+// If this option is not provided, http.DefaultClient is used by default.
+func WithDoer(doer Doer) *ClientOption {
+	return &ClientOption{
+		set: func(config *clientConfig) {
+			config.Doer = doer
+		},
+	}
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Http request otions
+// ──────────────────────────────────────────────────────────────
+
+type httpRequestOption struct {
+	set func(config *httpRequestConfig)
+}
+
+type httpRequestConfig struct {
+	Header http.Header
+	Body   io.Reader
+	Query  url.Values
+}
+
+func WithHeader(header http.Header) *httpRequestOption {
+	return &httpRequestOption{
+		set: func(config *httpRequestConfig) {
+			config.Header = header
+		},
+	}
+}
+
+func WithBody(body io.Reader) *httpRequestOption {
+	return &httpRequestOption{
+		set: func(config *httpRequestConfig) {
+			config.Body = body
+		},
+	}
+}
+
+func WithQuery(query url.Values) *httpRequestOption {
+	return &httpRequestOption{
+		set: func(config *httpRequestConfig) {
+			config.Query = query
+		},
+	}
+}

--- a/internal/core/client_option.go
+++ b/internal/core/client_option.go
@@ -22,10 +22,6 @@ type clientConfig struct {
 	Doer Doer
 }
 
-// WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.
-// This is useful for providing a custom *http.Client or a mock implementation during testing.
-//
-// If this option is not provided, http.DefaultClient is used by default.
 func WithDoer(doer Doer) *ClientOption {
 	return &ClientOption{
 		set: func(config *clientConfig) {

--- a/internal/core/client_option.go
+++ b/internal/core/client_option.go
@@ -38,7 +38,7 @@ func WithDoer(doer Doer) *ClientOption {
 //  Http request otions
 // ──────────────────────────────────────────────────────────────
 
-type httpRequestOption struct {
+type HttpRequestOption struct {
 	set func(config *httpRequestConfig)
 }
 
@@ -48,24 +48,24 @@ type httpRequestConfig struct {
 	Query  url.Values
 }
 
-func WithHeader(header http.Header) *httpRequestOption {
-	return &httpRequestOption{
+func WithHeader(header http.Header) *HttpRequestOption {
+	return &HttpRequestOption{
 		set: func(config *httpRequestConfig) {
 			config.Header = header
 		},
 	}
 }
 
-func WithBody(body io.Reader) *httpRequestOption {
-	return &httpRequestOption{
+func WithBody(body io.Reader) *HttpRequestOption {
+	return &HttpRequestOption{
 		set: func(config *httpRequestConfig) {
 			config.Body = body
 		},
 	}
 }
 
-func WithQuery(query url.Values) *httpRequestOption {
-	return &httpRequestOption{
+func WithQuery(query url.Values) *HttpRequestOption {
+	return &HttpRequestOption{
 		set: func(config *httpRequestConfig) {
 			config.Query = query
 		},

--- a/internal/core/wrapper.go
+++ b/internal/core/wrapper.go
@@ -1,4 +1,4 @@
-package backlog
+package core
 
 import (
 	"io"
@@ -9,12 +9,12 @@ import (
 //  Wrapper interface for I/O abstractions
 // ──────────────────────────────────────────────────────────────
 
-type wrapper interface {
+type Wrapper interface {
 	Copy(dst io.Writer, src io.Reader) error
-	NewMultipartWriter(w io.Writer) multipartWriter
+	NewMultipartWriter(w io.Writer) MultipartWriter
 }
 
-type multipartWriter interface {
+type MultipartWriter interface {
 	CreateFormFile(fieldname, filename string) (io.Writer, error)
 	FormDataContentType() string
 	Close() error
@@ -24,14 +24,14 @@ type multipartWriter interface {
 //  Default wrapper implementations
 // ──────────────────────────────────────────────────────────────
 
-type defaultWrapper struct{}
+type DefaultWrapper struct{}
 
-func (*defaultWrapper) Copy(dst io.Writer, src io.Reader) error {
+func (*DefaultWrapper) Copy(dst io.Writer, src io.Reader) error {
 	_, err := io.Copy(dst, src)
 	return err
 }
 
-func (*defaultWrapper) NewMultipartWriter(w io.Writer) multipartWriter {
+func (*DefaultWrapper) NewMultipartWriter(w io.Writer) MultipartWriter {
 	return &defaultMultipartWriter{multipart.NewWriter(w)}
 }
 

--- a/issue.go
+++ b/issue.go
@@ -1,5 +1,7 @@
 package backlog
 
+import "github.com/nattokin/go-backlog/internal/core"
+
 func validateIssueIDOrKey(issueIDOrKey string) error {
 	if issueIDOrKey == "" {
 		return newValidationError("issueIDOrKey must not be empty")
@@ -12,7 +14,7 @@ func validateIssueIDOrKey(issueIDOrKey string) error {
 
 // IssueService handles communication with the issue-related methods of the Backlog API.
 type IssueService struct {
-	method *method
+	method *core.Method
 
 	Attachment *IssueAttachmentService
 }

--- a/priority.go
+++ b/priority.go
@@ -1,8 +1,10 @@
 package backlog
 
+import "github.com/nattokin/go-backlog/internal/core"
+
 // PriorityService handles communication with the priority-related methods of the Backlog API.
 //
 //nolint:unused // API not implemented yet
 type PriorityService struct {
-	method *method
+	method *core.Method
 }

--- a/project.go
+++ b/project.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/url"
 	"path"
+
+	"github.com/nattokin/go-backlog/internal/core"
 )
 
 func validateProjectID(projectID int) error {
@@ -25,7 +27,7 @@ func validateProjectIDOrKey(projectIDOrKey string) error {
 
 // ProjectService handles communication with the project-related methods of the Backlog API.
 type ProjectService struct {
-	method *method
+	method *core.Method
 
 	Activity *ProjectActivityService
 	User     *ProjectUserService
@@ -54,7 +56,7 @@ func (s *ProjectService) All(ctx context.Context, opts ...RequestOption) ([]*Pro
 	}
 
 	v := []*Project{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -76,7 +78,7 @@ func (s *ProjectService) One(ctx context.Context, projectIDOrKey string) (*Proje
 	}
 
 	v := Project{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -108,7 +110,7 @@ func (s *ProjectService) Create(ctx context.Context, key, name string, opts ...R
 	}
 
 	v := Project{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -149,7 +151,7 @@ func (s *ProjectService) Update(ctx context.Context, projectIDOrKey string, opts
 	}
 
 	v := Project{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -171,7 +173,7 @@ func (s *ProjectService) Delete(ctx context.Context, projectIDOrKey string) (*Pr
 	}
 
 	v := Project{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -1,5 +1,7 @@
 package backlog
 
+import "github.com/nattokin/go-backlog/internal/core"
+
 func validatePRNumber(prNumber int) error {
 	if prNumber < 1 {
 		return newValidationError("prNumber must not be less than 1")
@@ -9,7 +11,7 @@ func validatePRNumber(prNumber int) error {
 
 // PullRequestService handles communication with the Pull Request-related methods of the Backlog API.
 type PullRequestService struct {
-	method *method
+	method *core.Method
 
 	Attachment *PullRequestAttachmentService
 }

--- a/repository.go
+++ b/repository.go
@@ -1,5 +1,7 @@
 package backlog
 
+import "github.com/nattokin/go-backlog/internal/core"
+
 func validateRepositoryIDOrName(repositoryIDOrName string) error {
 	if repositoryIDOrName == "" {
 		return newValidationError("repositoryIDOrName must not be empty")
@@ -14,5 +16,5 @@ func validateRepositoryIDOrName(repositoryIDOrName string) error {
 //
 //nolint:unused // API not implemented yet
 type RepositoryService struct {
-	method *method
+	method *core.Method
 }

--- a/resolution.go
+++ b/resolution.go
@@ -1,8 +1,10 @@
 package backlog
 
+import "github.com/nattokin/go-backlog/internal/core"
+
 // ResolutionService handles communication with the resolution-related methods of the Backlog API.
 //
 //nolint:unused // API not implemented yet
 type ResolutionService struct {
-	method *method
+	method *core.Method
 }

--- a/service_init.go
+++ b/service_init.go
@@ -14,21 +14,21 @@ func initServices(c *Client) {
 
 	// --- Initialize IssueService -------------------------------------------------
 	c.Issue = &IssueService{
-		method: c.method,
+		method: c.core.Method,
 		Attachment: &IssueAttachmentService{
-			method: c.method,
+			method: c.core.Method,
 		},
 	}
 
 	// --- Initialize ProjectService ----------------------------------------------
 	c.Project = &ProjectService{
-		method: c.method,
+		method: c.core.Method,
 		Activity: &ProjectActivityService{
-			method: c.method,
+			method: c.core.Method,
 			Option: activityOptionService,
 		},
 		User: &ProjectUserService{
-			method: c.method,
+			method: c.core.Method,
 		},
 		Option: &ProjectOptionService{
 			base: baseOptionService,
@@ -37,29 +37,29 @@ func initServices(c *Client) {
 
 	// --- Initialize PullRequestService ------------------------------------------
 	c.PullRequest = &PullRequestService{
-		method: c.method,
+		method: c.core.Method,
 		Attachment: &PullRequestAttachmentService{
-			method: c.method,
+			method: c.core.Method,
 		},
 	}
 
 	// --- Initialize SpaceService -------------------------------------------------
 	c.Space = &SpaceService{
-		method: c.method,
+		method: c.core.Method,
 		Activity: &SpaceActivityService{
-			method: c.method,
+			method: c.core.Method,
 			Option: activityOptionService,
 		},
 		Attachment: &SpaceAttachmentService{
-			method: c.method,
+			method: c.core.Method,
 		},
 	}
 
 	// --- Initialize UserService --------------------------------------------------
 	c.User = &UserService{
-		method: c.method,
+		method: c.core.Method,
 		Activity: &UserActivityService{
-			method: c.method,
+			method: c.core.Method,
 			Option: activityOptionService,
 		},
 		Option: &UserOptionService{
@@ -69,9 +69,9 @@ func initServices(c *Client) {
 
 	// --- Initialize WikiService --------------------------------------------------
 	c.Wiki = &WikiService{
-		method: c.method,
+		method: c.core.Method,
 		Attachment: &WikiAttachmentService{
-			method: c.method,
+			method: c.core.Method,
 		},
 		Option: &WikiOptionService{
 			base: baseOptionService,

--- a/space.go
+++ b/space.go
@@ -1,8 +1,10 @@
 package backlog
 
+import "github.com/nattokin/go-backlog/internal/core"
+
 // SpaceService handles communication with the space-related methods of the Backlog API.
 type SpaceService struct {
-	method *method
+	method *core.Method
 
 	Activity   *SpaceActivityService
 	Attachment *SpaceAttachmentService

--- a/status.go
+++ b/status.go
@@ -1,8 +1,10 @@
 package backlog
 
+import "github.com/nattokin/go-backlog/internal/core"
+
 // StatusService handles communication with the status-related methods of the Backlog API.
 //
 //nolint:unused // API not implemented yet
 type StatusService struct {
-	method *method
+	method *core.Method
 }

--- a/user.go
+++ b/user.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/core"
 )
 
 // UserID is the unique identifier for a user.
@@ -21,70 +23,70 @@ func (id UserID) String() string {
 	return strconv.Itoa(int(id))
 }
 
-func getUser(ctx context.Context, m *method, spath string) (*User, error) {
+func getUser(ctx context.Context, m *core.Method, spath string) (*User, error) {
 	resp, err := m.Get(ctx, spath, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	v := User{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
 	return &v, nil
 }
 
-func getUserList(ctx context.Context, m *method, spath string, query url.Values) ([]*User, error) {
+func getUserList(ctx context.Context, m *core.Method, spath string, query url.Values) ([]*User, error) {
 	resp, err := m.Get(ctx, spath, query)
 	if err != nil {
 		return nil, err
 	}
 
 	v := []*User{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
 	return v, nil
 }
 
-func addUser(ctx context.Context, m *method, spath string, form url.Values) (*User, error) {
+func addUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*User, error) {
 	resp, err := m.Post(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
 
 	v := User{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
 	return &v, nil
 }
 
-func updateUser(ctx context.Context, m *method, spath string, form url.Values) (*User, error) {
+func updateUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*User, error) {
 	resp, err := m.Patch(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
 
 	v := User{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
 	return &v, nil
 }
 
-func deleteUser(ctx context.Context, m *method, spath string, form url.Values) (*User, error) {
+func deleteUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*User, error) {
 	resp, err := m.Delete(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
 
 	v := User{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -93,7 +95,7 @@ func deleteUser(ctx context.Context, m *method, spath string, form url.Values) (
 
 // UserService has methods for user
 type UserService struct {
-	method *method
+	method *core.Method
 
 	Activity *UserActivityService
 	Option   *UserOptionService
@@ -190,7 +192,7 @@ func (s *UserService) Delete(ctx context.Context, id int) (*User, error) {
 
 // ProjectUserService has methods for user of project.
 type ProjectUserService struct {
-	method *method
+	method *core.Method
 }
 
 // All returns all users in the project.

--- a/version.go
+++ b/version.go
@@ -1,8 +1,10 @@
 package backlog
 
+import "github.com/nattokin/go-backlog/internal/core"
+
 // VersionService handles communication with the version-related methods of the Backlog API.
 //
 //nolint:unused // API not implemented yet
 type VersionService struct {
-	method *method
+	method *core.Method
 }

--- a/wiki.go
+++ b/wiki.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/core"
 )
 
 func validateWikiID(wikiID int) error {
@@ -16,7 +18,7 @@ func validateWikiID(wikiID int) error {
 
 // WikiService handles communication with the wiki-related methods of the Backlog API.
 type WikiService struct {
-	method *method
+	method *core.Method
 
 	Attachment *WikiAttachmentService
 	Option     *WikiOptionService
@@ -48,7 +50,7 @@ func (s *WikiService) All(ctx context.Context, projectIDOrKey string, opts ...Re
 	}
 
 	v := []*Wiki{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +74,7 @@ func (s *WikiService) Count(ctx context.Context, projectIDOrKey string) (int, er
 	}
 
 	v := map[string]int{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return 0, err
 	}
 
@@ -94,7 +96,7 @@ func (s *WikiService) One(ctx context.Context, wikiID int) (*Wiki, error) {
 	}
 
 	v := Wiki{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -130,7 +132,7 @@ func (s *WikiService) Create(ctx context.Context, projectID int, name, content s
 	}
 
 	v := Wiki{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -170,7 +172,7 @@ func (s *WikiService) Update(ctx context.Context, wikiID int, option RequestOpti
 	}
 
 	v := Wiki{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 
@@ -202,7 +204,7 @@ func (s *WikiService) Delete(ctx context.Context, wikiID int, opts ...RequestOpt
 	}
 
 	v := Wiki{}
-	if err := decodeResponse(resp, &v); err != nil {
+	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
 

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -1,6 +1,10 @@
 package backlog
 
-import "io"
+import (
+	"io"
+
+	"github.com/nattokin/go-backlog/internal/core"
+)
 
 type mockWrapper struct {
 	createErr error
@@ -8,7 +12,7 @@ type mockWrapper struct {
 	closeErr  error
 }
 
-func (w mockWrapper) NewMultipartWriter(_ io.Writer) multipartWriter {
+func (w mockWrapper) NewMultipartWriter(_ io.Writer) core.MultipartWriter {
 	return &mockMultipartWriter{wrapper: w}
 }
 


### PR DESCRIPTION
## Summary

Move the core HTTP client logic to `internal/core` to separate infrastructure
concerns from the public API surface.

`backlog.Client` becomes a thin wrapper that holds `core *core.Client` and the
service endpoints. Each service continues to hold `*method` directly, keeping
existing tests unaffected.

## Changes

- Add `internal/core` package with `Client` struct (`baseURL`, `token`, `doer`, `wrapper`, `method`)
- Implement `Get`, `Post`, `Patch`, `Delete`, `Upload` methods on `core.Client`
- Wire `method` as a wrapper around `core.Client` methods during the migration period
- Move `Doer`, `wrapper`, `do`, `newRequest`, `checkResponse`, `decodeResponse`, `apiVersion` to `internal/core`
- Move `APIResponseError` to `internal/core`; re-export via type alias in `error.go`
- Replace `backlog.Client` fields with `core *core.Client`

## Notes

`method` is intentionally kept as a bridge. It will be removed once all service
packages are migrated to `*core.Client` in subsequent PRs.

Part of #149