### PR TITLE
fix(ci): fix -coverpkg format to comma-separated for go test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,8 +73,9 @@ jobs:
 
       - name: Test
         run: |
-          PKGS=$(go list ./... | grep -Ev '/examples/|/internal/testutil' | tr '\n' ',')
-          go test ${PKGS%,} -race -coverpkg=${PKGS%,} -coverprofile=coverage.txt -covermode=atomic
+          PKGS=$(go list ./... | grep -Ev '/examples/|/internal/testutil')
+          COVERPKGS=$(echo "$PKGS" | tr '\n' ',')
+          go test $PKGS -race -coverpkg=${COVERPKGS%,} -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload coverage to Codecov
         if: matrix.go-version == '1.24'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,8 +73,8 @@ jobs:
 
       - name: Test
         run: |
-          PKGS=$(go list ./... | grep -Ev '/examples/|/internal/testutil')
-          go test $PKGS -race -coverpkg=$PKGS -coverprofile=coverage.txt -covermode=atomic
+          PKGS=$(go list ./... | grep -Ev '/examples/|/internal/testutil' | tr '\n' ',')
+          go test ${PKGS%,} -race -coverpkg=${PKGS%,} -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload coverage to Codecov
         if: matrix.go-version == '1.24'


### PR DESCRIPTION
## Summary

`-coverpkg` flag of `go test` requires a comma-separated package list, but the previous implementation passed a space-separated list directly, causing `coverage.txt` to not be generated and the Codecov upload to fail.

## Changes

Split into two variables: `PKGS` (space-separated, for `go test` arguments) and `COVERPKGS` (comma-separated, for `-coverpkg`).

```diff
- PKGS=$(go list ./... | grep -Ev '/examples/|/internal/testutil')
- go test $PKGS -race -coverpkg=$PKGS -coverprofile=coverage.txt -covermode=atomic
+ PKGS=$(go list ./... | grep -Ev '/examples/|/internal/testutil')
+ COVERPKGS=$(echo "$PKGS" | tr '\n' ',')
+ go test $PKGS -race -coverpkg=${COVERPKGS%,} -coverprofile=coverage.txt -covermode=atomic
```
