### PR TITLE
refactor!: move user service to internal/user

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -3,7 +3,6 @@ package backlog
 import (
 	"context"
 	"path"
-	"strconv"
 
 	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/core"
@@ -34,35 +33,5 @@ func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string
 	}
 
 	spath := path.Join("projects", projectIDOrKey, "activities")
-	return activity.GetActivityList(ctx, s.method, spath, opts...)
-}
-
-type SpaceActivityService = activity.SpaceActivityService
-
-// UserActivityService handles communication with the user activities-related methods of the Backlog API.
-type UserActivityService struct {
-	method *core.Method
-
-	Option *ActivityOptionService
-}
-
-// List returns a list of user activities.
-//
-// This method supports options returned by methods in "*Client.Activity.Option",
-// such as:
-//   - WithActivityTypeIDs
-//   - WithCount
-//   - WithMaxID
-//   - WithMinID
-//   - WithOrder
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates
-func (s *UserActivityService) List(ctx context.Context, userID int, opts ...RequestOption) ([]*Activity, error) {
-	uID := UserID(userID)
-	if err := uID.validate(); err != nil {
-		return nil, err
-	}
-
-	spath := path.Join("users", strconv.Itoa(userID), "activities")
 	return activity.GetActivityList(ctx, s.method, spath, opts...)
 }

--- a/activity_test.go
+++ b/activity_test.go
@@ -101,11 +101,12 @@ func TestUserActivityService_List(t *testing.T) {
 		spath: "users/" + strconv.Itoa(id) + "/activities",
 	}
 
-	s := newUserActivityService()
-	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-		assert.Equal(t, want.spath, spath)
-		return nil, errors.New("error")
-	}
+	s := activity.NewUserActivityService(&core.Method{
+		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+			assert.Equal(t, want.spath, spath)
+			return nil, errors.New("error")
+		},
+	}, &core.OptionService{})
 
 	_, err := s.List(context.Background(), id)
 	assert.Error(t, err)
@@ -115,11 +116,12 @@ func TestUserActivityService_List_invalidID(t *testing.T) {
 	t.Parallel()
 
 	id := 0
-	s := newUserActivityService()
-	s.method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-		t.Error("s.method.Get must never be called")
-		return nil, errors.New("error")
-	}
+	s := activity.NewUserActivityService(&core.Method{
+		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+			t.Error("s.method.Get must never be called")
+			return nil, errors.New("error")
+		},
+	}, &core.OptionService{})
 
 	_, err := s.List(context.Background(), id)
 	assert.Error(t, err)
@@ -314,11 +316,13 @@ func TestActivityService_contextPropagation(t *testing.T) {
 			s.List(ctx) //nolint:errcheck
 		}},
 		{"UserActivityService.List", func(t *testing.T) {
-			s := newUserActivityService()
-			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := activity.NewUserActivityService(&core.Method{
+				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, &core.OptionService{})
+
 			s.List(ctx, 1) //nolint:errcheck
 		}},
 	}

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package backlog
 
 import (
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/user"
 )
 
 // ──────────────────────────────────────────────────────────────
@@ -24,7 +25,7 @@ type Client struct {
 	Project     *ProjectService
 	PullRequest *PullRequestService
 	Space       *SpaceService
-	User        *UserService
+	User        *user.UserService
 	Wiki        *WikiService
 }
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/user"
 )
 
 //
@@ -39,13 +40,6 @@ func newProjectOptionService() *ProjectOptionService {
 	}
 }
 
-// newUserOptionService returns a test instance of UserOptionService.
-func newUserOptionService() *UserOptionService {
-	return &UserOptionService{
-		base: newOptionService(),
-	}
-}
-
 // --- ProjectService ------------------------------------------------------------
 
 // newProjectService returns a test instance of ProjectService.
@@ -53,7 +47,7 @@ func newProjectService() *ProjectService {
 	return &ProjectService{
 		method:   newClientMethod(),
 		Activity: newProjectActivityService(),
-		User:     newProjectUserService(),
+		User:     user.NewProjectUserService(newClientMethod(), &core.OptionService{}),
 		Option:   newProjectOptionService(),
 	}
 }
@@ -61,32 +55,6 @@ func newProjectService() *ProjectService {
 // newProjectActivityService returns a test instance of ProjectActivityService.
 func newProjectActivityService() *ProjectActivityService {
 	return &ProjectActivityService{
-		method: newClientMethod(),
-		Option: activity.NewActivityOptionService(&core.OptionService{}),
-	}
-}
-
-// newProjectUserService returns a test instance of ProjectUserService.
-func newProjectUserService() *ProjectUserService {
-	return &ProjectUserService{
-		method: newClientMethod(),
-	}
-}
-
-// --- UserService ------------------------------------------------------------
-
-// newUserService returns a test instance of UserService.
-func newUserService() *UserService {
-	return &UserService{
-		method:   newClientMethod(),
-		Activity: newUserActivityService(),
-		Option:   newUserOptionService(),
-	}
-}
-
-// newUserActivityService returns a test instance of UserActivityService.
-func newUserActivityService() *UserActivityService {
-	return &UserActivityService{
 		method: newClientMethod(),
 		Option: activity.NewActivityOptionService(&core.OptionService{}),
 	}

--- a/internal/activity/service.go
+++ b/internal/activity/service.go
@@ -3,9 +3,12 @@ package activity
 import (
 	"context"
 	"net/url"
+	"path"
+	"strconv"
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/validate"
 )
 
 func GetActivityList(ctx context.Context, m *core.Method, spath string, opts ...core.RequestOption) ([]*model.Activity, error) {
@@ -50,12 +53,46 @@ func (s *SpaceActivityService) List(ctx context.Context, opts ...core.RequestOpt
 	return GetActivityList(ctx, s.method, "space/activities", opts...)
 }
 
+// UserActivityService handles communication with the user activities-related methods of the Backlog API.
+type UserActivityService struct {
+	method *core.Method
+
+	Option *ActivityOptionService
+}
+
+// List returns a list of user activities.
+//
+// This method supports options returned by methods in "*Client.Activity.Option",
+// such as:
+//   - WithActivityTypeIDs
+//   - WithCount
+//   - WithMaxID
+//   - WithMinID
+//   - WithOrder
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates
+func (s *UserActivityService) List(ctx context.Context, userID int, opts ...core.RequestOption) ([]*model.Activity, error) {
+	if err := validate.ValidateUserID(userID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("users", strconv.Itoa(userID), "activities")
+	return GetActivityList(ctx, s.method, spath, opts...)
+}
+
 // ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
 func NewSpaceActivityService(method *core.Method, option *core.OptionService) *SpaceActivityService {
 	return &SpaceActivityService{
+		method: method,
+		Option: &ActivityOptionService{},
+	}
+}
+
+func NewUserActivityService(method *core.Method, option *core.OptionService) *UserActivityService {
+	return &UserActivityService{
 		method: method,
 		Option: &ActivityOptionService{},
 	}

--- a/internal/user/option.go
+++ b/internal/user/option.go
@@ -1,0 +1,53 @@
+package user
+
+import (
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+)
+
+//
+// ──────────────────────────────────────────────────────────────
+//  UserOptionService
+// ──────────────────────────────────────────────────────────────
+//
+
+// UserOptionService provides a domain-specific set of option builders
+// for operations within the UserService.
+type UserOptionService struct {
+	base *core.OptionService
+}
+
+func (s *UserOptionService) WithMailAddress(mail string) core.RequestOption {
+	return s.base.WithMailAddress(mail)
+}
+
+func (s *UserOptionService) WithName(name string) core.RequestOption {
+	return s.base.WithName(name)
+}
+
+func (s *UserOptionService) WithPassword(password string) core.RequestOption {
+	return s.base.WithPassword(password)
+}
+
+func (s *UserOptionService) WithRoleType(role model.Role) core.RequestOption {
+	return s.base.WithRoleType(role)
+}
+
+func (s *UserOptionService) WithSendMail(enabled bool) core.RequestOption {
+	return s.base.WithSendMail(enabled)
+}
+
+func (s *UserOptionService) WithUserID(id int) core.RequestOption {
+	return s.base.WithUserID(id)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
+// NewUserService returns a new UserService.
+func NewUserOptionService(option *core.OptionService) *UserOptionService {
+	return &UserOptionService{
+		base: option,
+	}
+}

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -1,4 +1,4 @@
-package backlog
+package user
 
 import (
 	"context"
@@ -6,31 +6,19 @@ import (
 	"path"
 	"strconv"
 
+	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// UserID is the unique identifier for a user.
-type UserID int
-
-func (id UserID) validate() error {
-	if id < 1 {
-		return core.NewValidationError("userID must not be less than 1")
-	}
-	return nil
-}
-
-func (id UserID) String() string {
-	return strconv.Itoa(int(id))
-}
-
-func getUser(ctx context.Context, m *core.Method, spath string) (*User, error) {
+func getUser(ctx context.Context, m *core.Method, spath string) (*model.User, error) {
 	resp, err := m.Get(ctx, spath, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	v := User{}
+	v := model.User{}
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
@@ -38,13 +26,13 @@ func getUser(ctx context.Context, m *core.Method, spath string) (*User, error) {
 	return &v, nil
 }
 
-func getUserList(ctx context.Context, m *core.Method, spath string, query url.Values) ([]*User, error) {
+func getUserList(ctx context.Context, m *core.Method, spath string, query url.Values) ([]*model.User, error) {
 	resp, err := m.Get(ctx, spath, query)
 	if err != nil {
 		return nil, err
 	}
 
-	v := []*User{}
+	v := []*model.User{}
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
@@ -52,13 +40,13 @@ func getUserList(ctx context.Context, m *core.Method, spath string, query url.Va
 	return v, nil
 }
 
-func addUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*User, error) {
+func addUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*model.User, error) {
 	resp, err := m.Post(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
 
-	v := User{}
+	v := model.User{}
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
@@ -66,13 +54,13 @@ func addUser(ctx context.Context, m *core.Method, spath string, form url.Values)
 	return &v, nil
 }
 
-func updateUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*User, error) {
+func updateUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*model.User, error) {
 	resp, err := m.Patch(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
 
-	v := User{}
+	v := model.User{}
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
@@ -80,13 +68,13 @@ func updateUser(ctx context.Context, m *core.Method, spath string, form url.Valu
 	return &v, nil
 }
 
-func deleteUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*User, error) {
+func deleteUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*model.User, error) {
 	resp, err := m.Delete(ctx, spath, form)
 	if err != nil {
 		return nil, err
 	}
 
-	v := User{}
+	v := model.User{}
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
@@ -98,48 +86,47 @@ func deleteUser(ctx context.Context, m *core.Method, spath string, form url.Valu
 type UserService struct {
 	method *core.Method
 
-	Activity *UserActivityService
+	Activity *activity.UserActivityService
 	Option   *UserOptionService
 }
 
 // All returns all users in your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-list
-func (s *UserService) All(ctx context.Context) ([]*User, error) {
+func (s *UserService) All(ctx context.Context) ([]*model.User, error) {
 	return getUserList(ctx, s.method, "users", nil)
 }
 
 // One returns a user in your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user
-func (s *UserService) One(ctx context.Context, id int) (*User, error) {
-	uID := UserID(id)
-	if err := uID.validate(); err != nil {
+func (s *UserService) One(ctx context.Context, id int) (*model.User, error) {
+	if err := validate.ValidateUserID(id); err != nil {
 		return nil, err
 	}
 
-	spath := path.Join("users", uID.String())
+	spath := path.Join("users", strconv.Itoa(id))
 	return getUser(ctx, s.method, spath)
 }
 
 // Own returns your own user.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-own-user
-func (s *UserService) Own(ctx context.Context) (*User, error) {
+func (s *UserService) Own(ctx context.Context) (*model.User, error) {
 	return getUser(ctx, s.method, "users/myself")
 }
 
 // Add adds a user to your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-user
-func (s *UserService) Add(ctx context.Context, userID, password, name, mailAddress string, roleType Role) (*User, error) {
+func (s *UserService) Add(ctx context.Context, userID, password, name, mailAddress string, roleType model.Role) (*model.User, error) {
 	if userID == "" {
 		return nil, core.NewValidationError("userID must not be empty")
 	}
 
 	form := url.Values{}
-	validTypes := []apiParamOptionType{core.ParamPassword, core.ParamName, core.ParamMailAddress, core.ParamRoleType}
-	options := []RequestOption{
+	validTypes := []core.APIParamOptionType{core.ParamPassword, core.ParamName, core.ParamMailAddress, core.ParamRoleType}
+	options := []core.RequestOption{
 		s.Option.base.WithPassword(password),
 		s.Option.base.WithName(name),
 		s.Option.base.WithMailAddress(mailAddress),
@@ -161,15 +148,15 @@ func (s *UserService) Add(ctx context.Context, userID, password, name, mailAddre
 //   - WithMailAddress
 //   - WithName
 //   - WithPassword
-//   - WithRoleType
+//   - Withmodel.RoleType
 //   - WithUserID
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-user
-func (s *UserService) Update(ctx context.Context, id int, opts ...RequestOption) (*User, error) {
+func (s *UserService) Update(ctx context.Context, id int, opts ...core.RequestOption) (*model.User, error) {
 
 	form := url.Values{}
-	validTypes := []apiParamOptionType{core.ParamUserID, core.ParamName, core.ParamPassword, core.ParamMailAddress, core.ParamRoleType}
-	options := append([]RequestOption{s.Option.base.WithUserID(id)}, opts...)
+	validTypes := []core.APIParamOptionType{core.ParamUserID, core.ParamName, core.ParamPassword, core.ParamMailAddress, core.ParamRoleType}
+	options := append([]core.RequestOption{s.Option.base.WithUserID(id)}, opts...)
 	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
 		return nil, err
 	}
@@ -181,13 +168,12 @@ func (s *UserService) Update(ctx context.Context, id int, opts ...RequestOption)
 // Delete deletes a user from your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-user
-func (s *UserService) Delete(ctx context.Context, id int) (*User, error) {
-	uID := UserID(id)
-	if err := uID.validate(); err != nil {
+func (s *UserService) Delete(ctx context.Context, id int) (*model.User, error) {
+	if err := validate.ValidateUserID(id); err != nil {
 		return nil, err
 	}
 
-	spath := path.Join("users", uID.String())
+	spath := path.Join("users", strconv.Itoa(id))
 	return deleteUser(ctx, s.method, spath, nil)
 }
 
@@ -199,7 +185,7 @@ type ProjectUserService struct {
 // All returns all users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-user-list
-func (s *ProjectUserService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*User, error) {
+func (s *ProjectUserService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -214,18 +200,17 @@ func (s *ProjectUserService) All(ctx context.Context, projectIDOrKey string, exc
 // Add adds a user to the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project-user
-func (s *ProjectUserService) Add(ctx context.Context, projectIDOrKey string, userID int) (*User, error) {
+func (s *ProjectUserService) Add(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
-	uID := UserID(userID)
-	if err := uID.validate(); err != nil {
+	if err := validate.ValidateUserID(userID); err != nil {
 		return nil, err
 	}
 
 	form := url.Values{}
-	form.Set("userId", uID.String())
+	form.Set("userId", strconv.Itoa(userID))
 
 	spath := path.Join("projects", projectIDOrKey, "users")
 	return addUser(ctx, s.method, spath, form)
@@ -234,18 +219,17 @@ func (s *ProjectUserService) Add(ctx context.Context, projectIDOrKey string, use
 // Delete deletes a user from the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-project-user
-func (s *ProjectUserService) Delete(ctx context.Context, projectIDOrKey string, userID int) (*User, error) {
+func (s *ProjectUserService) Delete(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
-	uID := UserID(userID)
-	if err := uID.validate(); err != nil {
+	if err := validate.ValidateUserID(userID); err != nil {
 		return nil, err
 	}
 
 	form := url.Values{}
-	form.Set("userId", uID.String())
+	form.Set("userId", strconv.Itoa(userID))
 
 	spath := path.Join("projects", projectIDOrKey, "users")
 	return deleteUser(ctx, s.method, spath, form)
@@ -254,18 +238,17 @@ func (s *ProjectUserService) Delete(ctx context.Context, projectIDOrKey string, 
 // AddAdmin adds a admin user to the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project-administrator
-func (s *ProjectUserService) AddAdmin(ctx context.Context, projectIDOrKey string, userID int) (*User, error) {
+func (s *ProjectUserService) AddAdmin(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
-	uID := UserID(userID)
-	if err := uID.validate(); err != nil {
+	if err := validate.ValidateUserID(userID); err != nil {
 		return nil, err
 	}
 
 	form := url.Values{}
-	form.Set("userId", uID.String())
+	form.Set("userId", strconv.Itoa(userID))
 
 	spath := path.Join("projects", projectIDOrKey, "administrators")
 	return addUser(ctx, s.method, spath, form)
@@ -274,7 +257,7 @@ func (s *ProjectUserService) AddAdmin(ctx context.Context, projectIDOrKey string
 // AdminAll returns a list of all admin users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-project-administrators
-func (s *ProjectUserService) AdminAll(ctx context.Context, projectIDOrKey string) ([]*User, error) {
+func (s *ProjectUserService) AdminAll(ctx context.Context, projectIDOrKey string) ([]*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -286,19 +269,38 @@ func (s *ProjectUserService) AdminAll(ctx context.Context, projectIDOrKey string
 // DeleteAdmin removes an admin user from the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-project-administrator
-func (s *ProjectUserService) DeleteAdmin(ctx context.Context, projectIDOrKey string, userID int) (*User, error) {
+func (s *ProjectUserService) DeleteAdmin(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
-	uID := UserID(userID)
-	if err := uID.validate(); err != nil {
+	if err := validate.ValidateUserID(userID); err != nil {
 		return nil, err
 	}
 
 	form := url.Values{}
-	form.Set("userId", uID.String())
+	form.Set("userId", strconv.Itoa(userID))
 
 	spath := path.Join("projects", projectIDOrKey, "administrators")
 	return deleteUser(ctx, s.method, spath, form)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
+// NewUserService returns a new UserService.
+func NewUserService(method *core.Method, option *core.OptionService) *UserService {
+	return &UserService{
+		method:   method,
+		Activity: activity.NewUserActivityService(method, option),
+		Option:   NewUserOptionService(option),
+	}
+}
+
+// NewProjectUserService returns a new ProjectUserService.
+func NewProjectUserService(method *core.Method, option *core.OptionService) *ProjectUserService {
+	return &ProjectUserService{
+		method: method,
+	}
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -53,6 +53,13 @@ func ValidateRepositoryIDOrName(repositoryIDOrName string) error {
 	return nil
 }
 
+func ValidateUserID(userID int) error {
+	if userID < 1 {
+		return core.NewValidationError("userID must not be less than 1")
+	}
+	return nil
+}
+
 func ValidateWikiID(wikiID int) error {
 	if wikiID < 1 {
 		return core.NewValidationError("wikiID must not be less than 1")

--- a/option_service.go
+++ b/option_service.go
@@ -3,6 +3,7 @@ package backlog
 import (
 	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/user"
 	"github.com/nattokin/go-backlog/internal/wiki"
 )
 
@@ -64,35 +65,7 @@ func (s *ProjectOptionService) WithTextFormattingRule(format Format) RequestOpti
 // ──────────────────────────────────────────────────────────────
 //
 
-// UserOptionService provides a domain-specific set of option builders
-// for operations within the UserService.
-type UserOptionService struct {
-	base *core.OptionService
-}
-
-func (s *UserOptionService) WithMailAddress(mail string) RequestOption {
-	return s.base.WithMailAddress(mail)
-}
-
-func (s *UserOptionService) WithName(name string) RequestOption {
-	return s.base.WithName(name)
-}
-
-func (s *UserOptionService) WithPassword(password string) RequestOption {
-	return s.base.WithPassword(password)
-}
-
-func (s *UserOptionService) WithRoleType(role Role) RequestOption {
-	return s.base.WithRoleType(role)
-}
-
-func (s *UserOptionService) WithSendMail(enabled bool) RequestOption {
-	return s.base.WithSendMail(enabled)
-}
-
-func (s *UserOptionService) WithUserID(id int) RequestOption {
-	return s.base.WithUserID(id)
-}
+type UserOptionService = user.UserOptionService
 
 //
 // ──────────────────────────────────────────────────────────────
@@ -100,6 +73,4 @@ func (s *UserOptionService) WithUserID(id int) RequestOption {
 // ──────────────────────────────────────────────────────────────
 //
 
-// WikiOptionService provides a domain-specific set of option builders
-// for operations within the WikiService.
 type WikiOptionService = wiki.WikiOptionService

--- a/option_service_test.go
+++ b/option_service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/user"
 	"github.com/nattokin/go-backlog/internal/wiki"
 )
 
@@ -225,7 +226,7 @@ func TestProjectOptionService(t *testing.T) {
 }
 
 func TestUserOptionService(t *testing.T) {
-	o := newUserOptionService()
+	o := user.NewUserOptionService(&core.OptionService{})
 
 	// --- Boolean options ------------------------------------------------------------
 	t.Run("boolean-options", func(t *testing.T) {

--- a/project.go
+++ b/project.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/user"
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
@@ -14,7 +15,7 @@ type ProjectService struct {
 	method *core.Method
 
 	Activity *ProjectActivityService
-	User     *ProjectUserService
+	User     *user.ProjectUserService
 	Option   *ProjectOptionService
 }
 

--- a/service.go
+++ b/service.go
@@ -1,10 +1,12 @@
 package backlog
 
 import (
+	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/issue"
 	"github.com/nattokin/go-backlog/internal/pullrequest"
 	"github.com/nattokin/go-backlog/internal/space"
+	"github.com/nattokin/go-backlog/internal/user"
 	"github.com/nattokin/go-backlog/internal/wiki"
 )
 
@@ -16,9 +18,15 @@ type PullRequestAttachmentService = attachment.PullRequestAttachmentService
 
 type PullRequestService = pullrequest.PullRequestService
 
+type SpaceActivityService = activity.SpaceActivityService
+
 type SpaceAttachmentService = attachment.SpaceAttachmentService
 
 type SpaceService = space.SpaceService
+
+type UserActivityService = activity.UserActivityService
+
+type UserService = user.UserService
 
 type WikiAttachmentService = attachment.WikiAttachmentService
 

--- a/service_init.go
+++ b/service_init.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/issue"
 	"github.com/nattokin/go-backlog/internal/pullrequest"
 	"github.com/nattokin/go-backlog/internal/space"
+	"github.com/nattokin/go-backlog/internal/user"
 	"github.com/nattokin/go-backlog/internal/wiki"
 )
 
@@ -29,9 +30,7 @@ func initServices(c *Client) {
 			method: c.core.Method,
 			Option: activityOptionService,
 		},
-		User: &ProjectUserService{
-			method: c.core.Method,
-		},
+		User: user.NewProjectUserService(c.core.Method, baseOptionService),
 		Option: &ProjectOptionService{
 			base: baseOptionService,
 		},
@@ -44,16 +43,7 @@ func initServices(c *Client) {
 	c.Space = space.NewSpaceService(c.core.Method, baseOptionService)
 
 	// --- Initialize UserService --------------------------------------------------
-	c.User = &UserService{
-		method: c.core.Method,
-		Activity: &UserActivityService{
-			method: c.core.Method,
-			Option: activityOptionService,
-		},
-		Option: &UserOptionService{
-			base: baseOptionService,
-		},
-	}
+	c.User = user.NewUserService(c.core.Method, baseOptionService)
 
 	// --- Initialize WikiService --------------------------------------------------
 	c.Wiki = wiki.NewWikiService(c.core.Method, baseOptionService)

--- a/user_test.go
+++ b/user_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
+	"github.com/nattokin/go-backlog/internal/user"
 )
 
 func TestUserService_One(t *testing.T) {
@@ -69,14 +70,14 @@ func TestUserService_One(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newUserService()
-
 			// default: unexpected API call
-			s.method.Get = mock.NewUnexpectedGetFn(t)
-
-			if tc.mockGetFn != nil {
-				s.method.Get = tc.mockGetFn
+			method := &core.Method{
+				Get: mock.NewUnexpectedGetFn(t),
 			}
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+			s := user.NewUserService(method, nil)
 
 			user, err := s.One(context.Background(), tc.id)
 
@@ -230,14 +231,14 @@ func TestUserService_Add(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newUserService()
-
 			// default: unexpected API call
-			s.method.Post = mock.NewUnexpectedPostFn(t)
-
-			if tc.mockPostFn != nil {
-				s.method.Post = tc.mockPostFn
+			method := &core.Method{
+				Post: mock.NewUnexpectedPostFn(t),
 			}
+			if tc.mockPostFn != nil {
+				method.Post = tc.mockPostFn
+			}
+			s := user.NewUserService(method, nil)
 
 			user, err := s.Add(context.Background(), tc.userID, tc.password, tc.name, tc.mailAddress, tc.roleType)
 
@@ -314,14 +315,14 @@ func TestUserService_All(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newUserService()
-
 			// default: unexpected API call
-			s.method.Get = mock.NewUnexpectedGetFn(t)
-
-			if tc.mockGetFn != nil {
-				s.method.Get = tc.mockGetFn
+			method := &core.Method{
+				Get: mock.NewUnexpectedGetFn(t),
 			}
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+			s := user.NewUserService(method, nil)
 
 			users, err := s.All(context.Background())
 
@@ -345,7 +346,7 @@ func TestUserService_All(t *testing.T) {
 }
 
 func TestUserService_Update(t *testing.T) {
-	o := newUserOptionService()
+	o := user.NewUserOptionService(&core.OptionService{})
 
 	cases := map[string]struct {
 		id   int
@@ -505,14 +506,14 @@ func TestUserService_Update(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newUserService()
-
 			// default: unexpected API call
-			s.method.Patch = mock.NewUnexpectedPatchFn(t)
-
-			if tc.mockPatchFn != nil {
-				s.method.Patch = tc.mockPatchFn
+			method := &core.Method{
+				Patch: mock.NewUnexpectedPatchFn(t),
 			}
+			if tc.mockPatchFn != nil {
+				method.Patch = tc.mockPatchFn
+			}
+			s := user.NewUserService(method, nil)
 
 			user, err := s.Update(context.Background(), tc.id, tc.opts...)
 
@@ -585,14 +586,14 @@ func TestUserService_Own(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newUserService()
-
 			// default: unexpected API call
-			s.method.Get = mock.NewUnexpectedGetFn(t)
-
-			if tc.mockGetFn != nil {
-				s.method.Get = tc.mockGetFn
+			method := &core.Method{
+				Get: mock.NewUnexpectedPatchFn(t),
 			}
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+			s := user.NewUserService(method, nil)
 
 			user, err := s.Own(context.Background())
 
@@ -674,14 +675,14 @@ func TestUserService_Delete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newUserService()
-
 			// default: unexpected API call
-			s.method.Delete = mock.NewUnexpectedDeleteFn(t)
-
-			if tc.mockDeleteFn != nil {
-				s.method.Delete = tc.mockDeleteFn
+			method := &core.Method{
+				Delete: mock.NewUnexpectedPatchFn(t),
 			}
+			if tc.mockDeleteFn != nil {
+				method.Delete = tc.mockDeleteFn
+			}
+			s := user.NewUserService(method, nil)
 
 			user, err := s.Delete(context.Background(), tc.id)
 
@@ -799,14 +800,14 @@ func TestProjectUserService_All(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newProjectUserService()
-
 			// default: unexpected API call
-			s.method.Get = mock.NewUnexpectedGetFn(t)
-
-			if tc.mockGetFn != nil {
-				s.method.Get = tc.mockGetFn
+			method := &core.Method{
+				Get: mock.NewUnexpectedGetFn(t),
 			}
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+			s := user.NewProjectUserService(method, nil)
 
 			users, err := s.All(context.Background(), tc.projectKey, tc.excludeGroupMembers)
 
@@ -910,14 +911,14 @@ func TestProjectUserService_Add(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newProjectUserService()
-
 			// default: unexpected API call
-			s.method.Post = mock.NewUnexpectedPostFn(t)
-
-			if tc.mockPostFn != nil {
-				s.method.Post = tc.mockPostFn
+			method := &core.Method{
+				Post: mock.NewUnexpectedPostFn(t),
 			}
+			if tc.mockPostFn != nil {
+				method.Post = tc.mockPostFn
+			}
+			s := user.NewProjectUserService(method, nil)
 
 			user, err := s.Add(context.Background(), tc.projectKey, tc.userID)
 
@@ -1041,14 +1042,14 @@ func TestProjectUserService_Delete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newProjectUserService()
-
 			// default: unexpected API call
-			s.method.Delete = mock.NewUnexpectedDeleteFn(t)
-
-			if tc.mockDeleteFn != nil {
-				s.method.Delete = tc.mockDeleteFn
+			method := &core.Method{
+				Delete: mock.NewUnexpectedDeleteFn(t),
 			}
+			if tc.mockDeleteFn != nil {
+				method.Delete = tc.mockDeleteFn
+			}
+			s := user.NewProjectUserService(method, nil)
 
 			user, err := s.Delete(context.Background(), tc.projectKey, tc.userID)
 
@@ -1151,14 +1152,14 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newProjectUserService()
-
 			// default: unexpected API call
-			s.method.Post = mock.NewUnexpectedPostFn(t)
-
-			if tc.mockPostFn != nil {
-				s.method.Post = tc.mockPostFn
+			method := &core.Method{
+				Post: mock.NewUnexpectedPostFn(t),
 			}
+			if tc.mockPostFn != nil {
+				method.Post = tc.mockPostFn
+			}
+			s := user.NewProjectUserService(method, nil)
 
 			user, err := s.AddAdmin(context.Background(), tc.projectKey, tc.userID)
 
@@ -1209,14 +1210,14 @@ func TestProjectUserService_AdminAll(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newProjectUserService()
-
 			// default: unexpected API call
-			s.method.Get = mock.NewUnexpectedGetFn(t)
-
-			if tc.mockGetFn != nil {
-				s.method.Get = tc.mockGetFn
+			method := &core.Method{
+				Get: mock.NewUnexpectedGetFn(t),
 			}
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+			s := user.NewProjectUserService(method, nil)
 
 			users, err := s.AdminAll(context.Background(), tc.projectKey)
 
@@ -1278,14 +1279,14 @@ func TestProjectUserService_DeleteAdmin(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := newProjectUserService()
-
 			// default: unexpected API call
-			s.method.Delete = mock.NewUnexpectedDeleteFn(t)
-
-			if tc.mockDeleteFn != nil {
-				s.method.Delete = tc.mockDeleteFn
+			method := &core.Method{
+				Delete: mock.NewUnexpectedDeleteFn(t),
 			}
+			if tc.mockDeleteFn != nil {
+				method.Delete = tc.mockDeleteFn
+			}
+			s := user.NewProjectUserService(method, nil)
 
 			user, err := s.DeleteAdmin(context.Background(), tc.projectKey, tc.userID)
 
@@ -1306,106 +1307,118 @@ func TestUserService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
-	o := newUserOptionService()
+	o := user.NewUserOptionService(&core.OptionService{})
 
 	cases := []struct {
 		name string
 		call func(t *testing.T)
 	}{
 		{"UserService.All", func(t *testing.T) {
-			s := newUserService()
-			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewUserService(&core.Method{
+				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.All(ctx) //nolint:errcheck
 		}},
 		{"UserService.One", func(t *testing.T) {
-			s := newUserService()
-			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewUserService(&core.Method{
+				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.One(ctx, 1) //nolint:errcheck
 		}},
 		{"UserService.Own", func(t *testing.T) {
-			s := newUserService()
-			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewUserService(&core.Method{
+				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.Own(ctx) //nolint:errcheck
 		}},
 		{"UserService.Add", func(t *testing.T) {
-			s := newUserService()
-			s.method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewUserService(&core.Method{
+				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.Add(ctx, "u", "p", "n", "m@m.com", RoleAdministrator) //nolint:errcheck
 		}},
 		{"UserService.Update", func(t *testing.T) {
-			s := newUserService()
-			s.method.Patch = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewUserService(&core.Method{
+				Patch: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
 		}},
 		{"UserService.Delete", func(t *testing.T) {
-			s := newUserService()
-			s.method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewUserService(&core.Method{
+				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.Delete(ctx, 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.All", func(t *testing.T) {
-			s := newProjectUserService()
-			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewProjectUserService(&core.Method{
+				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.All(ctx, "TEST", false) //nolint:errcheck
 		}},
 		{"ProjectUserService.Add", func(t *testing.T) {
-			s := newProjectUserService()
-			s.method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewProjectUserService(&core.Method{
+				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.Add(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.Delete", func(t *testing.T) {
-			s := newProjectUserService()
-			s.method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewProjectUserService(&core.Method{
+				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.Delete(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.AddAdmin", func(t *testing.T) {
-			s := newProjectUserService()
-			s.method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewProjectUserService(&core.Method{
+				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.AddAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.AdminAll", func(t *testing.T) {
-			s := newProjectUserService()
-			s.method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewProjectUserService(&core.Method{
+				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.AdminAll(ctx, "TEST") //nolint:errcheck
 		}},
 		{"ProjectUserService.DeleteAdmin", func(t *testing.T) {
-			s := newProjectUserService()
-			s.method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			s := user.NewProjectUserService(&core.Method{
+				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+					assert.Same(t, sentinel, got.Value(ctxKey{}))
+					return nil, errors.New("stop")
+				},
+			}, nil)
 			s.DeleteAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},
 	}


### PR DESCRIPTION
## Summary

Extract user-related internal logic into the `internal/user` package as part of the internalization refactor (#149).

The following service types and their associated option types are moved or added to internal packages:

- `UserService` → `internal/user`
- `UserOptionService` → `internal/user`
- `UserActivityService` → `internal/activity`

## Changes

- `internal/user/service.go` — user service implementation
- `internal/user/option.go` — user option types
- `internal/activity/service.go` — added `UserActivityService`

## ⚠️ Breaking Change

The exported type `UserID` has been removed. Any code referencing `backlog.UserID` will no longer compile. Use `int` directly instead.

Part of #149