### PR TITLE
refactor: use internal package types directly in Client struct fields

### DIFF
--- a/activity_test.go
+++ b/activity_test.go
@@ -140,12 +140,12 @@ func TestBaseActivityService_GetList(t *testing.T) {
 		order          string
 	}
 	cases := map[string]struct {
-		opts      []RequestOption
+		opts      []core.RequestOption
 		wantError bool
 		want      want
 	}{
 		"success-no-option": {
-			opts:      []RequestOption{},
+			opts:      []core.RequestOption{},
 			wantError: false,
 			want: want{
 				activityTypeID: nil,
@@ -156,7 +156,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 			},
 		},
 		"success-withActivityTypeIDs": {
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithActivityTypeIDs([]int{1}),
 			},
 			wantError: false,
@@ -169,7 +169,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 			},
 		},
 		"success-withMinID": {
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithMinID(1),
 			},
 			wantError: false,
@@ -182,7 +182,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 			},
 		},
 		"success-withMaxID": {
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithMaxID(1),
 			},
 			wantError: false,
@@ -195,7 +195,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 			},
 		},
 		"success-withCount": {
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithCount(1),
 			},
 			wantError: false,
@@ -208,7 +208,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 			},
 		},
 		"success-withOrder": {
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithOrder(OrderAsc),
 			},
 			wantError: false,
@@ -221,7 +221,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 			},
 		},
 		"success-multiple-options": {
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithActivityTypeIDs([]int{1, 2}),
 				o.WithMinID(1),
 				o.WithMaxID(26),
@@ -238,19 +238,19 @@ func TestBaseActivityService_GetList(t *testing.T) {
 			},
 		},
 		"error-option-invalid-value": {
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithCount(0),
 			},
 			wantError: true,
 			want:      want{},
 		},
 		"error-option-invalid-type": {
-			opts:      []RequestOption{mock.NewInvalidTypeOption()},
+			opts:      []core.RequestOption{mock.NewInvalidTypeOption()},
 			wantError: true,
 			want:      want{},
 		},
 		"error-option-set-failed": {
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				mock.NewFailingSetOption(core.ParamCount),
 			},
 			wantError: true,

--- a/client.go
+++ b/client.go
@@ -26,12 +26,12 @@ type Client struct {
 	core *core.Client
 
 	// Service endpoints
-	Issue       *IssueService
+	Issue       *issue.IssueService
 	Project     *project.ProjectService
-	PullRequest *PullRequestService
-	Space       *SpaceService
+	PullRequest *pullrequest.PullRequestService
+	Space       *space.SpaceService
 	User        *user.UserService
-	Wiki        *WikiService
+	Wiki        *wiki.WikiService
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -85,8 +85,7 @@ func initServices(c *Client) {
 
 type ClientOption = core.ClientOption
 
-// WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.
-// This is useful for providing a custom *http.Client or a mock implementation during testing.
+// WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.\n// This is useful for providing a custom *http.Client or a mock implementation during testing.
 //
 // If this option is not provided, http.DefaultClient is used by default.
 func WithDoer(doer Doer) *ClientOption {

--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ type Client struct {
 // This function supports options returned by package-level functions,
 // such as:
 //   - WithDoer
-func NewClient(baseURL, token string, opts ...*ClientOption) (*Client, error) {
+func NewClient(baseURL, token string, opts ...*core.ClientOption) (*Client, error) {
 	core, err := core.NewClient(baseURL, token, opts...)
 	if err != nil {
 		return nil, err
@@ -88,6 +88,6 @@ type ClientOption = core.ClientOption
 // WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.\n// This is useful for providing a custom *http.Client or a mock implementation during testing.
 //
 // If this option is not provided, http.DefaultClient is used by default.
-func WithDoer(doer Doer) *ClientOption {
+func WithDoer(doer Doer) *core.ClientOption {
 	return core.WithDoer(doer)
 }

--- a/error_test.go
+++ b/error_test.go
@@ -109,7 +109,7 @@ func TestValidationError_errorsAs(t *testing.T) {
 // TestInvalidOptionKeyError_errorsAs_query verifies that InvalidOptionKeyError
 // can be unwrapped with errors.As by callers.
 func TestInvalidOptionKeyError_errorsAs_query(t *testing.T) {
-	err := core.NewInvalidOptionKeyError(core.ParamActivityTypeIDs.Value(), []apiParamOptionType{core.ParamAll, core.ParamArchived})
+	err := core.NewInvalidOptionKeyError(core.ParamActivityTypeIDs.Value(), []core.APIParamOptionType{core.ParamAll, core.ParamArchived})
 	wrapped := fmt.Errorf("wrap: %w", err)
 
 	var target *InvalidOptionKeyError
@@ -120,7 +120,7 @@ func TestInvalidOptionKeyError_errorsAs_query(t *testing.T) {
 // TestInvalidOptionKeyError_errorsAs_form verifies that InvalidOptionKeyError
 // can be unwrapped with errors.As by callers.
 func TestInvalidOptionKeyError_errorsAs_form(t *testing.T) {
-	err := core.NewInvalidOptionKeyError(core.ParamKey.Value(), []apiParamOptionType{core.ParamName, core.ParamChartEnabled})
+	err := core.NewInvalidOptionKeyError(core.ParamKey.Value(), []core.APIParamOptionType{core.ParamName, core.ParamChartEnabled})
 	wrapped := fmt.Errorf("wrap: %w", err)
 
 	var target *InvalidOptionKeyError

--- a/internal/space/service.go
+++ b/internal/space/service.go
@@ -22,7 +22,7 @@ type SpaceService struct {
 func NewSpaceService(method *core.Method, option *core.OptionService) *SpaceService {
 	return &SpaceService{
 		method:     method,
-		Activity:   activity.NewSpaceActivityService(method, &core.OptionService{}),
+		Activity:   activity.NewSpaceActivityService(method, option),
 		Attachment: attachment.NewSpaceAttachmentService(method),
 	}
 }

--- a/option.go
+++ b/option.go
@@ -8,11 +8,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/wiki"
 )
 
-type apiParamOptionType = core.APIParamOptionType
-
 type RequestOption = core.RequestOption
-
-type apiParamOption = core.APIParamOption
 
 type ActivityOptionService = activity.ActivityOptionService
 

--- a/option_base_test.go
+++ b/option_base_test.go
@@ -23,7 +23,7 @@ func TestOptionService(t *testing.T) {
 	// --- Boolean options -----------------------------------------------------------
 	t.Run("boolean-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue bool
 		}{
@@ -115,7 +115,7 @@ func TestOptionService(t *testing.T) {
 	// --- Integer options -----------------------------------------------------------
 	t.Run("integer-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue int
 			wantErr   bool
@@ -197,7 +197,7 @@ func TestOptionService(t *testing.T) {
 	// --- String options ------------------------------------------------------------
 	t.Run("string-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue string
 			wantErr   bool
@@ -294,7 +294,7 @@ func TestOptionService(t *testing.T) {
 	// --- Enum or special options ---------------------------------------------------
 	t.Run("enum-or-special-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue string
 			wantErr   bool

--- a/option_service_test.go
+++ b/option_service_test.go
@@ -21,7 +21,7 @@ func TestActivityOptionService(t *testing.T) {
 	// --- Integer options ------------------------------------------------------------
 	t.Run("integer-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue int
 		}{
@@ -57,7 +57,7 @@ func TestActivityOptionService(t *testing.T) {
 	// --- Enum options ---------------------------------------------------------------
 	t.Run("enum-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue string
 		}{
@@ -88,7 +88,7 @@ func TestActivityOptionService(t *testing.T) {
 	// --- Special options -------------------------------------------------------------
 	t.Run("special-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue []int
 		}{
@@ -125,7 +125,7 @@ func TestProjectOptionService(t *testing.T) {
 	// --- Form boolean options -------------------------------------------------------
 	t.Run("form-boolean-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue bool
 		}{
@@ -161,7 +161,7 @@ func TestProjectOptionService(t *testing.T) {
 	// --- Query boolean options ------------------------------------------------------
 	t.Run("query-boolean-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue bool
 		}{
@@ -192,7 +192,7 @@ func TestProjectOptionService(t *testing.T) {
 	// --- Form string options --------------------------------------------------------
 	t.Run("form-string-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue string
 		}{
@@ -232,7 +232,7 @@ func TestUserOptionService(t *testing.T) {
 	// --- Boolean options ------------------------------------------------------------
 	t.Run("boolean-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue bool
 		}{
@@ -258,7 +258,7 @@ func TestUserOptionService(t *testing.T) {
 	// --- Integer options ------------------------------------------------------------
 	t.Run("integer-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue int
 		}{
@@ -289,7 +289,7 @@ func TestUserOptionService(t *testing.T) {
 	// --- String options -------------------------------------------------------------
 	t.Run("string-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue string
 		}{
@@ -329,7 +329,7 @@ func TestWikiOptionService(t *testing.T) {
 	// --- Query options ------------------------------------------------------------
 	t.Run("query-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue string
 		}{
@@ -355,7 +355,7 @@ func TestWikiOptionService(t *testing.T) {
 	// --- Form string options ------------------------------------------------------
 	t.Run("form-string-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue string
 		}{
@@ -386,7 +386,7 @@ func TestWikiOptionService(t *testing.T) {
 	// --- Form boolean options -----------------------------------------------------
 	t.Run("form-boolean-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    RequestOption
+			option    core.RequestOption
 			key       string
 			wantValue bool
 		}{

--- a/option_test.go
+++ b/option_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-func Test_apiParamOption(t *testing.T) {
+func TestAPIParamOption(t *testing.T) {
 	cases := map[string]struct {
 		option      core.RequestOption
 		expectPanic bool
 	}{
 		"SetFunc-nil": {
-			option: &apiParamOption{
+			option: &core.APIParamOption{
 				Type:      core.ParamKey,
 				CheckFunc: func() error { return nil },
 				SetFunc:   nil,
@@ -21,7 +21,7 @@ func Test_apiParamOption(t *testing.T) {
 			expectPanic: true,
 		},
 		"CheckFunc-nil": {
-			option: &apiParamOption{
+			option: &core.APIParamOption{
 				Type:      core.ParamKey,
 				CheckFunc: nil,
 				SetFunc:   func(_ url.Values) error { return nil },
@@ -46,7 +46,7 @@ func Test_apiParamOption(t *testing.T) {
 			}()
 
 			v := url.Values{}
-			core.ApplyOptions(v, []apiParamOptionType{core.ParamKey}, tc.option)
+			core.ApplyOptions(v, []core.APIParamOptionType{core.ParamKey}, tc.option)
 		})
 	}
 

--- a/option_test.go
+++ b/option_test.go
@@ -9,7 +9,7 @@ import (
 
 func Test_apiParamOption(t *testing.T) {
 	cases := map[string]struct {
-		option      RequestOption
+		option      core.RequestOption
 		expectPanic bool
 	}{
 		"SetFunc-nil": {

--- a/project_test.go
+++ b/project_test.go
@@ -23,7 +23,7 @@ func TestProjectService_All(t *testing.T) {
 	o := project.NewProjectOptionService(&core.OptionService{})
 
 	cases := map[string]struct {
-		opts []RequestOption
+		opts []core.RequestOption
 
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
@@ -32,7 +32,7 @@ func TestProjectService_All(t *testing.T) {
 		wantErrType error
 	}{
 		"success-without-option": {
-			opts: []RequestOption{},
+			opts: []core.RequestOption{},
 
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects", spath)
@@ -49,7 +49,7 @@ func TestProjectService_All(t *testing.T) {
 			wantErrType: nil,
 		},
 		"success-with-valid-option": {
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithAll(false),
 				o.WithArchived(true),
 			},
@@ -69,17 +69,17 @@ func TestProjectService_All(t *testing.T) {
 			wantErrType: nil,
 		},
 		"error-option-set-failed": {
-			opts: []RequestOption{mock.NewFailingSetOption(core.ParamAll)},
+			opts: []core.RequestOption{mock.NewFailingSetOption(core.ParamAll)},
 
 			wantErrType: errors.New(""),
 		},
 		"error-option-invalid-type": {
-			opts: []RequestOption{mock.NewInvalidTypeOption()},
+			opts: []core.RequestOption{mock.NewInvalidTypeOption()},
 
 			wantErrType: &InvalidOptionKeyError{},
 		},
 		"error-client-network": {
-			opts: []RequestOption{},
+			opts: []core.RequestOption{},
 
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
@@ -88,7 +88,7 @@ func TestProjectService_All(t *testing.T) {
 			wantErrType: errors.New(""),
 		},
 		"error-response-invalid-json": {
-			opts: []RequestOption{},
+			opts: []core.RequestOption{},
 
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return &http.Response{
@@ -237,7 +237,7 @@ func TestProjectService_Create(t *testing.T) {
 	cases := map[string]struct {
 		key  string
 		name string
-		opts []RequestOption
+		opts []core.RequestOption
 
 		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
@@ -265,7 +265,7 @@ func TestProjectService_Create(t *testing.T) {
 		"success-without-option": {
 			key:  "TEST",
 			name: "test",
-			opts: []RequestOption{},
+			opts: []core.RequestOption{},
 
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "", form.Get("chartEnabled"))
@@ -286,7 +286,7 @@ func TestProjectService_Create(t *testing.T) {
 			key:  "TEST",
 			name: "test",
 
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithChartEnabled(true),
 				o.WithSubtaskingEnabled(true),
 				o.WithProjectLeaderCanEditProjectLeader(true),
@@ -326,7 +326,7 @@ func TestProjectService_Create(t *testing.T) {
 			key:  "TEST",
 			name: "test",
 
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithTextFormattingRule("invalid"),
 			},
 
@@ -337,7 +337,7 @@ func TestProjectService_Create(t *testing.T) {
 			key:  "TEST",
 			name: "test",
 
-			opts: []RequestOption{mock.NewInvalidTypeOption()},
+			opts: []core.RequestOption{mock.NewInvalidTypeOption()},
 
 			wantErrType: &InvalidOptionKeyError{},
 		},
@@ -404,7 +404,7 @@ func TestProjectService_Update(t *testing.T) {
 
 	cases := map[string]struct {
 		projectIDOrKey string
-		opts           []RequestOption
+		opts           []core.RequestOption
 
 		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
@@ -456,7 +456,7 @@ func TestProjectService_Update(t *testing.T) {
 		"success-with-options": {
 			projectIDOrKey: "TEST",
 
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithKey("TEST1"),
 				o.WithName("test1"),
 				o.WithChartEnabled(true),
@@ -487,7 +487,7 @@ func TestProjectService_Update(t *testing.T) {
 		"error-option-invalid-value": {
 			projectIDOrKey: "TEST",
 
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithTextFormattingRule("invalid"),
 			},
 
@@ -497,7 +497,7 @@ func TestProjectService_Update(t *testing.T) {
 		"error-option-invalid-type": {
 			projectIDOrKey: "TEST",
 
-			opts: []RequestOption{mock.NewInvalidTypeOption()},
+			opts: []core.RequestOption{mock.NewInvalidTypeOption()},
 
 			wantErrType: &InvalidOptionKeyError{},
 		},

--- a/user_test.go
+++ b/user_test.go
@@ -350,7 +350,7 @@ func TestUserService_Update(t *testing.T) {
 
 	cases := map[string]struct {
 		id   int
-		opts []RequestOption
+		opts []core.RequestOption
 
 		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
@@ -359,7 +359,7 @@ func TestUserService_Update(t *testing.T) {
 	}{
 		"success-update-user": {
 			id: 1,
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithPassword("password"),
 				o.WithName("admin"),
 				o.WithMailAddress("eguchi@nulab.example"),
@@ -407,7 +407,7 @@ func TestUserService_Update(t *testing.T) {
 		},
 		"success-option-withName": {
 			id: 1,
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithName("testname"),
 			},
 
@@ -421,7 +421,7 @@ func TestUserService_Update(t *testing.T) {
 		},
 		"success-option-withPassword": {
 			id: 1,
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithPassword("testpassword"),
 			},
 
@@ -435,7 +435,7 @@ func TestUserService_Update(t *testing.T) {
 		},
 		"success-option-withMailAddress": {
 			id: 1,
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithMailAddress("test@test.com"),
 			},
 
@@ -449,7 +449,7 @@ func TestUserService_Update(t *testing.T) {
 		},
 		"success-option-withRoleType": {
 			id: 1,
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithRoleType(RoleAdministrator),
 			},
 
@@ -463,7 +463,7 @@ func TestUserService_Update(t *testing.T) {
 		},
 		"success-option-multiple": {
 			id: 1,
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithPassword("testpassword1"),
 				o.WithName("testname1"),
 				o.WithMailAddress("test1@test.com"),
@@ -483,7 +483,7 @@ func TestUserService_Update(t *testing.T) {
 		},
 		"error-option-invalid-value": {
 			id: 1,
-			opts: []RequestOption{
+			opts: []core.RequestOption{
 				o.WithName(""),
 			},
 
@@ -491,13 +491,13 @@ func TestUserService_Update(t *testing.T) {
 		},
 		"error-option-invalid-type": {
 			id:   1,
-			opts: []RequestOption{mock.NewInvalidTypeOption()},
+			opts: []core.RequestOption{mock.NewInvalidTypeOption()},
 
 			wantErrType: &InvalidOptionKeyError{},
 		},
 		"error-option-set-faild": {
 			id:          1,
-			opts:        []RequestOption{mock.NewFailingSetOption(core.ParamName)},
+			opts:        []core.RequestOption{mock.NewFailingSetOption(core.ParamName)},
 			wantErrType: errors.New(""),
 		},
 	}


### PR DESCRIPTION
## Summary

Internal package types were not used consistently at the public boundary. This PR fixes two categories of issues:

1. **`Client` struct fields** in `client.go` used root package type aliases (`*IssueService`, `*PullRequestService`, `*SpaceService`, `*WikiService`) instead of concrete `internal/*` types.
2. **Root package tests** referenced private aliases (`apiParamOptionType`, `apiParamOption`, `RequestOption`) that were defined as unexported shorthands in `option.go`. These have been removed in favour of directly using `core.RequestOption`, `core.APIParamOptionType`, and `core.APIParamOption` in test code.

In addition, `NewSpaceService` was passing a newly allocated `&core.OptionService{}` to `NewSpaceActivityService` instead of forwarding the `option` argument received from the caller.

## Changes

**`client.go`**
- `Client.Issue`: `*IssueService` → `*issue.IssueService`
- `Client.PullRequest`: `*PullRequestService` → `*pullrequest.PullRequestService`
- `Client.Space`: `*SpaceService` → `*space.SpaceService`
- `Client.Wiki`: `*WikiService` → `*wiki.WikiService`
- `NewClient` return type annotation: `*ClientOption` → `*core.ClientOption` (alias still exported)
- `WithDoer` return type annotation: `*ClientOption` → `*core.ClientOption`

**`option.go`**
- Remove unexported aliases `apiParamOptionType` and `apiParamOption` (were only used in tests; tests now reference `core` types directly)

**`internal/space/service.go`**
- `NewSpaceService`: pass `option` argument through to `NewSpaceActivityService` instead of `&core.OptionService{}`

**Test files** (`activity_test.go`, `error_test.go`, `option_base_test.go`, `option_service_test.go`, `option_test.go`, `project_test.go`, `user_test.go`)
- Replace `RequestOption` → `core.RequestOption`
- Replace `apiParamOptionType` → `core.APIParamOptionType`
- Replace `apiParamOption` → `core.APIParamOption`
- Rename `Test_apiParamOption` → `TestAPIParamOption` (Go test naming convention)

Closes #162