### PR TITLE
fix: correct ChangeLog, CustomFieldItem, Repository to type aliases in models.go

### DIFF
--- a/models.go
+++ b/models.go
@@ -12,13 +12,13 @@ type Attachment = model.Attachment
 
 type Category = model.Category
 
-type ChangeLog model.ChangeLog
+type ChangeLog = model.ChangeLog
 
 type Comment = model.Comment
 
 type CustomField = model.CustomField
 
-type CustomFieldItem model.CustomFieldItem
+type CustomFieldItem = model.CustomFieldItem
 
 type DiskUsageBase = model.DiskUsageBase
 
@@ -40,7 +40,7 @@ type Project = model.Project
 
 type PullRequest = model.PullRequest
 
-type Repository model.Repository
+type Repository = model.Repository
 
 type Resolution = model.Resolution
 


### PR DESCRIPTION
## Summary

Fixed three type definitions in `models.go` that were missing `=` and were unintentionally declared as new types instead of type aliases.

```go
// Before (new type definitions — unintended)
type ChangeLog model.ChangeLog
type CustomFieldItem model.CustomFieldItem
type Repository model.Repository

// After (type aliases — intended)
type ChangeLog = model.ChangeLog
type CustomFieldItem = model.CustomFieldItem
type Repository = model.Repository
```

Without `=`, `backlog.ChangeLog` and `model.ChangeLog` become distinct types, requiring explicit conversions when assigning values returned by `internal/model` functions.

Part of #149