### PR TITLE
docs: fix malformed \n literal in WithDoer comment

### DIFF
--- a/client.go
+++ b/client.go
@@ -85,7 +85,8 @@ func initServices(c *Client) {
 
 type ClientOption = core.ClientOption
 
-// WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.\n// This is useful for providing a custom *http.Client or a mock implementation during testing.
+// WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.
+// This is useful for providing a custom *http.Client or a mock implementation during testing.
 //
 // If this option is not provided, http.DefaultClient is used by default.
 func WithDoer(doer Doer) *core.ClientOption {


### PR DESCRIPTION
## Summary

Fix a malformed `\\n` literal that was accidentally embedded in the `WithDoer` function comment in `client.go`.

**Before:**
```go
// WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.\\n// This is useful for providing a custom *http.Client or a mock implementation during testing.
```

**After:**
```go
// WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.
// This is useful for providing a custom *http.Client or a mock implementation during testing.
```