### PR TITLE
refactor: wrap IssueService at root package

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package backlog
 
 import (
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/issue"
 	"github.com/nattokin/go-backlog/internal/pullrequest"
 	"github.com/nattokin/go-backlog/internal/space"
 	"github.com/nattokin/go-backlog/internal/user"
@@ -24,7 +23,7 @@ type Client struct {
 	core *core.Client
 
 	// Service endpoints
-	Issue       *issue.IssueService
+	Issue       *IssueService
 	Project     *ProjectService
 	PullRequest *pullrequest.PullRequestService
 	Space       *space.SpaceService
@@ -64,7 +63,7 @@ func NewClient(baseURL, token string, opts ...*core.ClientOption) (*Client, erro
 func initServices(c *Client) {
 	baseOptionService := &core.OptionService{}
 
-	c.Issue = issue.NewIssueService(c.core.Method, baseOptionService)
+	c.Issue = newIssueService(c.core.Method, baseOptionService)
 
 	c.Project = newProjectService(c.core.Method, baseOptionService)
 

--- a/internal/attachment/service.go
+++ b/internal/attachment/service.go
@@ -45,14 +45,10 @@ func RemoveAttachment(ctx context.Context, m *core.Method, spath string) (*model
 //  IssueAttachmentService
 // ──────────────────────────────────────────────────────────────
 
-// IssueAttachmentService handles communication with the issue attachment-related methods of the Backlog API.
 type IssueAttachmentService struct {
 	method *core.Method
 }
 
-// List returns a list of all attachments in the issue.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-issue-attachments
 func (s *IssueAttachmentService) List(ctx context.Context, issueIDOrKey string) ([]*model.Attachment, error) {
 	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
 		return nil, err
@@ -62,9 +58,6 @@ func (s *IssueAttachmentService) List(ctx context.Context, issueIDOrKey string) 
 	return ListAttachments(ctx, s.method, spath)
 }
 
-// Remove removes a file attached to the issue.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-issue-attachment
 func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string, attachmentID int) (*model.Attachment, error) {
 	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
 		return nil, err

--- a/internal/issue/service.go
+++ b/internal/issue/service.go
@@ -1,25 +1,19 @@
 package issue
 
 import (
-	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-// IssueService handles communication with the issue-related methods of the Backlog API.
 type IssueService struct {
 	method *core.Method
-
-	Attachment *attachment.IssueAttachmentService
 }
 
 // ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-// NewWikiService returns a new WikiService.
 func NewIssueService(method *core.Method, option *core.OptionService) *IssueService {
 	return &IssueService{
-		method:     method,
-		Attachment: attachment.NewIssueAttachmentService(method),
+		method: method,
 	}
 }

--- a/issue.go
+++ b/issue.go
@@ -1,0 +1,61 @@
+package backlog
+
+import (
+	"context"
+
+	"github.com/nattokin/go-backlog/internal/attachment"
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/issue"
+	"github.com/nattokin/go-backlog/internal/model"
+)
+
+// ──────────────────────────────────────────────────────────────
+//  IssueService
+// ──────────────────────────────────────────────────────────────
+
+// IssueService handles communication with the issue-related methods of the Backlog API.
+type IssueService struct {
+	base *issue.IssueService
+
+	Attachment *IssueAttachmentService
+}
+
+// ──────────────────────────────────────────────────────────────
+//  IssueAttachmentService
+// ──────────────────────────────────────────────────────────────
+
+// IssueAttachmentService handles communication with the issue attachment-related methods of the Backlog API.
+type IssueAttachmentService struct {
+	base *attachment.IssueAttachmentService
+}
+
+// List returns a list of all attachments in the issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-issue-attachments
+func (s *IssueAttachmentService) List(ctx context.Context, issueIDOrKey string) ([]*model.Attachment, error) {
+	return s.base.List(ctx, issueIDOrKey)
+}
+
+// Remove removes a file attached to the issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-issue-attachment
+func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string, attachmentID int) (*model.Attachment, error) {
+	return s.base.Remove(ctx, issueIDOrKey, attachmentID)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
+func newIssueService(method *core.Method, option *core.OptionService) *IssueService {
+	return &IssueService{
+		base:       issue.NewIssueService(method, option),
+		Attachment: newIssueAttachmentService(method),
+	}
+}
+
+func newIssueAttachmentService(method *core.Method) *IssueAttachmentService {
+	return &IssueAttachmentService{
+		base: attachment.NewIssueAttachmentService(method),
+	}
+}

--- a/issue_test.go
+++ b/issue_test.go
@@ -1,0 +1,67 @@
+package backlog_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+func TestIssueAttachmentService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"List": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues/TEST-1/attachments", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.ListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Attachment.List(ctx, "TEST-1")
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, 2, got[0].ID)
+				assert.Equal(t, 5, got[1].ID)
+			},
+		},
+		"Remove": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, "/api/v2/issues/TEST-1/attachments/8", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Attachment.Remove(ctx, "TEST-1", 8)
+				require.NoError(t, err)
+				assert.Equal(t, 8, got.ID)
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}

--- a/service.go
+++ b/service.go
@@ -4,7 +4,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/issue"
 	"github.com/nattokin/go-backlog/internal/pullrequest"
 	"github.com/nattokin/go-backlog/internal/space"
 	"github.com/nattokin/go-backlog/internal/user"
@@ -13,10 +12,6 @@ import (
 // ──────────────────────────────────────────────────────────────
 //  Implemented services (aliases to internal packages)
 // ──────────────────────────────────────────────────────────────
-
-type IssueAttachmentService = attachment.IssueAttachmentService
-
-type IssueService = issue.IssueService
 
 type PullRequestAttachmentService = attachment.PullRequestAttachmentService
 


### PR DESCRIPTION
## Summary

Wraps `IssueService` and `IssueAttachmentService` at the root `backlog` package, following the same pattern established in #171 and #172.

## Changes

### Root package

- `issue.go` (new): defines `IssueService` and `IssueAttachmentService` as wrapper structs with doc comments; delegates all method calls to internal implementations
- `client.go`: changes `Issue` field type from `*issue.IssueService` to `*IssueService`; removes `internal/issue` import; wires `newIssueService`
- `service.go`: removes `IssueService` and `IssueAttachmentService` type aliases; removes `internal/issue` import

### `internal/issue`

- `service.go`: removes `Attachment` field and doc comment from `IssueService`; removes `internal/attachment` import

### `internal/attachment`

- `service.go`: removes doc comments from `IssueAttachmentService` struct and its methods (moved to root `issue.go`)

### Root tests

- `issue_test.go` (new): `TestIssueAttachmentService` — integration-style tests covering List / Remove using `backlog.NewClient` + `backlog.WithDoer`

Part of #170