### PR TITLE
refactor: wrap PullRequestService at root package

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package backlog
 
 import (
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/pullrequest"
 	"github.com/nattokin/go-backlog/internal/space"
 	"github.com/nattokin/go-backlog/internal/user"
 )
@@ -25,7 +24,7 @@ type Client struct {
 	// Service endpoints
 	Issue       *IssueService
 	Project     *ProjectService
-	PullRequest *pullrequest.PullRequestService
+	PullRequest *PullRequestService
 	Space       *space.SpaceService
 	User        *user.UserService
 	Wiki        *WikiService
@@ -67,7 +66,7 @@ func initServices(c *Client) {
 
 	c.Project = newProjectService(c.core.Method, baseOptionService)
 
-	c.PullRequest = pullrequest.NewPullRequestService(c.core.Method)
+	c.PullRequest = newPullRequestService(c.core.Method)
 
 	c.Space = space.NewSpaceService(c.core.Method, baseOptionService)
 

--- a/internal/attachment/service.go
+++ b/internal/attachment/service.go
@@ -74,14 +74,10 @@ func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string
 //  PullRequestAttachmentService
 // ──────────────────────────────────────────────────────────────
 
-// PullRequestAttachmentService handles communication with the pull request attachment-related methods of the Backlog API.
 type PullRequestAttachmentService struct {
 	method *core.Method
 }
 
-// List returns a list of all attachments in the pull request.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-pull-request-attachment
 func (s *PullRequestAttachmentService) List(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int) ([]*model.Attachment, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -97,9 +93,6 @@ func (s *PullRequestAttachmentService) List(ctx context.Context, projectIDOrKey 
 	return ListAttachments(ctx, s.method, spath)
 }
 
-// Remove removes a file attached to the pull request.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-pull-request-attachments
 func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*model.Attachment, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err

--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -1,15 +1,11 @@
 package pullrequest
 
 import (
-	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-// PullRequestService handles communication with the Pull Request-related methods of the Backlog API.
 type PullRequestService struct {
 	method *core.Method
-
-	Attachment *attachment.PullRequestAttachmentService
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -18,7 +14,6 @@ type PullRequestService struct {
 
 func NewPullRequestService(method *core.Method) *PullRequestService {
 	return &PullRequestService{
-		method:     method,
-		Attachment: attachment.NewPullRequestAttachmentService(method),
+		method: method,
 	}
 }

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -1,0 +1,61 @@
+package backlog
+
+import (
+	"context"
+
+	"github.com/nattokin/go-backlog/internal/attachment"
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/pullrequest"
+)
+
+// ──────────────────────────────────────────────────────────────
+//  PullRequestService
+// ──────────────────────────────────────────────────────────────
+
+// PullRequestService handles communication with the pull request-related methods of the Backlog API.
+type PullRequestService struct {
+	base *pullrequest.PullRequestService
+
+	Attachment *PullRequestAttachmentService
+}
+
+// ──────────────────────────────────────────────────────────────
+//  PullRequestAttachmentService
+// ──────────────────────────────────────────────────────────────
+
+// PullRequestAttachmentService handles communication with the pull request attachment-related methods of the Backlog API.
+type PullRequestAttachmentService struct {
+	base *attachment.PullRequestAttachmentService
+}
+
+// List returns a list of all attachments in the pull request.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-pull-request-attachment
+func (s *PullRequestAttachmentService) List(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int) ([]*model.Attachment, error) {
+	return s.base.List(ctx, projectIDOrKey, repositoryIDOrName, prNumber)
+}
+
+// Remove removes a file attached to the pull request.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-pull-request-attachments
+func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*model.Attachment, error) {
+	return s.base.Remove(ctx, projectIDOrKey, repositoryIDOrName, prNumber, attachmentID)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
+func newPullRequestService(method *core.Method) *PullRequestService {
+	return &PullRequestService{
+		base:       pullrequest.NewPullRequestService(method),
+		Attachment: newPullRequestAttachmentService(method),
+	}
+}
+
+func newPullRequestAttachmentService(method *core.Method) *PullRequestAttachmentService {
+	return &PullRequestAttachmentService{
+		base: attachment.NewPullRequestAttachmentService(method),
+	}
+}

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -1,0 +1,67 @@
+package backlog_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+func TestPullRequestAttachmentService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"List": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1/attachments", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.ListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.Attachment.List(ctx, "TEST", "repo", 1)
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, 2, got[0].ID)
+				assert.Equal(t, 5, got[1].ID)
+			},
+		},
+		"Remove": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1/attachments/8", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.Attachment.Remove(ctx, "TEST", "repo", 1, 8)
+				require.NoError(t, err)
+				assert.Equal(t, 8, got.ID)
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}

--- a/service.go
+++ b/service.go
@@ -4,7 +4,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/pullrequest"
 	"github.com/nattokin/go-backlog/internal/space"
 	"github.com/nattokin/go-backlog/internal/user"
 )
@@ -12,10 +11,6 @@ import (
 // ──────────────────────────────────────────────────────────────
 //  Implemented services (aliases to internal packages)
 // ──────────────────────────────────────────────────────────────
-
-type PullRequestAttachmentService = attachment.PullRequestAttachmentService
-
-type PullRequestService = pullrequest.PullRequestService
 
 type SpaceActivityService = activity.SpaceActivityService
 


### PR DESCRIPTION
## Summary

Wraps `PullRequestService` and `PullRequestAttachmentService` at the root `backlog` package, following the same pattern established in #171, #172, and #173.

## Changes

### Root package

- `pullrequest.go` (new): defines `PullRequestService` and `PullRequestAttachmentService` as wrapper structs with doc comments; delegates all method calls to internal implementations
- `client.go`: changes `PullRequest` field type from `*pullrequest.PullRequestService` to `*PullRequestService`; removes `internal/pullrequest` import; wires `newPullRequestService`
- `service.go`: removes `PullRequestService` and `PullRequestAttachmentService` type aliases; removes `internal/pullrequest` import

### `internal/pullrequest`

- `service.go`: removes `Attachment` field and doc comment from `PullRequestService`; removes `internal/attachment` import

### `internal/attachment`

- `service.go`: removes doc comments from `PullRequestAttachmentService` struct and its methods (moved to root `pullrequest.go`)

### Root tests

- `pullrequest_test.go` (new): `TestPullRequestAttachmentService` — integration-style tests covering List / Remove using `backlog.NewClient` + `backlog.WithDoer`

Part of #170