### PR TITLE
refactor: wrap SpaceService at root package

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package backlog
 
 import (
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/space"
 	"github.com/nattokin/go-backlog/internal/user"
 )
 
@@ -25,7 +24,7 @@ type Client struct {
 	Issue       *IssueService
 	Project     *ProjectService
 	PullRequest *PullRequestService
-	Space       *space.SpaceService
+	Space       *SpaceService
 	User        *user.UserService
 	Wiki        *WikiService
 }
@@ -68,7 +67,7 @@ func initServices(c *Client) {
 
 	c.PullRequest = newPullRequestService(c.core.Method)
 
-	c.Space = space.NewSpaceService(c.core.Method, baseOptionService)
+	c.Space = newSpaceService(c.core.Method, baseOptionService)
 
 	c.User = user.NewUserService(c.core.Method, baseOptionService)
 

--- a/internal/activity/service.go
+++ b/internal/activity/service.go
@@ -44,24 +44,10 @@ func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string
 	return GetActivityList(ctx, s.method, spath, opts...)
 }
 
-// SpaceActivityService handles communication with the space activities-related methods of the Backlog API.
 type SpaceActivityService struct {
 	method *core.Method
-
-	Option *ActivityOptionService
 }
 
-// List returns a list of activities in your space.
-//
-// This method supports options returned by methods in "*Client.Activity.Option",
-// such as:
-//   - WithActivityTypeIDs
-//   - WithCount
-//   - WithMaxID
-//   - WithMinID
-//   - WithOrder
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-recent-updates
 func (s *SpaceActivityService) List(ctx context.Context, opts ...core.RequestOption) ([]*model.Activity, error) {
 	return GetActivityList(ctx, s.method, "space/activities", opts...)
 }
@@ -106,7 +92,6 @@ func NewProjectActivityService(method *core.Method) *ProjectActivityService {
 func NewSpaceActivityService(method *core.Method, option *core.OptionService) *SpaceActivityService {
 	return &SpaceActivityService{
 		method: method,
-		Option: &ActivityOptionService{},
 	}
 }
 

--- a/internal/attachment/service.go
+++ b/internal/attachment/service.go
@@ -115,16 +115,10 @@ func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKe
 //  SpaceAttachmentService
 // ──────────────────────────────────────────────────────────────
 
-// SpaceAttachmentService handles communication with the space attachment-related methods of the Backlog API.
 type SpaceAttachmentService struct {
 	method *core.Method
 }
 
-// Upload uploads any file to the space.
-//
-// The file name must not be empty.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/post-attachment-file
 func (s *SpaceAttachmentService) Upload(ctx context.Context, fileName string, r io.Reader) (*model.Attachment, error) {
 	resp, err := s.method.Upload(ctx, "space/attachment", fileName, r)
 	if err != nil {

--- a/internal/space/service.go
+++ b/internal/space/service.go
@@ -1,28 +1,19 @@
 package space
 
 import (
-	"github.com/nattokin/go-backlog/internal/activity"
-	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-// SpaceService handles communication with the space-related methods of the Backlog API.
 type SpaceService struct {
 	method *core.Method
-
-	Activity   *activity.SpaceActivityService
-	Attachment *attachment.SpaceAttachmentService
 }
 
 // ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-// NewWikiService returns a new WikiService.
 func NewSpaceService(method *core.Method, option *core.OptionService) *SpaceService {
 	return &SpaceService{
-		method:     method,
-		Activity:   activity.NewSpaceActivityService(method, option),
-		Attachment: attachment.NewSpaceAttachmentService(method),
+		method: method,
 	}
 }

--- a/service.go
+++ b/service.go
@@ -2,21 +2,13 @@ package backlog
 
 import (
 	"github.com/nattokin/go-backlog/internal/activity"
-	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/space"
 	"github.com/nattokin/go-backlog/internal/user"
 )
 
 // ──────────────────────────────────────────────────────────────
 //  Implemented services (aliases to internal packages)
 // ──────────────────────────────────────────────────────────────
-
-type SpaceActivityService = activity.SpaceActivityService
-
-type SpaceAttachmentService = attachment.SpaceAttachmentService
-
-type SpaceService = space.SpaceService
 
 type UserActivityService = activity.UserActivityService
 

--- a/space.go
+++ b/space.go
@@ -1,0 +1,93 @@
+package backlog
+
+import (
+	"context"
+	"io"
+
+	"github.com/nattokin/go-backlog/internal/activity"
+	"github.com/nattokin/go-backlog/internal/attachment"
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/space"
+)
+
+// ──────────────────────────────────────────────────────────────
+//  SpaceService
+// ──────────────────────────────────────────────────────────────
+
+// SpaceService handles communication with the space-related methods of the Backlog API.
+type SpaceService struct {
+	base *space.SpaceService
+
+	Activity   *SpaceActivityService
+	Attachment *SpaceAttachmentService
+}
+
+// ──────────────────────────────────────────────────────────────
+//  SpaceActivityService
+// ──────────────────────────────────────────────────────────────
+
+// SpaceActivityService handles communication with the space activities-related methods of the Backlog API.
+type SpaceActivityService struct {
+	base *activity.SpaceActivityService
+
+	Option *ActivityOptionService
+}
+
+// List returns a list of activities in your space.
+//
+// This method supports options returned by methods in "*Client.Space.Activity.Option",
+// such as:
+//   - WithActivityTypeIDs
+//   - WithCount
+//   - WithMaxID
+//   - WithMinID
+//   - WithOrder
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-recent-updates
+func (s *SpaceActivityService) List(ctx context.Context, opts ...core.RequestOption) ([]*model.Activity, error) {
+	return s.base.List(ctx, opts...)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  SpaceAttachmentService
+// ──────────────────────────────────────────────────────────────
+
+// SpaceAttachmentService handles communication with the space attachment-related methods of the Backlog API.
+type SpaceAttachmentService struct {
+	base *attachment.SpaceAttachmentService
+}
+
+// Upload uploads any file to the space.
+//
+// The file name must not be empty.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/post-attachment-file
+func (s *SpaceAttachmentService) Upload(ctx context.Context, fileName string, r io.Reader) (*model.Attachment, error) {
+	return s.base.Upload(ctx, fileName, r)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
+func newSpaceService(method *core.Method, option *core.OptionService) *SpaceService {
+	return &SpaceService{
+		base:       space.NewSpaceService(method, option),
+		Activity:   newSpaceActivityService(method, option),
+		Attachment: newSpaceAttachmentService(method),
+	}
+}
+
+func newSpaceActivityService(method *core.Method, option *core.OptionService) *SpaceActivityService {
+	return &SpaceActivityService{
+		base:   activity.NewSpaceActivityService(method, option),
+		Option: &ActivityOptionService{},
+	}
+}
+
+func newSpaceAttachmentService(method *core.Method) *SpaceAttachmentService {
+	return &SpaceAttachmentService{
+		base: attachment.NewSpaceAttachmentService(method),
+	}
+}

--- a/space_test.go
+++ b/space_test.go
@@ -1,0 +1,50 @@
+package backlog_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+func TestSpaceActivityService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"List": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/space/activities", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.ListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Space.Activity.List(ctx)
+				require.NoError(t, err)
+				assert.Len(t, got, 1)
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}

--- a/space_test.go
+++ b/space_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,4 +49,33 @@ func TestSpaceActivityService(t *testing.T) {
 			tc.call(t, c)
 		})
 	}
+}
+
+func TestSpaceAttachmentService(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Upload", func(t *testing.T) {
+		doFunc := func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, http.MethodPost, req.Method)
+			assert.Equal(t, "/api/v2/space/attachment", req.URL.Path)
+			assert.True(t, strings.HasPrefix(req.Header.Get("Content-Type"), "multipart/form-data"))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.UploadJSON))),
+			}, nil
+		}
+
+		c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: doFunc}))
+		require.NoError(t, err)
+
+		f, err := os.Open("testdata/testfile")
+		require.NoError(t, err)
+		defer f.Close()
+
+		got, err := c.Space.Attachment.Upload(ctx, "testfile", f)
+		require.NoError(t, err)
+		assert.Equal(t, 1, got.ID)
+		assert.Equal(t, "test.txt", got.Name)
+		assert.Equal(t, 8857, got.Size)
+	})
 }


### PR DESCRIPTION
## Summary

Wraps `SpaceService`, `SpaceActivityService`, and `SpaceAttachmentService` at the root `backlog` package, following the same pattern established in #171–#174.

## Changes

### Root package

- `space.go` (new): defines `SpaceService`, `SpaceActivityService`, and `SpaceAttachmentService` as wrapper structs with doc comments; `SpaceActivityService` holds `Option *ActivityOptionService` at root (same pattern as `ProjectActivityService` in #171)
- `client.go`: changes `Space` field type from `*space.SpaceService` to `*SpaceService`; removes `internal/space` import; wires `newSpaceService`
- `service.go`: removes `SpaceService`, `SpaceActivityService`, and `SpaceAttachmentService` type aliases; removes `internal/space` and `internal/attachment` imports

### `internal/space`

- `service.go`: removes `Activity` and `Attachment` fields and doc comment from `SpaceService`; removes `internal/activity` and `internal/attachment` imports

### `internal/activity`

- `service.go`: removes `Option` field and doc comments from `SpaceActivityService` (moved to root `space.go`); removes `option` argument handling in `NewSpaceActivityService`

### `internal/attachment`

- `service.go`: removes doc comments from `SpaceAttachmentService` struct and its `Upload` method (moved to root `space.go`)

### Root tests

- `space_test.go` (new): `TestSpaceActivityService` — integration-style test covering `List`; `TestSpaceAttachmentService` — `Upload` test using `testdata/testfile`, verifying multipart `Content-Type`, path, and response; both using `backlog.NewClient` + `backlog.WithDoer`

Part of #170