### PR TITLE
refactor: rename internal service types to remove package-name prefix

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,7 +60,7 @@ func NewClient(baseURL, token string, opts ...*core.ClientOption) (*Client, erro
 func initServices(c *Client) {
 	baseOptionService := &core.OptionService{}
 
-	c.Issue = newIssueService(c.core.Method, baseOptionService)
+	c.Issue = newIssueService(c.core.Method)
 
 	c.Project = newProjectService(c.core.Method, baseOptionService)
 

--- a/internal/activity/service.go
+++ b/internal/activity/service.go
@@ -31,11 +31,11 @@ func GetActivityList(ctx context.Context, m *core.Method, spath string, opts ...
 	return v, nil
 }
 
-type ProjectActivityService struct {
+type ProjectService struct {
 	method *core.Method
 }
 
-func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Activity, error) {
+func (s *ProjectService) List(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Activity, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -44,19 +44,19 @@ func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string
 	return GetActivityList(ctx, s.method, spath, opts...)
 }
 
-type SpaceActivityService struct {
+type SpaceService struct {
 	method *core.Method
 }
 
-func (s *SpaceActivityService) List(ctx context.Context, opts ...core.RequestOption) ([]*model.Activity, error) {
+func (s *SpaceService) List(ctx context.Context, opts ...core.RequestOption) ([]*model.Activity, error) {
 	return GetActivityList(ctx, s.method, "space/activities", opts...)
 }
 
-type UserActivityService struct {
+type UserService struct {
 	method *core.Method
 }
 
-func (s *UserActivityService) List(ctx context.Context, userID int, opts ...core.RequestOption) ([]*model.Activity, error) {
+func (s *UserService) List(ctx context.Context, userID int, opts ...core.RequestOption) ([]*model.Activity, error) {
 	if err := validate.ValidateUserID(userID); err != nil {
 		return nil, err
 	}
@@ -69,20 +69,20 @@ func (s *UserActivityService) List(ctx context.Context, userID int, opts ...core
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewProjectActivityService(method *core.Method) *ProjectActivityService {
-	return &ProjectActivityService{
+func NewProjectService(method *core.Method) *ProjectService {
+	return &ProjectService{
 		method: method,
 	}
 }
 
-func NewSpaceActivityService(method *core.Method, option *core.OptionService) *SpaceActivityService {
-	return &SpaceActivityService{
+func NewSpaceService(method *core.Method, option *core.OptionService) *SpaceService {
+	return &SpaceService{
 		method: method,
 	}
 }
 
-func NewUserActivityService(method *core.Method, option *core.OptionService) *UserActivityService {
-	return &UserActivityService{
+func NewUserService(method *core.Method, option *core.OptionService) *UserService {
+	return &UserService{
 		method: method,
 	}
 }

--- a/internal/activity/service.go
+++ b/internal/activity/service.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-func GetActivityList(ctx context.Context, m *core.Method, spath string, opts ...core.RequestOption) ([]*model.Activity, error) {
+func getList(ctx context.Context, m *core.Method, spath string, opts ...core.RequestOption) ([]*model.Activity, error) {
 	query := url.Values{}
 	validOptionKeys := []core.APIParamOptionType{core.ParamActivityTypeIDs, core.ParamMinID, core.ParamMaxID, core.ParamCount, core.ParamOrder}
 	if err := core.ApplyOptions(query, validOptionKeys, opts...); err != nil {
@@ -41,7 +41,7 @@ func (s *ProjectService) List(ctx context.Context, projectIDOrKey string, opts .
 	}
 
 	spath := path.Join("projects", projectIDOrKey, "activities")
-	return GetActivityList(ctx, s.method, spath, opts...)
+	return getList(ctx, s.method, spath, opts...)
 }
 
 type SpaceService struct {
@@ -49,7 +49,7 @@ type SpaceService struct {
 }
 
 func (s *SpaceService) List(ctx context.Context, opts ...core.RequestOption) ([]*model.Activity, error) {
-	return GetActivityList(ctx, s.method, "space/activities", opts...)
+	return getList(ctx, s.method, "space/activities", opts...)
 }
 
 type UserService struct {
@@ -62,7 +62,7 @@ func (s *UserService) List(ctx context.Context, userID int, opts ...core.Request
 	}
 
 	spath := path.Join("users", strconv.Itoa(userID), "activities")
-	return GetActivityList(ctx, s.method, spath, opts...)
+	return getList(ctx, s.method, spath, opts...)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -75,13 +75,13 @@ func NewProjectService(method *core.Method) *ProjectService {
 	}
 }
 
-func NewSpaceService(method *core.Method, option *core.OptionService) *SpaceService {
+func NewSpaceService(method *core.Method) *SpaceService {
 	return &SpaceService{
 		method: method,
 	}
 }
 
-func NewUserService(method *core.Method, option *core.OptionService) *UserService {
+func NewUserService(method *core.Method) *UserService {
 	return &UserService{
 		method: method,
 	}

--- a/internal/activity/service_test.go
+++ b/internal/activity/service_test.go
@@ -31,7 +31,7 @@ func TestProjectActivityService_List(t *testing.T) {
 		spath: "projects/" + projectKey + "/activities",
 	}
 
-	s := activity.NewProjectActivityService(&core.Method{
+	s := activity.NewProjectService(&core.Method{
 		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 			assert.Equal(t, want.spath, spath)
 			return nil, errors.New("error")
@@ -46,7 +46,7 @@ func TestProjectActivityService_List_projectIDOrKeyIsEmpty(t *testing.T) {
 	t.Parallel()
 
 	projectKey := ""
-	s := activity.NewProjectActivityService(&core.Method{
+	s := activity.NewProjectService(&core.Method{
 		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 			t.Error("s.method.Get must never be called")
 			return nil, errors.New("error")
@@ -60,7 +60,7 @@ func TestProjectActivityService_List_projectIDOrKeyIsEmpty(t *testing.T) {
 func TestProjectActivityService_List_invalidJson(t *testing.T) {
 	t.Parallel()
 
-	s := activity.NewProjectActivityService(&core.Method{
+	s := activity.NewProjectService(&core.Method{
 		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
@@ -84,12 +84,12 @@ func TestSpaceActivityService_List(t *testing.T) {
 		spath: "space/activities",
 	}
 
-	s := activity.NewSpaceActivityService(&core.Method{
+	s := activity.NewSpaceService(&core.Method{
 		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 			assert.Equal(t, want.spath, spath)
 			return nil, errors.New("error")
 		},
-	}, &core.OptionService{})
+	})
 
 	_, err := s.List(context.Background())
 	assert.Error(t, err)
@@ -106,12 +106,12 @@ func TestUserActivityService_List(t *testing.T) {
 		spath: "users/" + strconv.Itoa(id) + "/activities",
 	}
 
-	s := activity.NewUserActivityService(&core.Method{
+	s := activity.NewUserService(&core.Method{
 		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 			assert.Equal(t, want.spath, spath)
 			return nil, errors.New("error")
 		},
-	}, &core.OptionService{})
+	})
 
 	_, err := s.List(context.Background(), id)
 	assert.Error(t, err)
@@ -121,12 +121,12 @@ func TestUserActivityService_List_invalidID(t *testing.T) {
 	t.Parallel()
 
 	id := 0
-	s := activity.NewUserActivityService(&core.Method{
+	s := activity.NewUserService(&core.Method{
 		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 			t.Error("s.method.Get must never be called")
 			return nil, errors.New("error")
 		},
-	}, &core.OptionService{})
+	})
 
 	_, err := s.List(context.Background(), id)
 	assert.Error(t, err)
@@ -263,7 +263,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			t.Parallel()
 
-			s := activity.NewSpaceActivityService(&core.Method{
+			s := activity.NewSpaceService(&core.Method{
 				Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 					assert.Equal(t, tc.want.activityTypeID, (query)["activityTypeId[]"])
 					assert.Equal(t, tc.want.minID, query.Get("minId"))
@@ -277,7 +277,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 					}
 					return resp, nil
 				},
-			}, &core.OptionService{})
+			})
 
 			if resp, err := s.List(context.Background(), tc.opts...); tc.wantError {
 				require.Error(t, err)
@@ -304,7 +304,7 @@ func TestActivityService_contextPropagation(t *testing.T) {
 		call func(t *testing.T)
 	}{
 		{"ProjectActivityService.List", func(t *testing.T) {
-			s := activity.NewProjectActivityService(&core.Method{
+			s := activity.NewProjectService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
@@ -313,21 +313,21 @@ func TestActivityService_contextPropagation(t *testing.T) {
 			s.List(ctx, "TEST") //nolint:errcheck
 		}},
 		{"SpaceActivityService.List", func(t *testing.T) {
-			s := activity.NewSpaceActivityService(&core.Method{
+			s := activity.NewSpaceService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, &core.OptionService{})
+			})
 			s.List(ctx) //nolint:errcheck
 		}},
 		{"UserActivityService.List", func(t *testing.T) {
-			s := activity.NewUserActivityService(&core.Method{
+			s := activity.NewUserService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, &core.OptionService{})
+			})
 
 			s.List(ctx, 1) //nolint:errcheck
 		}},

--- a/internal/attachment/service.go
+++ b/internal/attachment/service.go
@@ -42,14 +42,14 @@ func RemoveAttachment(ctx context.Context, m *core.Method, spath string) (*model
 }
 
 // ──────────────────────────────────────────────────────────────
-//  IssueAttachmentService
+//  IssueService
 // ──────────────────────────────────────────────────────────────
 
-type IssueAttachmentService struct {
+type IssueService struct {
 	method *core.Method
 }
 
-func (s *IssueAttachmentService) List(ctx context.Context, issueIDOrKey string) ([]*model.Attachment, error) {
+func (s *IssueService) List(ctx context.Context, issueIDOrKey string) ([]*model.Attachment, error) {
 	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (s *IssueAttachmentService) List(ctx context.Context, issueIDOrKey string) 
 	return ListAttachments(ctx, s.method, spath)
 }
 
-func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string, attachmentID int) (*model.Attachment, error) {
+func (s *IssueService) Remove(ctx context.Context, issueIDOrKey string, attachmentID int) (*model.Attachment, error) {
 	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
 		return nil, err
 	}
@@ -71,14 +71,14 @@ func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string
 }
 
 // ──────────────────────────────────────────────────────────────
-//  PullRequestAttachmentService
+//  PullRequestService
 // ──────────────────────────────────────────────────────────────
 
-type PullRequestAttachmentService struct {
+type PullRequestService struct {
 	method *core.Method
 }
 
-func (s *PullRequestAttachmentService) List(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int) ([]*model.Attachment, error) {
+func (s *PullRequestService) List(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int) ([]*model.Attachment, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (s *PullRequestAttachmentService) List(ctx context.Context, projectIDOrKey 
 	return ListAttachments(ctx, s.method, spath)
 }
 
-func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*model.Attachment, error) {
+func (s *PullRequestService) Remove(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*model.Attachment, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -112,14 +112,14 @@ func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKe
 }
 
 // ──────────────────────────────────────────────────────────────
-//  SpaceAttachmentService
+//  SpaceService
 // ──────────────────────────────────────────────────────────────
 
-type SpaceAttachmentService struct {
+type SpaceService struct {
 	method *core.Method
 }
 
-func (s *SpaceAttachmentService) Upload(ctx context.Context, fileName string, r io.Reader) (*model.Attachment, error) {
+func (s *SpaceService) Upload(ctx context.Context, fileName string, r io.Reader) (*model.Attachment, error) {
 	resp, err := s.method.Upload(ctx, "space/attachment", fileName, r)
 	if err != nil {
 		return nil, err
@@ -134,14 +134,14 @@ func (s *SpaceAttachmentService) Upload(ctx context.Context, fileName string, r 
 }
 
 // ──────────────────────────────────────────────────────────────
-//  WikiAttachmentService
+//  WikiService
 // ──────────────────────────────────────────────────────────────
 
-type WikiAttachmentService struct {
+type WikiService struct {
 	method *core.Method
 }
 
-func (s *WikiAttachmentService) Attach(ctx context.Context, wikiID int, attachmentIDs []int) ([]*model.Attachment, error) {
+func (s *WikiService) Attach(ctx context.Context, wikiID int, attachmentIDs []int) ([]*model.Attachment, error) {
 	if err := validate.ValidateWikiID(wikiID); err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (s *WikiAttachmentService) Attach(ctx context.Context, wikiID int, attachme
 	return v, nil
 }
 
-func (s *WikiAttachmentService) List(ctx context.Context, wikiID int) ([]*model.Attachment, error) {
+func (s *WikiService) List(ctx context.Context, wikiID int) ([]*model.Attachment, error) {
 	if err := validate.ValidateWikiID(wikiID); err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (s *WikiAttachmentService) List(ctx context.Context, wikiID int) ([]*model.
 	return ListAttachments(ctx, s.method, spath)
 }
 
-func (s *WikiAttachmentService) Remove(ctx context.Context, wikiID, attachmentID int) (*model.Attachment, error) {
+func (s *WikiService) Remove(ctx context.Context, wikiID, attachmentID int) (*model.Attachment, error) {
 	if err := validate.ValidateWikiID(wikiID); err != nil {
 		return nil, err
 	}
@@ -196,26 +196,26 @@ func (s *WikiAttachmentService) Remove(ctx context.Context, wikiID, attachmentID
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewPullRequestAttachmentService(method *core.Method) *PullRequestAttachmentService {
-	return &PullRequestAttachmentService{
+func NewPullRequestService(method *core.Method) *PullRequestService {
+	return &PullRequestService{
 		method: method,
 	}
 }
 
-func NewIssueAttachmentService(method *core.Method) *IssueAttachmentService {
-	return &IssueAttachmentService{
+func NewIssueService(method *core.Method) *IssueService {
+	return &IssueService{
 		method: method,
 	}
 }
 
-func NewSpaceAttachmentService(method *core.Method) *SpaceAttachmentService {
-	return &SpaceAttachmentService{
+func NewSpaceService(method *core.Method) *SpaceService {
+	return &SpaceService{
 		method: method,
 	}
 }
 
-func NewWikiAttachmentService(method *core.Method) *WikiAttachmentService {
-	return &WikiAttachmentService{
+func NewWikiService(method *core.Method) *WikiService {
+	return &WikiService{
 		method: method,
 	}
 }

--- a/internal/attachment/service_test.go
+++ b/internal/attachment/service_test.go
@@ -139,7 +139,7 @@ func TestSpaceAttachmentService_Upload(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewSpaceAttachmentService(&core.Method{
+			s := attachment.NewSpaceService(&core.Method{
 				Upload: tc.mockUploadFn,
 			})
 
@@ -257,7 +257,7 @@ func TestWikiAttachmentService_Attach(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewWikiAttachmentService(&core.Method{Post: tc.mockPostFn})
+			s := attachment.NewWikiService(&core.Method{Post: tc.mockPostFn})
 
 			attachments, err := s.Attach(context.Background(), tc.wikiID, tc.attachmentIDs)
 
@@ -344,7 +344,7 @@ func TestWikiAttachmentService_List(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewWikiAttachmentService(&core.Method{Get: tc.mockGetFn})
+			s := attachment.NewWikiService(&core.Method{Get: tc.mockGetFn})
 
 			attachments, err := s.List(context.Background(), tc.wikiID)
 
@@ -451,7 +451,7 @@ func TestWikiAttachmentService_Remove(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewWikiAttachmentService(&core.Method{Delete: tc.mockDeleteFn})
+			s := attachment.NewWikiService(&core.Method{Delete: tc.mockDeleteFn})
 
 			attachment, err := s.Remove(context.Background(), tc.wikiID, tc.attachmentID)
 
@@ -528,7 +528,7 @@ func TestIssueAttachmentService_List(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewIssueAttachmentService(&core.Method{
+			s := attachment.NewIssueService(&core.Method{
 				Get: tc.mockGetFn,
 			})
 
@@ -623,7 +623,7 @@ func TestIssueAttachmentService_Remove(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewIssueAttachmentService(&core.Method{
+			s := attachment.NewIssueService(&core.Method{
 				Delete: tc.mockDeleteFn,
 			})
 
@@ -732,7 +732,7 @@ func TestPullRequestAttachmentService_List(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewPullRequestAttachmentService(&core.Method{
+			s := attachment.NewPullRequestService(&core.Method{
 				Get: tc.mockGetFn,
 			})
 
@@ -865,7 +865,7 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewPullRequestAttachmentService(&core.Method{
+			s := attachment.NewPullRequestService(&core.Method{
 				Delete: tc.mockDeleteFn,
 			})
 
@@ -896,8 +896,6 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 
 // TestAttachmentService_contextPropagation verifies that the context passed to
 // each attachment service method is correctly relayed to the underlying method call.
-// A sentinel value is embedded in the context and its pointer identity is
-// asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
 func TestAttachmentService_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
@@ -907,8 +905,8 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T)
 	}{
-		{"SpaceAttachmentService.Upload", func(t *testing.T) {
-			s := attachment.NewSpaceAttachmentService(&core.Method{
+		{"SpaceService.Upload", func(t *testing.T) {
+			s := attachment.NewSpaceService(&core.Method{
 				Upload: func(got context.Context, _, _ string, _ io.Reader) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
@@ -916,8 +914,8 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 			})
 			s.Upload(ctx, "f", bytes.NewReader(nil)) //nolint:errcheck
 		}},
-		{"WikiAttachmentService.Attach", func(t *testing.T) {
-			s := attachment.NewWikiAttachmentService(&core.Method{
+		{"WikiService.Attach", func(t *testing.T) {
+			s := attachment.NewWikiService(&core.Method{
 				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
@@ -925,8 +923,8 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 			})
 			s.Attach(ctx, 1, []int{1}) //nolint:errcheck
 		}},
-		{"WikiAttachmentService.List", func(t *testing.T) {
-			s := attachment.NewWikiAttachmentService(&core.Method{
+		{"WikiService.List", func(t *testing.T) {
+			s := attachment.NewWikiService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
@@ -934,8 +932,8 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 			})
 			s.List(ctx, 1) //nolint:errcheck
 		}},
-		{"WikiAttachmentService.Remove", func(t *testing.T) {
-			s := attachment.NewWikiAttachmentService(&core.Method{
+		{"WikiService.Remove", func(t *testing.T) {
+			s := attachment.NewWikiService(&core.Method{
 				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
@@ -943,8 +941,8 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 			})
 			s.Remove(ctx, 1, 1) //nolint:errcheck
 		}},
-		{"IssueAttachmentService.List", func(t *testing.T) {
-			s := attachment.NewIssueAttachmentService(&core.Method{
+		{"IssueService.List", func(t *testing.T) {
+			s := attachment.NewIssueService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
@@ -952,8 +950,8 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 			})
 			s.List(ctx, "TEST-1") //nolint:errcheck
 		}},
-		{"IssueAttachmentService.Remove", func(t *testing.T) {
-			s := attachment.NewIssueAttachmentService(&core.Method{
+		{"IssueService.Remove", func(t *testing.T) {
+			s := attachment.NewIssueService(&core.Method{
 				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
@@ -961,8 +959,8 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 			})
 			s.Remove(ctx, "TEST-1", 1) //nolint:errcheck
 		}},
-		{"PullRequestAttachmentService.List", func(t *testing.T) {
-			s := attachment.NewPullRequestAttachmentService(&core.Method{
+		{"PullRequestService.List", func(t *testing.T) {
+			s := attachment.NewPullRequestService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
@@ -970,8 +968,8 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 			})
 			s.List(ctx, "TEST", "repo", 1) //nolint:errcheck
 		}},
-		{"PullRequestAttachmentService.Remove", func(t *testing.T) {
-			s := attachment.NewPullRequestAttachmentService(&core.Method{
+		{"PullRequestService.Remove", func(t *testing.T) {
+			s := attachment.NewPullRequestService(&core.Method{
 				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")

--- a/internal/issue/service.go
+++ b/internal/issue/service.go
@@ -4,7 +4,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-type IssueService struct {
+type Service struct {
 	method *core.Method
 }
 
@@ -12,8 +12,8 @@ type IssueService struct {
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewIssueService(method *core.Method, option *core.OptionService) *IssueService {
-	return &IssueService{
+func NewService(method *core.Method, option *core.OptionService) *Service {
+	return &Service{
 		method: method,
 	}
 }

--- a/internal/issue/service.go
+++ b/internal/issue/service.go
@@ -12,7 +12,7 @@ type Service struct {
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewService(method *core.Method, option *core.OptionService) *Service {
+func NewService(method *core.Method) *Service {
 	return &Service{
 		method: method,
 	}

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -128,7 +128,7 @@ func (s *Service) Delete(ctx context.Context, projectIDOrKey string) (*model.Pro
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewService(method *core.Method, option *core.OptionService) *Service {
+func NewService(method *core.Method) *Service {
 	return &Service{
 		method: method,
 	}

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -10,11 +10,11 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-type ProjectService struct {
+type Service struct {
 	method *core.Method
 }
 
-func (s *ProjectService) All(ctx context.Context, opts ...core.RequestOption) ([]*model.Project, error) {
+func (s *Service) All(ctx context.Context, opts ...core.RequestOption) ([]*model.Project, error) {
 
 	query := url.Values{}
 	validTypes := []core.APIParamOptionType{core.ParamAll, core.ParamArchived}
@@ -35,7 +35,7 @@ func (s *ProjectService) All(ctx context.Context, opts ...core.RequestOption) ([
 	return v, nil
 }
 
-func (s *ProjectService) One(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
+func (s *Service) One(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (s *ProjectService) One(ctx context.Context, projectIDOrKey string) (*model
 	return &v, nil
 }
 
-func (s *ProjectService) Create(ctx context.Context, key, name string, opts ...core.RequestOption) (*model.Project, error) {
+func (s *Service) Create(ctx context.Context, key, name string, opts ...core.RequestOption) (*model.Project, error) {
 	option := &core.OptionService{}
 
 	form := url.Values{}
@@ -77,7 +77,7 @@ func (s *ProjectService) Create(ctx context.Context, key, name string, opts ...c
 	return &v, nil
 }
 
-func (s *ProjectService) Update(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) (*model.Project, error) {
+func (s *Service) Update(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (s *ProjectService) Update(ctx context.Context, projectIDOrKey string, opts
 	return &v, nil
 }
 
-func (s *ProjectService) Delete(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
+func (s *Service) Delete(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -128,8 +128,8 @@ func (s *ProjectService) Delete(ctx context.Context, projectIDOrKey string) (*mo
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewProjectService(method *core.Method, option *core.OptionService) *ProjectService {
-	return &ProjectService{
+func NewService(method *core.Method, option *core.OptionService) *Service {
+	return &Service{
 		method: method,
 	}
 }

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -114,7 +114,7 @@ func TestProjectService_All(t *testing.T) {
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
-			s := project.NewProjectService(method, nil)
+			s := project.NewService(method)
 
 			projects, err := s.All(context.Background(), tc.opts...)
 
@@ -212,7 +212,7 @@ func TestProjectService_One(t *testing.T) {
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
-			s := project.NewProjectService(method, nil)
+			s := project.NewService(method)
 
 			project, err := s.One(context.Background(), tc.projectIDOrKey)
 
@@ -381,7 +381,7 @@ func TestProjectService_Create(t *testing.T) {
 			if tc.mockPostFn != nil {
 				method.Post = tc.mockPostFn
 			}
-			s := project.NewProjectService(method, nil)
+			s := project.NewService(method)
 
 			project, err := s.Create(context.Background(), tc.key, tc.name, tc.opts...)
 
@@ -539,7 +539,7 @@ func TestProjectService_Update(t *testing.T) {
 			if tc.mockPatchFn != nil {
 				method.Patch = tc.mockPatchFn
 			}
-			s := project.NewProjectService(method, nil)
+			s := project.NewService(method)
 
 			project, err := s.Update(context.Background(), tc.projectIDOrKey, tc.opts...)
 
@@ -637,7 +637,7 @@ func TestProjectService_Delete(t *testing.T) {
 			if tc.mockDeleteFn != nil {
 				method.Delete = tc.mockDeleteFn
 			}
-			s := project.NewProjectService(method, nil)
+			s := project.NewService(method)
 
 			project, err := s.Delete(context.Background(), tc.projectIDOrKey)
 
@@ -670,48 +670,48 @@ func TestProjectService_contextPropagation(t *testing.T) {
 		call func(t *testing.T)
 	}{
 		{"All", func(t *testing.T) {
-			s := project.NewProjectService(&core.Method{
+			s := project.NewService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.All(ctx) //nolint:errcheck
 		}},
 		{"One", func(t *testing.T) {
-			s := project.NewProjectService(&core.Method{
+			s := project.NewService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.One(ctx, "TEST") //nolint:errcheck
 		}},
 		{"Create", func(t *testing.T) {
-			s := project.NewProjectService(&core.Method{
+			s := project.NewService(&core.Method{
 				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.Create(ctx, "KEY", "name", o.WithChartEnabled(true)) //nolint:errcheck
 		}},
 		{"Update", func(t *testing.T) {
-			s := project.NewProjectService(&core.Method{
+			s := project.NewService(&core.Method{
 				Patch: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.Update(ctx, "TEST") //nolint:errcheck
 		}},
 		{"Delete", func(t *testing.T) {
-			s := project.NewProjectService(&core.Method{
+			s := project.NewService(&core.Method{
 				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.Delete(ctx, "TEST") //nolint:errcheck
 		}}}
 

--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -4,7 +4,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-type PullRequestService struct {
+type Service struct {
 	method *core.Method
 }
 
@@ -12,8 +12,8 @@ type PullRequestService struct {
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewPullRequestService(method *core.Method) *PullRequestService {
-	return &PullRequestService{
+func NewService(method *core.Method) *Service {
+	return &Service{
 		method: method,
 	}
 }

--- a/internal/space/service.go
+++ b/internal/space/service.go
@@ -12,7 +12,7 @@ type Service struct {
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewService(method *core.Method, option *core.OptionService) *Service {
+func NewService(method *core.Method) *Service {
 	return &Service{
 		method: method,
 	}

--- a/internal/space/service.go
+++ b/internal/space/service.go
@@ -4,7 +4,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-type SpaceService struct {
+type Service struct {
 	method *core.Method
 }
 
@@ -12,8 +12,8 @@ type SpaceService struct {
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewSpaceService(method *core.Method, option *core.OptionService) *SpaceService {
-	return &SpaceService{
+func NewService(method *core.Method, option *core.OptionService) *Service {
+	return &Service{
 		method: method,
 	}
 }

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -81,15 +81,17 @@ func deleteUser(ctx context.Context, m *core.Method, spath string, form url.Valu
 	return &v, nil
 }
 
-type UserService struct {
+type Service struct {
 	method *core.Method
+
+	Option *UserOptionService
 }
 
-func (s *UserService) All(ctx context.Context) ([]*model.User, error) {
+func (s *Service) All(ctx context.Context) ([]*model.User, error) {
 	return getUserList(ctx, s.method, "users", nil)
 }
 
-func (s *UserService) One(ctx context.Context, id int) (*model.User, error) {
+func (s *Service) One(ctx context.Context, id int) (*model.User, error) {
 	if err := validate.ValidateUserID(id); err != nil {
 		return nil, err
 	}
@@ -98,11 +100,11 @@ func (s *UserService) One(ctx context.Context, id int) (*model.User, error) {
 	return getUser(ctx, s.method, spath)
 }
 
-func (s *UserService) Own(ctx context.Context) (*model.User, error) {
+func (s *Service) Own(ctx context.Context) (*model.User, error) {
 	return getUser(ctx, s.method, "users/myself")
 }
 
-func (s *UserService) Add(ctx context.Context, userID, password, name, mailAddress string, roleType model.Role) (*model.User, error) {
+func (s *Service) Add(ctx context.Context, userID, password, name, mailAddress string, roleType model.Role) (*model.User, error) {
 	if userID == "" {
 		return nil, core.NewValidationError("userID must not be empty")
 	}
@@ -125,7 +127,7 @@ func (s *UserService) Add(ctx context.Context, userID, password, name, mailAddre
 	return addUser(ctx, s.method, "users", form)
 }
 
-func (s *UserService) Update(ctx context.Context, id int, opts ...core.RequestOption) (*model.User, error) {
+func (s *Service) Update(ctx context.Context, id int, opts ...core.RequestOption) (*model.User, error) {
 	option := &core.OptionService{}
 	form := url.Values{}
 	validTypes := []core.APIParamOptionType{core.ParamUserID, core.ParamName, core.ParamPassword, core.ParamMailAddress, core.ParamRoleType}
@@ -138,7 +140,7 @@ func (s *UserService) Update(ctx context.Context, id int, opts ...core.RequestOp
 	return updateUser(ctx, s.method, spath, form)
 }
 
-func (s *UserService) Delete(ctx context.Context, id int) (*model.User, error) {
+func (s *Service) Delete(ctx context.Context, id int) (*model.User, error) {
 	if err := validate.ValidateUserID(id); err != nil {
 		return nil, err
 	}
@@ -147,11 +149,11 @@ func (s *UserService) Delete(ctx context.Context, id int) (*model.User, error) {
 	return deleteUser(ctx, s.method, spath, nil)
 }
 
-type ProjectUserService struct {
+type ProjectService struct {
 	method *core.Method
 }
 
-func (s *ProjectUserService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*model.User, error) {
+func (s *ProjectService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -163,7 +165,7 @@ func (s *ProjectUserService) All(ctx context.Context, projectIDOrKey string, exc
 	return getUserList(ctx, s.method, spath, query)
 }
 
-func (s *ProjectUserService) Add(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
+func (s *ProjectService) Add(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -179,7 +181,7 @@ func (s *ProjectUserService) Add(ctx context.Context, projectIDOrKey string, use
 	return addUser(ctx, s.method, spath, form)
 }
 
-func (s *ProjectUserService) Delete(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
+func (s *ProjectService) Delete(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -195,7 +197,7 @@ func (s *ProjectUserService) Delete(ctx context.Context, projectIDOrKey string, 
 	return deleteUser(ctx, s.method, spath, form)
 }
 
-func (s *ProjectUserService) AddAdmin(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
+func (s *ProjectService) AddAdmin(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -211,7 +213,7 @@ func (s *ProjectUserService) AddAdmin(ctx context.Context, projectIDOrKey string
 	return addUser(ctx, s.method, spath, form)
 }
 
-func (s *ProjectUserService) AdminAll(ctx context.Context, projectIDOrKey string) ([]*model.User, error) {
+func (s *ProjectService) AdminAll(ctx context.Context, projectIDOrKey string) ([]*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -220,7 +222,7 @@ func (s *ProjectUserService) AdminAll(ctx context.Context, projectIDOrKey string
 	return getUserList(ctx, s.method, spath, nil)
 }
 
-func (s *ProjectUserService) DeleteAdmin(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
+func (s *ProjectService) DeleteAdmin(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -240,14 +242,15 @@ func (s *ProjectUserService) DeleteAdmin(ctx context.Context, projectIDOrKey str
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewUserService(method *core.Method, option *core.OptionService) *UserService {
-	return &UserService{
+func NewService(method *core.Method, option *core.OptionService) *Service {
+	return &Service{
 		method: method,
+		Option: NewUserOptionService(option),
 	}
 }
 
-func NewProjectUserService(method *core.Method, option *core.OptionService) *ProjectUserService {
-	return &ProjectUserService{
+func NewProjectService(method *core.Method, option *core.OptionService) *ProjectService {
+	return &ProjectService{
 		method: method,
 	}
 }

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-func getUser(ctx context.Context, m *core.Method, spath string) (*model.User, error) {
+func get(ctx context.Context, m *core.Method, spath string) (*model.User, error) {
 	resp, err := m.Get(ctx, spath, nil)
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func getUser(ctx context.Context, m *core.Method, spath string) (*model.User, er
 	return &v, nil
 }
 
-func getUserList(ctx context.Context, m *core.Method, spath string, query url.Values) ([]*model.User, error) {
+func getList(ctx context.Context, m *core.Method, spath string, query url.Values) ([]*model.User, error) {
 	resp, err := m.Get(ctx, spath, query)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func getUserList(ctx context.Context, m *core.Method, spath string, query url.Va
 	return v, nil
 }
 
-func addUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*model.User, error) {
+func add(ctx context.Context, m *core.Method, spath string, form url.Values) (*model.User, error) {
 	resp, err := m.Post(ctx, spath, form)
 	if err != nil {
 		return nil, err
@@ -53,7 +53,7 @@ func addUser(ctx context.Context, m *core.Method, spath string, form url.Values)
 	return &v, nil
 }
 
-func updateUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*model.User, error) {
+func update(ctx context.Context, m *core.Method, spath string, form url.Values) (*model.User, error) {
 	resp, err := m.Patch(ctx, spath, form)
 	if err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func updateUser(ctx context.Context, m *core.Method, spath string, form url.Valu
 	return &v, nil
 }
 
-func deleteUser(ctx context.Context, m *core.Method, spath string, form url.Values) (*model.User, error) {
+func delete(ctx context.Context, m *core.Method, spath string, form url.Values) (*model.User, error) {
 	resp, err := m.Delete(ctx, spath, form)
 	if err != nil {
 		return nil, err
@@ -83,12 +83,10 @@ func deleteUser(ctx context.Context, m *core.Method, spath string, form url.Valu
 
 type Service struct {
 	method *core.Method
-
-	Option *UserOptionService
 }
 
 func (s *Service) All(ctx context.Context) ([]*model.User, error) {
-	return getUserList(ctx, s.method, "users", nil)
+	return getList(ctx, s.method, "users", nil)
 }
 
 func (s *Service) One(ctx context.Context, id int) (*model.User, error) {
@@ -97,11 +95,11 @@ func (s *Service) One(ctx context.Context, id int) (*model.User, error) {
 	}
 
 	spath := path.Join("users", strconv.Itoa(id))
-	return getUser(ctx, s.method, spath)
+	return get(ctx, s.method, spath)
 }
 
 func (s *Service) Own(ctx context.Context) (*model.User, error) {
-	return getUser(ctx, s.method, "users/myself")
+	return get(ctx, s.method, "users/myself")
 }
 
 func (s *Service) Add(ctx context.Context, userID, password, name, mailAddress string, roleType model.Role) (*model.User, error) {
@@ -124,7 +122,7 @@ func (s *Service) Add(ctx context.Context, userID, password, name, mailAddress s
 
 	form.Set("userId", userID)
 
-	return addUser(ctx, s.method, "users", form)
+	return add(ctx, s.method, "users", form)
 }
 
 func (s *Service) Update(ctx context.Context, id int, opts ...core.RequestOption) (*model.User, error) {
@@ -137,7 +135,7 @@ func (s *Service) Update(ctx context.Context, id int, opts ...core.RequestOption
 	}
 
 	spath := path.Join("users", strconv.Itoa(id))
-	return updateUser(ctx, s.method, spath, form)
+	return update(ctx, s.method, spath, form)
 }
 
 func (s *Service) Delete(ctx context.Context, id int) (*model.User, error) {
@@ -146,7 +144,7 @@ func (s *Service) Delete(ctx context.Context, id int) (*model.User, error) {
 	}
 
 	spath := path.Join("users", strconv.Itoa(id))
-	return deleteUser(ctx, s.method, spath, nil)
+	return delete(ctx, s.method, spath, nil)
 }
 
 type ProjectService struct {
@@ -162,7 +160,7 @@ func (s *ProjectService) All(ctx context.Context, projectIDOrKey string, exclude
 	query.Set("excludeGroupMembers", strconv.FormatBool(excludeGroupMembers))
 
 	spath := path.Join("projects", projectIDOrKey, "users")
-	return getUserList(ctx, s.method, spath, query)
+	return getList(ctx, s.method, spath, query)
 }
 
 func (s *ProjectService) Add(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
@@ -178,7 +176,7 @@ func (s *ProjectService) Add(ctx context.Context, projectIDOrKey string, userID 
 	form.Set("userId", strconv.Itoa(userID))
 
 	spath := path.Join("projects", projectIDOrKey, "users")
-	return addUser(ctx, s.method, spath, form)
+	return add(ctx, s.method, spath, form)
 }
 
 func (s *ProjectService) Delete(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
@@ -194,7 +192,7 @@ func (s *ProjectService) Delete(ctx context.Context, projectIDOrKey string, user
 	form.Set("userId", strconv.Itoa(userID))
 
 	spath := path.Join("projects", projectIDOrKey, "users")
-	return deleteUser(ctx, s.method, spath, form)
+	return delete(ctx, s.method, spath, form)
 }
 
 func (s *ProjectService) AddAdmin(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
@@ -210,7 +208,7 @@ func (s *ProjectService) AddAdmin(ctx context.Context, projectIDOrKey string, us
 	form.Set("userId", strconv.Itoa(userID))
 
 	spath := path.Join("projects", projectIDOrKey, "administrators")
-	return addUser(ctx, s.method, spath, form)
+	return add(ctx, s.method, spath, form)
 }
 
 func (s *ProjectService) AdminAll(ctx context.Context, projectIDOrKey string) ([]*model.User, error) {
@@ -219,7 +217,7 @@ func (s *ProjectService) AdminAll(ctx context.Context, projectIDOrKey string) ([
 	}
 
 	spath := path.Join("projects", projectIDOrKey, "administrators")
-	return getUserList(ctx, s.method, spath, nil)
+	return getList(ctx, s.method, spath, nil)
 }
 
 func (s *ProjectService) DeleteAdmin(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
@@ -235,21 +233,20 @@ func (s *ProjectService) DeleteAdmin(ctx context.Context, projectIDOrKey string,
 	form.Set("userId", strconv.Itoa(userID))
 
 	spath := path.Join("projects", projectIDOrKey, "administrators")
-	return deleteUser(ctx, s.method, spath, form)
+	return delete(ctx, s.method, spath, form)
 }
 
 // ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewService(method *core.Method, option *core.OptionService) *Service {
+func NewService(method *core.Method) *Service {
 	return &Service{
 		method: method,
-		Option: NewUserOptionService(option),
 	}
 }
 
-func NewProjectService(method *core.Method, option *core.OptionService) *ProjectService {
+func NewProjectService(method *core.Method) *ProjectService {
 	return &ProjectService{
 		method: method,
 	}

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -79,7 +79,7 @@ func TestUserService_One(t *testing.T) {
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
-			s := user.NewUserService(method, nil)
+			s := user.NewService(method)
 
 			user, err := s.One(context.Background(), tc.id)
 
@@ -240,7 +240,7 @@ func TestUserService_Add(t *testing.T) {
 			if tc.mockPostFn != nil {
 				method.Post = tc.mockPostFn
 			}
-			s := user.NewUserService(method, nil)
+			s := user.NewService(method)
 
 			user, err := s.Add(context.Background(), tc.userID, tc.password, tc.name, tc.mailAddress, tc.roleType)
 
@@ -324,7 +324,7 @@ func TestUserService_All(t *testing.T) {
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
-			s := user.NewUserService(method, nil)
+			s := user.NewService(method)
 
 			users, err := s.All(context.Background())
 
@@ -515,7 +515,7 @@ func TestUserService_Update(t *testing.T) {
 			if tc.mockPatchFn != nil {
 				method.Patch = tc.mockPatchFn
 			}
-			s := user.NewUserService(method, nil)
+			s := user.NewService(method)
 
 			user, err := s.Update(context.Background(), tc.id, tc.opts...)
 
@@ -595,7 +595,7 @@ func TestUserService_Own(t *testing.T) {
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
-			s := user.NewUserService(method, nil)
+			s := user.NewService(method)
 
 			user, err := s.Own(context.Background())
 
@@ -684,7 +684,7 @@ func TestUserService_Delete(t *testing.T) {
 			if tc.mockDeleteFn != nil {
 				method.Delete = tc.mockDeleteFn
 			}
-			s := user.NewUserService(method, nil)
+			s := user.NewService(method)
 
 			user, err := s.Delete(context.Background(), tc.id)
 
@@ -809,7 +809,7 @@ func TestProjectUserService_All(t *testing.T) {
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
-			s := user.NewProjectUserService(method, nil)
+			s := user.NewProjectService(method)
 
 			users, err := s.All(context.Background(), tc.projectKey, tc.excludeGroupMembers)
 
@@ -920,7 +920,7 @@ func TestProjectUserService_Add(t *testing.T) {
 			if tc.mockPostFn != nil {
 				method.Post = tc.mockPostFn
 			}
-			s := user.NewProjectUserService(method, nil)
+			s := user.NewProjectService(method)
 
 			user, err := s.Add(context.Background(), tc.projectKey, tc.userID)
 
@@ -1051,7 +1051,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 			if tc.mockDeleteFn != nil {
 				method.Delete = tc.mockDeleteFn
 			}
-			s := user.NewProjectUserService(method, nil)
+			s := user.NewProjectService(method)
 
 			user, err := s.Delete(context.Background(), tc.projectKey, tc.userID)
 
@@ -1161,7 +1161,7 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 			if tc.mockPostFn != nil {
 				method.Post = tc.mockPostFn
 			}
-			s := user.NewProjectUserService(method, nil)
+			s := user.NewProjectService(method)
 
 			user, err := s.AddAdmin(context.Background(), tc.projectKey, tc.userID)
 
@@ -1219,7 +1219,7 @@ func TestProjectUserService_AdminAll(t *testing.T) {
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
-			s := user.NewProjectUserService(method, nil)
+			s := user.NewProjectService(method)
 
 			users, err := s.AdminAll(context.Background(), tc.projectKey)
 
@@ -1288,7 +1288,7 @@ func TestProjectUserService_DeleteAdmin(t *testing.T) {
 			if tc.mockDeleteFn != nil {
 				method.Delete = tc.mockDeleteFn
 			}
-			s := user.NewProjectUserService(method, nil)
+			s := user.NewProjectService(method)
 
 			user, err := s.DeleteAdmin(context.Background(), tc.projectKey, tc.userID)
 
@@ -1316,111 +1316,111 @@ func TestUserService_contextPropagation(t *testing.T) {
 		call func(t *testing.T)
 	}{
 		{"UserService.All", func(t *testing.T) {
-			s := user.NewUserService(&core.Method{
+			s := user.NewService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.All(ctx) //nolint:errcheck
 		}},
 		{"UserService.One", func(t *testing.T) {
-			s := user.NewUserService(&core.Method{
+			s := user.NewService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.One(ctx, 1) //nolint:errcheck
 		}},
 		{"UserService.Own", func(t *testing.T) {
-			s := user.NewUserService(&core.Method{
+			s := user.NewService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.Own(ctx) //nolint:errcheck
 		}},
 		{"UserService.Add", func(t *testing.T) {
-			s := user.NewUserService(&core.Method{
+			s := user.NewService(&core.Method{
 				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.Add(ctx, "u", "p", "n", "m@m.com", model.RoleAdministrator) //nolint:errcheck
 		}},
 		{"UserService.Update", func(t *testing.T) {
-			s := user.NewUserService(&core.Method{
+			s := user.NewService(&core.Method{
 				Patch: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
 		}},
 		{"UserService.Delete", func(t *testing.T) {
-			s := user.NewUserService(&core.Method{
+			s := user.NewService(&core.Method{
 				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.Delete(ctx, 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.All", func(t *testing.T) {
-			s := user.NewProjectUserService(&core.Method{
+			s := user.NewProjectService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.All(ctx, "TEST", false) //nolint:errcheck
 		}},
 		{"ProjectUserService.Add", func(t *testing.T) {
-			s := user.NewProjectUserService(&core.Method{
+			s := user.NewProjectService(&core.Method{
 				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.Add(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.Delete", func(t *testing.T) {
-			s := user.NewProjectUserService(&core.Method{
+			s := user.NewProjectService(&core.Method{
 				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.Delete(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.AddAdmin", func(t *testing.T) {
-			s := user.NewProjectUserService(&core.Method{
+			s := user.NewProjectService(&core.Method{
 				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.AddAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.AdminAll", func(t *testing.T) {
-			s := user.NewProjectUserService(&core.Method{
+			s := user.NewProjectService(&core.Method{
 				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.AdminAll(ctx, "TEST") //nolint:errcheck
 		}},
 		{"ProjectUserService.DeleteAdmin", func(t *testing.T) {
-			s := user.NewProjectUserService(&core.Method{
+			s := user.NewProjectService(&core.Method{
 				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 					assert.Same(t, sentinel, got.Value(ctxKey{}))
 					return nil, errors.New("stop")
 				},
-			}, nil)
+			})
 			s.DeleteAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},
 	}

--- a/internal/wiki/service.go
+++ b/internal/wiki/service.go
@@ -169,7 +169,7 @@ func (s *Service) Delete(ctx context.Context, wikiID int, opts ...core.RequestOp
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewService(method *core.Method, option *core.OptionService) *Service {
+func NewService(method *core.Method) *Service {
 	return &Service{
 		method: method,
 	}

--- a/internal/wiki/service.go
+++ b/internal/wiki/service.go
@@ -11,11 +11,11 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-type WikiService struct {
+type Service struct {
 	method *core.Method
 }
 
-func (s *WikiService) All(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Wiki, error) {
+func (s *Service) All(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Wiki, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (s *WikiService) All(ctx context.Context, projectIDOrKey string, opts ...co
 	return v, nil
 }
 
-func (s *WikiService) Count(ctx context.Context, projectIDOrKey string) (int, error) {
+func (s *Service) Count(ctx context.Context, projectIDOrKey string) (int, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return 0, err
 	}
@@ -62,7 +62,7 @@ func (s *WikiService) Count(ctx context.Context, projectIDOrKey string) (int, er
 	return v["count"], nil
 }
 
-func (s *WikiService) One(ctx context.Context, wikiID int) (*model.Wiki, error) {
+func (s *Service) One(ctx context.Context, wikiID int) (*model.Wiki, error) {
 	if err := validate.ValidateWikiID(wikiID); err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (s *WikiService) One(ctx context.Context, wikiID int) (*model.Wiki, error) 
 	return &v, nil
 }
 
-func (s *WikiService) Create(ctx context.Context, projectID int, name, content string, opts ...core.RequestOption) (*model.Wiki, error) {
+func (s *Service) Create(ctx context.Context, projectID int, name, content string, opts ...core.RequestOption) (*model.Wiki, error) {
 	if err := validate.ValidateProjectID(projectID); err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (s *WikiService) Create(ctx context.Context, projectID int, name, content s
 	return &v, nil
 }
 
-func (s *WikiService) Update(ctx context.Context, wikiID int, option core.RequestOption, opts ...core.RequestOption) (*model.Wiki, error) {
+func (s *Service) Update(ctx context.Context, wikiID int, option core.RequestOption, opts ...core.RequestOption) (*model.Wiki, error) {
 	if err := validate.ValidateWikiID(wikiID); err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (s *WikiService) Update(ctx context.Context, wikiID int, option core.Reques
 	return &v, nil
 }
 
-func (s *WikiService) Delete(ctx context.Context, wikiID int, opts ...core.RequestOption) (*model.Wiki, error) {
+func (s *Service) Delete(ctx context.Context, wikiID int, opts ...core.RequestOption) (*model.Wiki, error) {
 	if err := validate.ValidateWikiID(wikiID); err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (s *WikiService) Delete(ctx context.Context, wikiID int, opts ...core.Reque
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func NewWikiService(method *core.Method, option *core.OptionService) *WikiService {
-	return &WikiService{
+func NewService(method *core.Method, option *core.OptionService) *Service {
+	return &Service{
 		method: method,
 	}
 }

--- a/internal/wiki/service_test.go
+++ b/internal/wiki/service_test.go
@@ -132,7 +132,7 @@ func TestWikiService_All(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := wiki.NewWikiService(method, nil)
+			s := wiki.NewService(method)
 
 			wikis, err := s.All(context.Background(), tc.projectIDOrKey, tc.opts...)
 
@@ -233,7 +233,7 @@ func TestWikiService_Count(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := wiki.NewWikiService(method, nil)
+			s := wiki.NewService(method)
 
 			count, err := s.Count(context.Background(), tc.projectIDOrKey)
 
@@ -320,7 +320,7 @@ func TestWikiService_One(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := wiki.NewWikiService(method, nil)
+			s := wiki.NewService(method)
 
 			wiki, err := s.One(context.Background(), tc.wikiID)
 
@@ -482,7 +482,7 @@ func TestWikiService_Create(t *testing.T) {
 				method.Post = tc.mockPostFn
 			}
 
-			s := wiki.NewWikiService(method, nil)
+			s := wiki.NewService(method)
 
 			wiki, err := s.Create(context.Background(), tc.projectID, tc.name, tc.content, tc.opts...)
 
@@ -664,7 +664,7 @@ func TestWikiService_Update(t *testing.T) {
 				method.Patch = tc.mockPatchFn
 			}
 
-			s := wiki.NewWikiService(method, nil)
+			s := wiki.NewService(method)
 
 			wiki, err := s.Update(context.Background(), tc.wikiID, tc.option, tc.opts...)
 
@@ -778,7 +778,7 @@ func TestWikiService_Delete(t *testing.T) {
 				method.Delete = tc.mockDeleteFn
 			}
 
-			s := wiki.NewWikiService(method, nil)
+			s := wiki.NewService(method)
 
 			wiki, err := s.Delete(context.Background(), tc.wikiID, tc.opts...)
 
@@ -817,7 +817,7 @@ func TestWikiService_contextPropagation(t *testing.T) {
 				assert.Same(t, sentinel, got.Value(ctxKey{}))
 				return nil, errors.New("stop")
 			}
-			s := wiki.NewWikiService(m, nil)
+			s := wiki.NewService(m)
 			s.All(ctx, "TEST") //nolint:errcheck
 		}},
 		{"Count", func(t *testing.T, m *core.Method) {
@@ -825,7 +825,7 @@ func TestWikiService_contextPropagation(t *testing.T) {
 				assert.Same(t, sentinel, got.Value(ctxKey{}))
 				return nil, errors.New("stop")
 			}
-			s := wiki.NewWikiService(m, nil)
+			s := wiki.NewService(m)
 			s.Count(ctx, "TEST") //nolint:errcheck
 		}},
 		{"One", func(t *testing.T, m *core.Method) {
@@ -833,7 +833,7 @@ func TestWikiService_contextPropagation(t *testing.T) {
 				assert.Same(t, sentinel, got.Value(ctxKey{}))
 				return nil, errors.New("stop")
 			}
-			s := wiki.NewWikiService(m, nil)
+			s := wiki.NewService(m)
 			s.One(ctx, 1) //nolint:errcheck
 		}},
 		{"Create", func(t *testing.T, m *core.Method) {
@@ -841,7 +841,7 @@ func TestWikiService_contextPropagation(t *testing.T) {
 				assert.Same(t, sentinel, got.Value(ctxKey{}))
 				return nil, errors.New("stop")
 			}
-			s := wiki.NewWikiService(m, nil)
+			s := wiki.NewService(m)
 			s.Create(ctx, 1, "name", "content") //nolint:errcheck
 		}},
 		{"Update", func(t *testing.T, m *core.Method) {
@@ -849,7 +849,7 @@ func TestWikiService_contextPropagation(t *testing.T) {
 				assert.Same(t, sentinel, got.Value(ctxKey{}))
 				return nil, errors.New("stop")
 			}
-			s := wiki.NewWikiService(m, nil)
+			s := wiki.NewService(m)
 			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
 		}},
 		{"Delete", func(t *testing.T, m *core.Method) {
@@ -857,7 +857,7 @@ func TestWikiService_contextPropagation(t *testing.T) {
 				assert.Same(t, sentinel, got.Value(ctxKey{}))
 				return nil, errors.New("stop")
 			}
-			s := wiki.NewWikiService(m, nil)
+			s := wiki.NewService(m)
 			s.Delete(ctx, 1) //nolint:errcheck
 		}},
 	}

--- a/issue.go
+++ b/issue.go
@@ -3,7 +3,6 @@ package backlog
 import (
 	"context"
 
-	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/issue"
@@ -52,9 +51,3 @@ func newIssueAttachmentService(method *core.Method) *IssueAttachmentService {
 		base: attachment.NewIssueService(method),
 	}
 }
-
-// ──────────────────────────────────────────────────────────────
-//  (kept for reference: activity.ProjectService is used in project.go)
-// ──────────────────────────────────────────────────────────────
-
-var _ = activity.NewProjectService // suppress unused import if needed

--- a/issue.go
+++ b/issue.go
@@ -3,30 +3,23 @@ package backlog
 import (
 	"context"
 
+	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/issue"
 	"github.com/nattokin/go-backlog/internal/model"
 )
 
-// ──────────────────────────────────────────────────────────────
-//  IssueService
-// ──────────────────────────────────────────────────────────────
-
 // IssueService handles communication with the issue-related methods of the Backlog API.
 type IssueService struct {
-	base *issue.IssueService
+	base *issue.Service
 
 	Attachment *IssueAttachmentService
 }
 
-// ──────────────────────────────────────────────────────────────
-//  IssueAttachmentService
-// ──────────────────────────────────────────────────────────────
-
 // IssueAttachmentService handles communication with the issue attachment-related methods of the Backlog API.
 type IssueAttachmentService struct {
-	base *attachment.IssueAttachmentService
+	base *attachment.IssueService
 }
 
 // List returns a list of all attachments in the issue.
@@ -49,13 +42,19 @@ func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string
 
 func newIssueService(method *core.Method, option *core.OptionService) *IssueService {
 	return &IssueService{
-		base:       issue.NewIssueService(method, option),
+		base:       issue.NewService(method, option),
 		Attachment: newIssueAttachmentService(method),
 	}
 }
 
 func newIssueAttachmentService(method *core.Method) *IssueAttachmentService {
 	return &IssueAttachmentService{
-		base: attachment.NewIssueAttachmentService(method),
+		base: attachment.NewIssueService(method),
 	}
 }
+
+// ──────────────────────────────────────────────────────────────
+//  (kept for reference: activity.ProjectService is used in project.go)
+// ──────────────────────────────────────────────────────────────
+
+var _ = activity.NewProjectService // suppress unused import if needed

--- a/issue.go
+++ b/issue.go
@@ -39,9 +39,9 @@ func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func newIssueService(method *core.Method, option *core.OptionService) *IssueService {
+func newIssueService(method *core.Method) *IssueService {
 	return &IssueService{
-		base:       issue.NewService(method, option),
+		base:       issue.NewService(method),
 		Attachment: newIssueAttachmentService(method),
 	}
 }

--- a/project.go
+++ b/project.go
@@ -9,13 +9,9 @@ import (
 	"github.com/nattokin/go-backlog/internal/project"
 )
 
-// ──────────────────────────────────────────────────────────────
-//  ProjectService
-// ──────────────────────────────────────────────────────────────
-
 // ProjectService handles communication with the project-related methods of the Backlog API.
 type ProjectService struct {
-	base *project.ProjectService
+	base *project.Service
 
 	Activity *ProjectActivityService
 	User     *ProjectUserService
@@ -79,13 +75,9 @@ func (s *ProjectService) Delete(ctx context.Context, projectIDOrKey string) (*mo
 	return s.base.Delete(ctx, projectIDOrKey)
 }
 
-// ──────────────────────────────────────────────────────────────
-//  ProjectActivityService
-// ──────────────────────────────────────────────────────────────
-
 // ProjectActivityService handles communication with the project activities-related methods of the Backlog API.
 type ProjectActivityService struct {
-	base *activity.ProjectActivityService
+	base *activity.ProjectService
 }
 
 // List returns a list of activities in the project.
@@ -107,17 +99,17 @@ func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func newProjectService(method *core.Method, option *core.OptionService) *ProjectService {
+func newProjectService(method *core.Method, baseOptionService *core.OptionService) *ProjectService {
 	return &ProjectService{
-		base:     project.NewProjectService(method, option),
+		base:     project.NewService(method, baseOptionService),
 		Activity: newProjectActivityService(method),
-		User:     newProjectUserService(method, option),
-		Option:   newProjectOptionService(option),
+		User:     newProjectUserService(method, baseOptionService),
+		Option:   newProjectOptionService(baseOptionService),
 	}
 }
 
 func newProjectActivityService(method *core.Method) *ProjectActivityService {
 	return &ProjectActivityService{
-		base: activity.NewProjectActivityService(method),
+		base: activity.NewProjectService(method),
 	}
 }

--- a/project.go
+++ b/project.go
@@ -99,12 +99,12 @@ func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func newProjectService(method *core.Method, baseOptionService *core.OptionService) *ProjectService {
+func newProjectService(method *core.Method, option *core.OptionService) *ProjectService {
 	return &ProjectService{
-		base:     project.NewService(method, baseOptionService),
+		base:     project.NewService(method),
 		Activity: newProjectActivityService(method),
-		User:     newProjectUserService(method, baseOptionService),
-		Option:   newProjectOptionService(baseOptionService),
+		User:     newProjectUserService(method, option),
+		Option:   newProjectOptionService(option),
 	}
 }
 

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -9,24 +9,16 @@ import (
 	"github.com/nattokin/go-backlog/internal/pullrequest"
 )
 
-// ──────────────────────────────────────────────────────────────
-//  PullRequestService
-// ──────────────────────────────────────────────────────────────
-
 // PullRequestService handles communication with the pull request-related methods of the Backlog API.
 type PullRequestService struct {
-	base *pullrequest.PullRequestService
+	base *pullrequest.Service
 
 	Attachment *PullRequestAttachmentService
 }
 
-// ──────────────────────────────────────────────────────────────
-//  PullRequestAttachmentService
-// ──────────────────────────────────────────────────────────────
-
 // PullRequestAttachmentService handles communication with the pull request attachment-related methods of the Backlog API.
 type PullRequestAttachmentService struct {
-	base *attachment.PullRequestAttachmentService
+	base *attachment.PullRequestService
 }
 
 // List returns a list of all attachments in the pull request.
@@ -49,13 +41,13 @@ func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKe
 
 func newPullRequestService(method *core.Method) *PullRequestService {
 	return &PullRequestService{
-		base:       pullrequest.NewPullRequestService(method),
+		base:       pullrequest.NewService(method),
 		Attachment: newPullRequestAttachmentService(method),
 	}
 }
 
 func newPullRequestAttachmentService(method *core.Method) *PullRequestAttachmentService {
 	return &PullRequestAttachmentService{
-		base: attachment.NewPullRequestAttachmentService(method),
+		base: attachment.NewPullRequestService(method),
 	}
 }

--- a/space.go
+++ b/space.go
@@ -61,7 +61,7 @@ func (s *SpaceAttachmentService) Upload(ctx context.Context, fileName string, r 
 
 func newSpaceService(method *core.Method, option *core.OptionService) *SpaceService {
 	return &SpaceService{
-		base:       space.NewService(method, option),
+		base:       space.NewService(method),
 		Activity:   newSpaceActivityService(method, option),
 		Attachment: newSpaceAttachmentService(method),
 	}
@@ -69,8 +69,8 @@ func newSpaceService(method *core.Method, option *core.OptionService) *SpaceServ
 
 func newSpaceActivityService(method *core.Method, option *core.OptionService) *SpaceActivityService {
 	return &SpaceActivityService{
-		base:   activity.NewSpaceService(method, option),
-		Option: &ActivityOptionService{},
+		base:   activity.NewSpaceService(method),
+		Option: activity.NewActivityOptionService(option),
 	}
 }
 

--- a/space.go
+++ b/space.go
@@ -11,25 +11,17 @@ import (
 	"github.com/nattokin/go-backlog/internal/space"
 )
 
-// ──────────────────────────────────────────────────────────────
-//  SpaceService
-// ──────────────────────────────────────────────────────────────
-
 // SpaceService handles communication with the space-related methods of the Backlog API.
 type SpaceService struct {
-	base *space.SpaceService
+	base *space.Service
 
 	Activity   *SpaceActivityService
 	Attachment *SpaceAttachmentService
 }
 
-// ──────────────────────────────────────────────────────────────
-//  SpaceActivityService
-// ──────────────────────────────────────────────────────────────
-
 // SpaceActivityService handles communication with the space activities-related methods of the Backlog API.
 type SpaceActivityService struct {
-	base *activity.SpaceActivityService
+	base *activity.SpaceService
 
 	Option *ActivityOptionService
 }
@@ -49,13 +41,9 @@ func (s *SpaceActivityService) List(ctx context.Context, opts ...core.RequestOpt
 	return s.base.List(ctx, opts...)
 }
 
-// ──────────────────────────────────────────────────────────────
-//  SpaceAttachmentService
-// ──────────────────────────────────────────────────────────────
-
 // SpaceAttachmentService handles communication with the space attachment-related methods of the Backlog API.
 type SpaceAttachmentService struct {
-	base *attachment.SpaceAttachmentService
+	base *attachment.SpaceService
 }
 
 // Upload uploads any file to the space.
@@ -73,7 +61,7 @@ func (s *SpaceAttachmentService) Upload(ctx context.Context, fileName string, r 
 
 func newSpaceService(method *core.Method, option *core.OptionService) *SpaceService {
 	return &SpaceService{
-		base:       space.NewSpaceService(method, option),
+		base:       space.NewService(method, option),
 		Activity:   newSpaceActivityService(method, option),
 		Attachment: newSpaceAttachmentService(method),
 	}
@@ -81,13 +69,13 @@ func newSpaceService(method *core.Method, option *core.OptionService) *SpaceServ
 
 func newSpaceActivityService(method *core.Method, option *core.OptionService) *SpaceActivityService {
 	return &SpaceActivityService{
-		base:   activity.NewSpaceActivityService(method, option),
+		base:   activity.NewSpaceService(method, option),
 		Option: &ActivityOptionService{},
 	}
 }
 
 func newSpaceAttachmentService(method *core.Method) *SpaceAttachmentService {
 	return &SpaceAttachmentService{
-		base: attachment.NewSpaceAttachmentService(method),
+		base: attachment.NewSpaceService(method),
 	}
 }

--- a/user.go
+++ b/user.go
@@ -141,7 +141,7 @@ func (s *ProjectUserService) DeleteAdmin(ctx context.Context, projectIDOrKey str
 
 func newUserService(method *core.Method, option *core.OptionService) *UserService {
 	return &UserService{
-		base:     user.NewService(method, option),
+		base:     user.NewService(method),
 		Activity: newUserActivityService(method, option),
 		Option:   newUserOptionService(option),
 	}
@@ -149,13 +149,13 @@ func newUserService(method *core.Method, option *core.OptionService) *UserServic
 
 func newUserActivityService(method *core.Method, option *core.OptionService) *UserActivityService {
 	return &UserActivityService{
-		base:   activity.NewUserService(method, option),
+		base:   activity.NewUserService(method),
 		Option: &ActivityOptionService{},
 	}
 }
 
 func newProjectUserService(method *core.Method, option *core.OptionService) *ProjectUserService {
 	return &ProjectUserService{
-		base: user.NewProjectService(method, option),
+		base: user.NewProjectService(method),
 	}
 }

--- a/user.go
+++ b/user.go
@@ -9,13 +9,9 @@ import (
 	"github.com/nattokin/go-backlog/internal/user"
 )
 
-// ──────────────────────────────────────────────────────────────
-//  UserService
-// ──────────────────────────────────────────────────────────────
-
 // UserService has methods for user.
 type UserService struct {
-	base *user.UserService
+	base *user.Service
 
 	Activity *UserActivityService
 	Option   *UserOptionService
@@ -70,13 +66,9 @@ func (s *UserService) Delete(ctx context.Context, id int) (*model.User, error) {
 	return s.base.Delete(ctx, id)
 }
 
-// ──────────────────────────────────────────────────────────────
-//  UserActivityService
-// ──────────────────────────────────────────────────────────────
-
 // UserActivityService handles communication with the user activities-related methods of the Backlog API.
 type UserActivityService struct {
-	base *activity.UserActivityService
+	base *activity.UserService
 
 	Option *ActivityOptionService
 }
@@ -96,13 +88,9 @@ func (s *UserActivityService) List(ctx context.Context, userID int, opts ...core
 	return s.base.List(ctx, userID, opts...)
 }
 
-// ──────────────────────────────────────────────────────────────
-//  ProjectUserService
-// ──────────────────────────────────────────────────────────────
-
 // ProjectUserService has methods for user of project.
 type ProjectUserService struct {
-	base *user.ProjectUserService
+	base *user.ProjectService
 }
 
 // All returns all users in the project.
@@ -153,7 +141,7 @@ func (s *ProjectUserService) DeleteAdmin(ctx context.Context, projectIDOrKey str
 
 func newUserService(method *core.Method, option *core.OptionService) *UserService {
 	return &UserService{
-		base:     user.NewUserService(method, option),
+		base:     user.NewService(method, option),
 		Activity: newUserActivityService(method, option),
 		Option:   newUserOptionService(option),
 	}
@@ -161,13 +149,13 @@ func newUserService(method *core.Method, option *core.OptionService) *UserServic
 
 func newUserActivityService(method *core.Method, option *core.OptionService) *UserActivityService {
 	return &UserActivityService{
-		base:   activity.NewUserActivityService(method, option),
+		base:   activity.NewUserService(method, option),
 		Option: &ActivityOptionService{},
 	}
 }
 
 func newProjectUserService(method *core.Method, option *core.OptionService) *ProjectUserService {
 	return &ProjectUserService{
-		base: user.NewProjectUserService(method, option),
+		base: user.NewProjectService(method, option),
 	}
 }

--- a/wiki.go
+++ b/wiki.go
@@ -111,7 +111,7 @@ func (s *WikiAttachmentService) Remove(ctx context.Context, wikiID, attachmentID
 
 func newWikiService(method *core.Method, option *core.OptionService) *WikiService {
 	return &WikiService{
-		base:       wiki.NewService(method, option),
+		base:       wiki.NewService(method),
 		Attachment: newWikiAttachmentService(method),
 		Option:     newWikiOptionService(option),
 	}

--- a/wiki.go
+++ b/wiki.go
@@ -9,13 +9,9 @@ import (
 	"github.com/nattokin/go-backlog/internal/wiki"
 )
 
-// ──────────────────────────────────────────────────────────────
-//  WikiService
-// ──────────────────────────────────────────────────────────────
-
 // WikiService handles communication with the wiki-related methods of the Backlog API.
 type WikiService struct {
-	base *wiki.WikiService
+	base *wiki.Service
 
 	Attachment *WikiAttachmentService
 	Option     *WikiOptionService
@@ -83,13 +79,9 @@ func (s *WikiService) Delete(ctx context.Context, wikiID int, opts ...core.Reque
 	return s.base.Delete(ctx, wikiID, opts...)
 }
 
-// ──────────────────────────────────────────────────────────────
-//  WikiAttachmentService
-// ──────────────────────────────────────────────────────────────
-
 // WikiAttachmentService handles communication with the wiki attachment-related methods of the Backlog API.
 type WikiAttachmentService struct {
-	base *attachment.WikiAttachmentService
+	base *attachment.WikiService
 }
 
 // Attach attaches files uploaded to the space to the specified wiki.
@@ -119,7 +111,7 @@ func (s *WikiAttachmentService) Remove(ctx context.Context, wikiID, attachmentID
 
 func newWikiService(method *core.Method, option *core.OptionService) *WikiService {
 	return &WikiService{
-		base:       wiki.NewWikiService(method, option),
+		base:       wiki.NewService(method, option),
 		Attachment: newWikiAttachmentService(method),
 		Option:     newWikiOptionService(option),
 	}
@@ -127,6 +119,6 @@ func newWikiService(method *core.Method, option *core.OptionService) *WikiServic
 
 func newWikiAttachmentService(method *core.Method) *WikiAttachmentService {
 	return &WikiAttachmentService{
-		base: attachment.NewWikiAttachmentService(method),
+		base: attachment.NewWikiService(method),
 	}
 }


### PR DESCRIPTION
## Summary

Rename internal service type names to remove redundant package-name prefixes, following Go naming conventions.

In Go, the package name is part of the qualified identifier at the call site (e.g., `activity.ProjectActivityService` → `activity.ProjectService`), so embedding the package name in the type name is redundant. This PR applies that convention consistently across all `internal/*` service packages.

## Changes

### Type renames

| Package | Before | After |
|---|---|---|
| `internal/activity` | `ProjectActivityService` | `ProjectService` |
| `internal/activity` | `SpaceActivityService` | `SpaceService` |
| `internal/activity` | `UserActivityService` | `UserService` |
| `internal/attachment` | `IssueAttachmentService` | `IssueService` |
| `internal/attachment` | `PullRequestAttachmentService` | `PullRequestService` |
| `internal/attachment` | `SpaceAttachmentService` | `SpaceService` |
| `internal/attachment` | `WikiAttachmentService` | `WikiService` |
| `internal/issue` | `IssueService` | `Service` |
| `internal/project` | `ProjectService` | `Service` |
| `internal/pullrequest` | `PullRequestService` | `Service` |
| `internal/space` | `SpaceService` | `Service` |
| `internal/user` | `UserService` | `Service` |
| `internal/user` | `ProjectUserService` | `ProjectService` |
| `internal/wiki` | `WikiService` | `Service` |

### Constructor renames

Constructors are renamed to match (e.g., `NewIssueService` → `NewService`, `NewProjectActivityService` → `NewProjectService`).

### Unused parameter removal

The `option *core.OptionService` parameter was removed from several constructors where it was accepted but never used (`NewSpaceActivityService`, `NewUserActivityService`, `NewSpaceService`, `NewSpaceAttachmentService`, `NewWikiService`, etc.).

### Internal helper renames (unexported)

Package-level unexported helpers in `internal/user` and `internal/activity` were also simplified (e.g., `getUser` → `get`, `getUserList` → `getList`, `GetActivityList` → `getList`).

### Root package updates

All references in root-level files (`client.go`, `issue.go`, `project.go`, `pullrequest.go`, `space.go`, `user.go`, `wiki.go`) are updated to use the new type and constructor names.

## No behavior changes

This is a pure rename refactor. No logic is modified. All existing tests pass without change to test intent.