### PR TITLE
refactor: hide internal types from public API

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,8 @@
 package backlog
 
 import (
+	"net/http"
+
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
@@ -8,7 +10,12 @@ import (
 //  Doer interface (HTTP abstraction)
 // ──────────────────────────────────────────────────────────────
 
-type Doer = core.Doer
+// Doer defines the minimal interface required to perform HTTP requests.
+// It is compatible with *http.Client and allows injection of mock clients
+// for unit or integration testing.
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
 
 // ──────────────────────────────────────────────────────────────
 //  Client structure and initialization
@@ -38,8 +45,12 @@ type Client struct {
 // This function supports options returned by package-level functions,
 // such as:
 //   - WithDoer
-func NewClient(baseURL, token string, opts ...*core.ClientOption) (*Client, error) {
-	core, err := core.NewClient(baseURL, token, opts...)
+func NewClient(baseURL, token string, opts ...*ClientOption) (*Client, error) {
+	coreOpts := make([]*core.ClientOption, len(opts))
+	for i, o := range opts {
+		coreOpts[i] = o.core
+	}
+	core, err := core.NewClient(baseURL, token, coreOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -77,12 +88,16 @@ func initServices(c *Client) {
 //  Client options
 // ──────────────────────────────────────────────────────────────
 
-type ClientOption = core.ClientOption
+// ClientOption defines a functional option for configuring a Client.
+// It is used to change the default behavior of the Client.
+type ClientOption struct {
+	core *core.ClientOption
+}
 
 // WithDoer returns a ClientOption that sets the HTTP client (Doer) for the Client.
 // This is useful for providing a custom *http.Client or a mock implementation during testing.
 //
 // If this option is not provided, http.DefaultClient is used by default.
-func WithDoer(doer Doer) *core.ClientOption {
-	return core.WithDoer(doer)
+func WithDoer(doer Doer) *ClientOption {
+	return &ClientOption{core: core.WithDoer(doer)}
 }

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -20,9 +20,6 @@ const (
 //  Doer interface (HTTP abstraction)
 // ──────────────────────────────────────────────────────────────
 
-// Doer defines the minimal interface required to perform HTTP requests.
-// It is compatible with *http.Client and allows injection of mock clients
-// for unit or integration testing.
 type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }

--- a/internal/core/client_option.go
+++ b/internal/core/client_option.go
@@ -10,8 +10,6 @@ import (
 //  Client options
 // ──────────────────────────────────────────────────────────────
 
-// ClientOption defines a functional option for configuring a Client.
-// It is used to change the default behavior of the Client.
 type ClientOption struct {
 	set func(config *clientConfig)
 }

--- a/option.go
+++ b/option.go
@@ -1,11 +1,17 @@
 package backlog
 
 import (
+	"net/url"
+
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
 )
 
-type RequestOption = core.RequestOption
+type RequestOption interface {
+	Key() string
+	Check() error
+	Set(url.Values) error
+}
 
 // ──────────────────────────────────────────────────────────────
 //  ActivityOptionService
@@ -17,27 +23,27 @@ type ActivityOptionService struct {
 }
 
 // WithActivityTypeIDs filters activities by type IDs.
-func (s *ActivityOptionService) WithActivityTypeIDs(typeIDs []int) core.RequestOption {
+func (s *ActivityOptionService) WithActivityTypeIDs(typeIDs []int) RequestOption {
 	return s.base.WithActivityTypeIDs(typeIDs)
 }
 
 // WithMinID filters activities whose ID is greater than or equal to id.
-func (s *ActivityOptionService) WithMinID(id int) core.RequestOption {
+func (s *ActivityOptionService) WithMinID(id int) RequestOption {
 	return s.base.WithMinID(id)
 }
 
 // WithMaxID filters activities whose ID is less than or equal to id.
-func (s *ActivityOptionService) WithMaxID(id int) core.RequestOption {
+func (s *ActivityOptionService) WithMaxID(id int) RequestOption {
 	return s.base.WithMaxID(id)
 }
 
 // WithCount sets the number of activities to retrieve.
-func (s *ActivityOptionService) WithCount(count int) core.RequestOption {
+func (s *ActivityOptionService) WithCount(count int) RequestOption {
 	return s.base.WithCount(count)
 }
 
 // WithOrder sets the sort order of results.
-func (s *ActivityOptionService) WithOrder(order model.Order) core.RequestOption {
+func (s *ActivityOptionService) WithOrder(order model.Order) RequestOption {
 	return s.base.WithOrder(order)
 }
 
@@ -47,4 +53,16 @@ func (s *ActivityOptionService) WithOrder(order model.Order) core.RequestOption 
 
 func newActivityOptionService(option *core.OptionService) *ActivityOptionService {
 	return &ActivityOptionService{base: option}
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Helpers
+// ──────────────────────────────────────────────────────────────
+
+func toCoreOptions(opts []RequestOption) []core.RequestOption {
+	coreOpts := make([]core.RequestOption, len(opts))
+	for i, o := range opts {
+		coreOpts[i] = o
+	}
+	return coreOpts
 }

--- a/option_test.go
+++ b/option_test.go
@@ -21,7 +21,7 @@ func TestActivityOptionService(t *testing.T) {
 	// --- Integer options ------------------------------------------------------------
 	t.Run("integer-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    core.RequestOption
+			option    backlog.RequestOption
 			key       string
 			wantValue int
 		}{
@@ -57,7 +57,7 @@ func TestActivityOptionService(t *testing.T) {
 	// --- Enum options ---------------------------------------------------------------
 	t.Run("enum-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    core.RequestOption
+			option    backlog.RequestOption
 			key       string
 			wantValue string
 		}{
@@ -88,7 +88,7 @@ func TestActivityOptionService(t *testing.T) {
 	// --- Special options -------------------------------------------------------------
 	t.Run("special-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    core.RequestOption
+			option    backlog.RequestOption
 			key       string
 			wantValue []int
 		}{

--- a/project.go
+++ b/project.go
@@ -30,8 +30,8 @@ type ProjectService struct {
 //   - WithQueryArchived
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-list
-func (s *ProjectService) All(ctx context.Context, opts ...core.RequestOption) ([]*model.Project, error) {
-	return s.base.All(ctx, opts...)
+func (s *ProjectService) All(ctx context.Context, opts ...RequestOption) ([]*model.Project, error) {
+	return s.base.All(ctx, toCoreOptions(opts)...)
 }
 
 // One returns one of the projects searched by ID or key.
@@ -51,8 +51,8 @@ func (s *ProjectService) One(ctx context.Context, projectIDOrKey string) (*model
 //   - WithTextFormattingRule
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project
-func (s *ProjectService) Create(ctx context.Context, key, name string, opts ...core.RequestOption) (*model.Project, error) {
-	return s.base.Create(ctx, key, name, opts...)
+func (s *ProjectService) Create(ctx context.Context, key, name string, opts ...RequestOption) (*model.Project, error) {
+	return s.base.Create(ctx, key, name, toCoreOptions(opts)...)
 }
 
 // Update updates a project.
@@ -68,8 +68,8 @@ func (s *ProjectService) Create(ctx context.Context, key, name string, opts ...c
 //   - WithTextFormattingRule
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-project
-func (s *ProjectService) Update(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) (*model.Project, error) {
-	return s.base.Update(ctx, projectIDOrKey, opts...)
+func (s *ProjectService) Update(ctx context.Context, projectIDOrKey string, opts ...RequestOption) (*model.Project, error) {
+	return s.base.Update(ctx, projectIDOrKey, toCoreOptions(opts)...)
 }
 
 // Delete deletes a project.
@@ -99,8 +99,8 @@ type ProjectActivityService struct {
 //   - WithOrder
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates
-func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Activity, error) {
-	return s.base.List(ctx, projectIDOrKey, opts...)
+func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*model.Activity, error) {
+	return s.base.List(ctx, projectIDOrKey, toCoreOptions(opts)...)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -114,42 +114,42 @@ type ProjectOptionService struct {
 }
 
 // WithAll sets whether to include all projects.
-func (s *ProjectOptionService) WithAll(enabled bool) core.RequestOption {
+func (s *ProjectOptionService) WithAll(enabled bool) RequestOption {
 	return s.base.WithAll(enabled)
 }
 
 // WithArchived sets whether to include archived projects.
-func (s *ProjectOptionService) WithArchived(enabled bool) core.RequestOption {
+func (s *ProjectOptionService) WithArchived(enabled bool) RequestOption {
 	return s.base.WithArchived(enabled)
 }
 
 // WithChartEnabled sets whether the project uses a chart.
-func (s *ProjectOptionService) WithChartEnabled(enabled bool) core.RequestOption {
+func (s *ProjectOptionService) WithChartEnabled(enabled bool) RequestOption {
 	return s.base.WithChartEnabled(enabled)
 }
 
 // WithKey sets the project key.
-func (s *ProjectOptionService) WithKey(key string) core.RequestOption {
+func (s *ProjectOptionService) WithKey(key string) RequestOption {
 	return s.base.WithKey(key)
 }
 
 // WithName sets the project name.
-func (s *ProjectOptionService) WithName(name string) core.RequestOption {
+func (s *ProjectOptionService) WithName(name string) RequestOption {
 	return s.base.WithName(name)
 }
 
 // WithProjectLeaderCanEditProjectLeader sets whether a project leader can edit other project leaders.
-func (s *ProjectOptionService) WithProjectLeaderCanEditProjectLeader(enabled bool) core.RequestOption {
+func (s *ProjectOptionService) WithProjectLeaderCanEditProjectLeader(enabled bool) RequestOption {
 	return s.base.WithProjectLeaderCanEditProjectLeader(enabled)
 }
 
 // WithSubtaskingEnabled sets whether subtasking is enabled.
-func (s *ProjectOptionService) WithSubtaskingEnabled(enabled bool) core.RequestOption {
+func (s *ProjectOptionService) WithSubtaskingEnabled(enabled bool) RequestOption {
 	return s.base.WithSubtaskingEnabled(enabled)
 }
 
 // WithTextFormattingRule sets the text formatting rule.
-func (s *ProjectOptionService) WithTextFormattingRule(format model.Format) core.RequestOption {
+func (s *ProjectOptionService) WithTextFormattingRule(format model.Format) RequestOption {
 	return s.base.WithTextFormattingRule(format)
 }
 

--- a/project_test.go
+++ b/project_test.go
@@ -27,13 +27,14 @@ func TestProjectService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects", req.URL.Path)
+				assert.Equal(t, "true", req.URL.Query().Get("archived"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.ListJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.All(ctx)
+				got, err := c.Project.All(ctx, c.Project.Option.WithArchived(true))
 				require.NoError(t, err)
 				assert.Len(t, got, 3)
 			},
@@ -60,13 +61,14 @@ func TestProjectService(t *testing.T) {
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "TEST", req.PostForm.Get("key"))
 				assert.Equal(t, "test", req.PostForm.Get("name"))
+				assert.Equal(t, "true", req.PostForm.Get("chartEnabled"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.Create(ctx, "TEST", "test")
+				got, err := c.Project.Create(ctx, "TEST", "test", c.Project.Option.WithChartEnabled(true))
 				require.NoError(t, err)
 				assert.Equal(t, "TEST", got.ProjectKey)
 			},
@@ -75,13 +77,15 @@ func TestProjectService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodPatch, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "new-name", req.PostForm.Get("name"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.Update(ctx, "TEST")
+				got, err := c.Project.Update(ctx, "TEST", c.Project.Option.WithName("new-name"))
 				require.NoError(t, err)
 				assert.Equal(t, "TEST", got.ProjectKey)
 			},
@@ -125,13 +129,14 @@ func TestProjectActivityService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/activities", req.URL.Path)
+				assert.Equal(t, "10", req.URL.Query().Get("count"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.ListJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.Activity.List(ctx, "TEST")
+				got, err := c.Project.Activity.List(ctx, "TEST", c.Project.Activity.Option.WithCount(10))
 				require.NoError(t, err)
 				assert.Len(t, got, 1)
 			},

--- a/project_test.go
+++ b/project_test.go
@@ -155,7 +155,7 @@ func TestProjectOptionService(t *testing.T) {
 	s := c.Project.Option
 
 	cases := map[string]struct {
-		option  core.RequestOption
+		option  backlog.RequestOption
 		wantKey string
 	}{
 		"WithAll": {

--- a/space.go
+++ b/space.go
@@ -45,8 +45,8 @@ type SpaceActivityService struct {
 //   - WithOrder
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-recent-updates
-func (s *SpaceActivityService) List(ctx context.Context, opts ...core.RequestOption) ([]*model.Activity, error) {
-	return s.base.List(ctx, opts...)
+func (s *SpaceActivityService) List(ctx context.Context, opts ...RequestOption) ([]*model.Activity, error) {
+	return s.base.List(ctx, toCoreOptions(opts)...)
 }
 
 // SpaceAttachmentService handles communication with the space attachment-related methods of the Backlog API.

--- a/space_test.go
+++ b/space_test.go
@@ -27,13 +27,14 @@ func TestSpaceActivityService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/space/activities", req.URL.Path)
+				assert.Equal(t, "20", req.URL.Query().Get("count"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.ListJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Space.Activity.List(ctx)
+				got, err := c.Space.Activity.List(ctx, c.Space.Activity.Option.WithCount(20))
 				require.NoError(t, err)
 				assert.Len(t, got, 1)
 			},

--- a/user.go
+++ b/user.go
@@ -59,8 +59,8 @@ func (s *UserService) Add(ctx context.Context, userID, password, name, mailAddre
 //   - WithRoleType
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-user
-func (s *UserService) Update(ctx context.Context, id int, opts ...core.RequestOption) (*model.User, error) {
-	return s.base.Update(ctx, id, opts...)
+func (s *UserService) Update(ctx context.Context, id int, opts ...RequestOption) (*model.User, error) {
+	return s.base.Update(ctx, id, toCoreOptions(opts)...)
 }
 
 // Delete deletes a user from your space.
@@ -92,8 +92,8 @@ type UserActivityService struct {
 //   - WithOrder
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates
-func (s *UserActivityService) List(ctx context.Context, userID int, opts ...core.RequestOption) ([]*model.Activity, error) {
-	return s.base.List(ctx, userID, opts...)
+func (s *UserActivityService) List(ctx context.Context, userID int, opts ...RequestOption) ([]*model.Activity, error) {
+	return s.base.List(ctx, userID, toCoreOptions(opts)...)
 }
 
 // ProjectUserService has methods for user of project.
@@ -154,32 +154,32 @@ type UserOptionService struct {
 }
 
 // WithMailAddress sets the mail address of a user.
-func (s *UserOptionService) WithMailAddress(mail string) core.RequestOption {
+func (s *UserOptionService) WithMailAddress(mail string) RequestOption {
 	return s.base.WithMailAddress(mail)
 }
 
 // WithName sets the name of a user.
-func (s *UserOptionService) WithName(name string) core.RequestOption {
+func (s *UserOptionService) WithName(name string) RequestOption {
 	return s.base.WithName(name)
 }
 
 // WithPassword sets the password of a user.
-func (s *UserOptionService) WithPassword(password string) core.RequestOption {
+func (s *UserOptionService) WithPassword(password string) RequestOption {
 	return s.base.WithPassword(password)
 }
 
 // WithRoleType sets the role type of a user.
-func (s *UserOptionService) WithRoleType(role model.Role) core.RequestOption {
+func (s *UserOptionService) WithRoleType(role model.Role) RequestOption {
 	return s.base.WithRoleType(role)
 }
 
 // WithSendMail sets whether to send a mail notification.
-func (s *UserOptionService) WithSendMail(enabled bool) core.RequestOption {
+func (s *UserOptionService) WithSendMail(enabled bool) RequestOption {
 	return s.base.WithSendMail(enabled)
 }
 
 // WithUserID sets the user ID.
-func (s *UserOptionService) WithUserID(id int) core.RequestOption {
+func (s *UserOptionService) WithUserID(id int) RequestOption {
 	return s.base.WithUserID(id)
 }
 

--- a/user_test.go
+++ b/user_test.go
@@ -217,13 +217,15 @@ func TestUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodPatch, req.Method)
 				assert.Equal(t, "/api/v2/users/1", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "updated-user", req.PostForm.Get("name"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.User.Update(ctx, 1)
+				got, err := c.User.Update(ctx, 1, c.User.Option.WithName("updated-user"))
 				require.NoError(t, err)
 				assert.Equal(t, "admin", got.UserID)
 			},
@@ -272,13 +274,14 @@ func TestUserActivityService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/1/activities", req.URL.Path)
+				assert.Equal(t, "5", req.URL.Query().Get("minId"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.ListJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.User.Activity.List(ctx, 1)
+				got, err := c.User.Activity.List(ctx, 1, c.User.Activity.Option.WithMinID(5))
 				require.NoError(t, err)
 				assert.Len(t, got, 1)
 			},

--- a/user_test.go
+++ b/user_test.go
@@ -304,7 +304,7 @@ func TestUserOptionService(t *testing.T) {
 	// --- Boolean options ------------------------------------------------------------
 	t.Run("boolean-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    core.RequestOption
+			option    backlog.RequestOption
 			key       string
 			wantValue bool
 		}{
@@ -330,7 +330,7 @@ func TestUserOptionService(t *testing.T) {
 	// --- Integer options ------------------------------------------------------------
 	t.Run("integer-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    core.RequestOption
+			option    backlog.RequestOption
 			key       string
 			wantValue int
 		}{
@@ -361,7 +361,7 @@ func TestUserOptionService(t *testing.T) {
 	// --- String options -------------------------------------------------------------
 	t.Run("string-options", func(t *testing.T) {
 		cases := map[string]struct {
-			option    core.RequestOption
+			option    backlog.RequestOption
 			key       string
 			wantValue string
 		}{

--- a/wiki.go
+++ b/wiki.go
@@ -28,8 +28,8 @@ type WikiService struct {
 //   - WithKeyword
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-list
-func (s *WikiService) All(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Wiki, error) {
-	return s.base.All(ctx, projectIDOrKey, opts...)
+func (s *WikiService) All(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*model.Wiki, error) {
+	return s.base.All(ctx, projectIDOrKey, toCoreOptions(opts)...)
 }
 
 // Count returns the number of wiki pages in the project.
@@ -53,8 +53,8 @@ func (s *WikiService) One(ctx context.Context, wikiID int) (*model.Wiki, error) 
 //   - WithMailNotify
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-wiki-page
-func (s *WikiService) Create(ctx context.Context, projectID int, name, content string, opts ...core.RequestOption) (*model.Wiki, error) {
-	return s.base.Create(ctx, projectID, name, content, opts...)
+func (s *WikiService) Create(ctx context.Context, projectID int, name, content string, opts ...RequestOption) (*model.Wiki, error) {
+	return s.base.Create(ctx, projectID, name, content, toCoreOptions(opts)...)
 }
 
 // Update updates a wiki page.
@@ -66,15 +66,15 @@ func (s *WikiService) Create(ctx context.Context, projectID int, name, content s
 //   - WithName
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-wiki-page
-func (s *WikiService) Update(ctx context.Context, wikiID int, option core.RequestOption, opts ...core.RequestOption) (*model.Wiki, error) {
-	return s.base.Update(ctx, wikiID, option, opts...)
+func (s *WikiService) Update(ctx context.Context, wikiID int, option RequestOption, opts ...RequestOption) (*model.Wiki, error) {
+	return s.base.Update(ctx, wikiID, option, toCoreOptions(opts)...)
 }
 
 // Delete deletes a wiki page.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-wiki-page
-func (s *WikiService) Delete(ctx context.Context, wikiID int, opts ...core.RequestOption) (*model.Wiki, error) {
-	return s.base.Delete(ctx, wikiID, opts...)
+func (s *WikiService) Delete(ctx context.Context, wikiID int, opts ...RequestOption) (*model.Wiki, error) {
+	return s.base.Delete(ctx, wikiID, toCoreOptions(opts)...)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -118,22 +118,22 @@ type WikiOptionService struct {
 }
 
 // WithKeyword filters wiki pages by keyword.
-func (s *WikiOptionService) WithKeyword(keyword string) core.RequestOption {
+func (s *WikiOptionService) WithKeyword(keyword string) RequestOption {
 	return s.base.WithKeyword(keyword)
 }
 
 // WithContent sets the content of a wiki page.
-func (s *WikiOptionService) WithContent(content string) core.RequestOption {
+func (s *WikiOptionService) WithContent(content string) RequestOption {
 	return s.base.WithContent(content)
 }
 
 // WithMailNotify sets whether to send a mail notification.
-func (s *WikiOptionService) WithMailNotify(enabled bool) core.RequestOption {
+func (s *WikiOptionService) WithMailNotify(enabled bool) RequestOption {
 	return s.base.WithMailNotify(enabled)
 }
 
 // WithName sets the name of a wiki page.
-func (s *WikiOptionService) WithName(name string) core.RequestOption {
+func (s *WikiOptionService) WithName(name string) RequestOption {
 	return s.base.WithName(name)
 }
 

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,8 +110,11 @@ func TestWikiService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34", req.URL.Path)
-				require.NoError(t, req.ParseForm())
-				assert.Equal(t, "true", req.PostForm.Get("mailNotify"))
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				form, err := url.ParseQuery(string(body))
+				require.NoError(t, err)
+				assert.Equal(t, "true", form.Get("mailNotify"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -208,7 +208,7 @@ func TestWikiOptionService(t *testing.T) {
 	s := c.Wiki.Option
 
 	cases := map[string]struct {
-		option  core.RequestOption
+		option  backlog.RequestOption
 		wantKey string
 	}{
 		"WithKeyword": {

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -26,13 +26,14 @@ func TestWikiService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis", req.URL.Path)
+				assert.Equal(t, "backlog", req.URL.Query().Get("keyword"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.ListJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Wiki.All(ctx, "TEST")
+				got, err := c.Wiki.All(ctx, "TEST", c.Wiki.Option.WithKeyword("backlog"))
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 			},
@@ -75,13 +76,14 @@ func TestWikiService(t *testing.T) {
 				assert.Equal(t, "56", req.PostForm.Get("projectId"))
 				assert.Equal(t, "Test Wiki", req.PostForm.Get("name"))
 				assert.Equal(t, "content", req.PostForm.Get("content"))
+				assert.Equal(t, "true", req.PostForm.Get("mailNotify"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MinimumJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Wiki.Create(ctx, 56, "Test Wiki", "content")
+				got, err := c.Wiki.Create(ctx, 56, "Test Wiki", "content", c.Wiki.Option.WithMailNotify(true))
 				require.NoError(t, err)
 				assert.Equal(t, "Minimum Wiki Page", got.Name)
 			},
@@ -107,13 +109,15 @@ func TestWikiService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "true", req.PostForm.Get("mailNotify"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Wiki.Delete(ctx, 34)
+				got, err := c.Wiki.Delete(ctx, 34, c.Wiki.Option.WithMailNotify(true))
 				require.NoError(t, err)
 				assert.Equal(t, 34, got.ID)
 			},


### PR DESCRIPTION
## Summary

Expose `Doer`, `ClientOption`, and `RequestOption` as proper public types defined in the root `backlog` package, removing the `= core.Xxx` type aliases that leaked internal package types into the public API.

## Changes

### `client.go`
- Define `Doer` interface directly in `package backlog` (instead of `type Doer = core.Doer`)
- Define `ClientOption` as a wrapper struct holding `*core.ClientOption` (instead of `type ClientOption = core.ClientOption`)
- `NewClient` now accepts `...*ClientOption` and converts to `[]*core.ClientOption` internally
- `WithDoer` now returns `*ClientOption`

### `option.go`
- Define `RequestOption` as an interface in `package backlog` (instead of `type RequestOption = core.RequestOption`)
- Add `toCoreOptions` helper to convert `[]RequestOption` → `[]core.RequestOption`
- All `XxxOptionService` methods now return `RequestOption` instead of `core.RequestOption`
- All service methods accepting opts now take `...RequestOption` and pass through `toCoreOptions`

### `internal/core/client.go` / `internal/core/client_option.go`
- Remove doc comments moved to the root package definitions

### Test files (`option_test.go`, `project_test.go`, `user_test.go`, `wiki_test.go`)
- Update field types from `core.RequestOption` to `backlog.RequestOption`

Closes #180 