### PR TITLE
refactor!: define error types in root package and wrap service errors via convertError

### DIFF
--- a/client.go
+++ b/client.go
@@ -50,18 +50,18 @@ func NewClient(baseURL, token string, opts ...*ClientOption) (*Client, error) {
 	for i, o := range opts {
 		coreOpts[i] = o.core
 	}
-	core, err := core.NewClient(baseURL, token, coreOpts...)
+	c, err := core.NewClient(baseURL, token, coreOpts...)
 	if err != nil {
-		return nil, err
+		return nil, convertError(err)
 	}
 
-	c := &Client{
-		core: core,
+	client := &Client{
+		core: c,
 	}
 
-	initServices(c)
+	initServices(client)
 
-	return c, nil
+	return client, nil
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/client_test.go
+++ b/client_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
@@ -52,7 +51,7 @@ func TestNewClient(t *testing.T) {
 	t.Run("error-core.NewClient", func(t *testing.T) {
 		c, err := NewClient("", "")
 		require.Error(t, err)
-		assert.IsType(t, &core.InternalClientError{}, err)
+		assert.IsType(t, &InternalClientError{}, err)
 		assert.Nil(t, c)
 	})
 }

--- a/error.go
+++ b/error.go
@@ -28,7 +28,7 @@ func (e *Error) Error() string {
 
 // APIResponseError represents Error Response of Backlog API.
 type APIResponseError struct {
-	StatusCode int      // HTTP status code (4xx or 5xx)
+	StatusCode int // HTTP status code (4xx or 5xx)
 	Errors     []*Error
 }
 

--- a/error.go
+++ b/error.go
@@ -1,16 +1,116 @@
 package backlog
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-type Error = core.Error
+// Error represents one of Backlog API response errors.
+type Error struct {
+	// Message is the detailed error message from the API.
+	Message  string
+	Code     int
+	MoreInfo string
+}
 
-type InternalClientError = core.InternalClientError
+// Error returns the API error message.
+func (e *Error) Error() string {
+	msg := fmt.Sprintf("Message:%s, Code:%d", e.Message, e.Code)
 
-type APIResponseError = core.APIResponseError
+	if e.MoreInfo == "" {
+		return msg
+	}
+
+	return msg + ", MoreInfo:" + e.MoreInfo
+}
+
+// APIResponseError represents Error Response of Backlog API.
+type APIResponseError struct {
+	StatusCode int      // HTTP status code (4xx or 5xx)
+	Errors     []*Error
+}
+
+// Error returns all error messages in APIResponseError.
+func (e *APIResponseError) Error() string {
+	msgs := make([]string, len(e.Errors))
+
+	for i, err := range e.Errors {
+		msgs[i] = err.Error()
+	}
+
+	return fmt.Sprintf("Status Code:%d\n%s", e.StatusCode, strings.Join(msgs, "\n"))
+}
 
 // InvalidOptionKeyError represents an error for an invalid option value.
-type InvalidOptionKeyError = core.InvalidOptionKeyError
+type InvalidOptionKeyError struct {
+	Invalid   string
+	ValidList []string
+}
 
-type ValidationError = core.ValidationError
+// Error returns the error message for an invalid option key.
+func (e *InvalidOptionKeyError) Error() string {
+	return fmt.Sprintf("invalid option key:%s, allowed option keys:%s", e.Invalid, strings.Join(e.ValidList, ","))
+}
+
+// ValidationError represents an argument validation error.
+type ValidationError struct {
+	message string
+}
+
+// Error returns the validation error message.
+func (e *ValidationError) Error() string {
+	return e.message
+}
+
+// InternalClientError represents client-side configuration or usage errors.
+// It is distinct from API-level errors and indicates issues like missing Token
+// or malformed base URL.
+type InternalClientError struct {
+	msg string
+}
+
+// Error returns the internal client error message.
+func (e *InternalClientError) Error() string {
+	return e.msg
+}
+
+// convertError converts an error returned from internal packages into the
+// corresponding root-package error type. This prevents internal types from
+// leaking into the public API surface.
+//
+// Only error types that core returns directly (without wrapping) are converted
+// here; *Error is excluded because it is never returned standalone.
+func convertError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch e := err.(type) {
+	case *core.APIResponseError:
+		out := &APIResponseError{
+			StatusCode: e.StatusCode,
+			Errors:     make([]*Error, len(e.Errors)),
+		}
+		for i, ce := range e.Errors {
+			out.Errors[i] = &Error{
+				Message:  ce.Message,
+				Code:     ce.Code,
+				MoreInfo: ce.MoreInfo,
+			}
+		}
+		return out
+	case *core.InvalidOptionKeyError:
+		return &InvalidOptionKeyError{
+			Invalid:   e.Invalid,
+			ValidList: e.ValidList,
+		}
+	case *core.ValidationError:
+		return &ValidationError{message: e.Error()}
+	case *core.InternalClientError:
+		return &InternalClientError{msg: e.Error()}
+	default:
+		return err
+	}
+}

--- a/error.go
+++ b/error.go
@@ -1,13 +1,11 @@
 package backlog
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-// Error represents one of Backlog API response errors.
+// Error represents one of the individual error entries in a Backlog API response.
+// It is a data structure used for decoding API responses and is not an error itself.
 type Error struct {
 	// Message is the detailed error message from the API.
 	Message  string
@@ -15,66 +13,61 @@ type Error struct {
 	MoreInfo string
 }
 
-// Error returns the API error message.
-func (e *Error) Error() string {
-	msg := fmt.Sprintf("Message:%s, Code:%d", e.Message, e.Code)
-
-	if e.MoreInfo == "" {
-		return msg
-	}
-
-	return msg + ", MoreInfo:" + e.MoreInfo
-}
-
-// APIResponseError represents Error Response of Backlog API.
+// APIResponseError represents an error response from the Backlog API.
 type APIResponseError struct {
-	StatusCode int // HTTP status code (4xx or 5xx)
-	Errors     []*Error
+	core *core.APIResponseError
 }
 
-// Error returns all error messages in APIResponseError.
-func (e *APIResponseError) Error() string {
-	msgs := make([]string, len(e.Errors))
+// Error implements the error interface.
+func (e *APIResponseError) Error() string { return e.core.Error() }
 
-	for i, err := range e.Errors {
-		msgs[i] = err.Error()
+// StatusCode returns the HTTP status code of the error response.
+func (e *APIResponseError) StatusCode() int { return e.core.StatusCode }
+
+// Errors returns the individual error entries in the response.
+func (e *APIResponseError) Errors() []*Error {
+	out := make([]*Error, len(e.core.Errors))
+	for i, ce := range e.core.Errors {
+		out[i] = &Error{
+			Message:  ce.Message,
+			Code:     ce.Code,
+			MoreInfo: ce.MoreInfo,
+		}
 	}
-
-	return fmt.Sprintf("Status Code:%d\n%s", e.StatusCode, strings.Join(msgs, "\n"))
+	return out
 }
 
-// InvalidOptionKeyError represents an error for an invalid option value.
+// InvalidOptionKeyError represents an error for an invalid option key.
 type InvalidOptionKeyError struct {
-	Invalid   string
-	ValidList []string
+	core *core.InvalidOptionKeyError
 }
 
-// Error returns the error message for an invalid option key.
-func (e *InvalidOptionKeyError) Error() string {
-	return fmt.Sprintf("invalid option key:%s, allowed option keys:%s", e.Invalid, strings.Join(e.ValidList, ","))
-}
+// Error implements the error interface.
+func (e *InvalidOptionKeyError) Error() string { return e.core.Error() }
+
+// Invalid returns the invalid option key that was provided.
+func (e *InvalidOptionKeyError) Invalid() string { return e.core.Invalid }
+
+// ValidList returns the list of allowed option keys.
+func (e *InvalidOptionKeyError) ValidList() []string { return e.core.ValidList }
 
 // ValidationError represents an argument validation error.
 type ValidationError struct {
-	message string
+	core *core.ValidationError
 }
 
-// Error returns the validation error message.
-func (e *ValidationError) Error() string {
-	return e.message
-}
+// Error implements the error interface.
+func (e *ValidationError) Error() string { return e.core.Error() }
 
 // InternalClientError represents client-side configuration or usage errors.
 // It is distinct from API-level errors and indicates issues like missing Token
 // or malformed base URL.
 type InternalClientError struct {
-	msg string
+	core *core.InternalClientError
 }
 
-// Error returns the internal client error message.
-func (e *InternalClientError) Error() string {
-	return e.msg
-}
+// Error implements the error interface.
+func (e *InternalClientError) Error() string { return e.core.Error() }
 
 // convertError converts an error returned from internal packages into the
 // corresponding root-package error type. This prevents internal types from
@@ -89,27 +82,13 @@ func convertError(err error) error {
 
 	switch e := err.(type) {
 	case *core.APIResponseError:
-		out := &APIResponseError{
-			StatusCode: e.StatusCode,
-			Errors:     make([]*Error, len(e.Errors)),
-		}
-		for i, ce := range e.Errors {
-			out.Errors[i] = &Error{
-				Message:  ce.Message,
-				Code:     ce.Code,
-				MoreInfo: ce.MoreInfo,
-			}
-		}
-		return out
+		return &APIResponseError{core: e}
 	case *core.InvalidOptionKeyError:
-		return &InvalidOptionKeyError{
-			Invalid:   e.Invalid,
-			ValidList: e.ValidList,
-		}
+		return &InvalidOptionKeyError{core: e}
 	case *core.ValidationError:
-		return &ValidationError{message: e.Error()}
+		return &ValidationError{core: e}
 	case *core.InternalClientError:
-		return &InternalClientError{msg: e.Error()}
+		return &InternalClientError{core: e}
 	default:
 		return err
 	}

--- a/error.go
+++ b/error.go
@@ -45,11 +45,11 @@ type InvalidOptionKeyError struct {
 // Error implements the error interface.
 func (e *InvalidOptionKeyError) Error() string { return e.core.Error() }
 
-// Invalid returns the invalid option key that was provided.
-func (e *InvalidOptionKeyError) Invalid() string { return e.core.Invalid }
+// InvalidKey returns the invalid option key that was provided.
+func (e *InvalidOptionKeyError) InvalidKey() string { return e.core.Invalid }
 
-// ValidList returns the list of allowed option keys.
-func (e *InvalidOptionKeyError) ValidList() []string { return e.core.ValidList }
+// AllowKeys returns the list of allowed option keys.
+func (e *InvalidOptionKeyError) AllowKeys() []string { return e.core.ValidList }
 
 // ValidationError represents an argument validation error.
 type ValidationError struct {

--- a/error_test.go
+++ b/error_test.go
@@ -143,3 +143,21 @@ func TestInternalClientError_Error(t *testing.T) {
 	require.True(t, errors.As(err, &target))
 	assert.NotEmpty(t, target.Error())
 }
+
+// ──────────────────────────────────────────────────────────────
+//  convertError (indirect via service methods)
+// ──────────────────────────────────────────────────────────────
+
+func Test_convertError_default_passthroughsUnknownError(t *testing.T) {
+	sentinel := errors.New("network error")
+	c, err := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(&mockDoer{do: func(req *http.Request) (*http.Response, error) {
+			return nil, sentinel
+		}}),
+	)
+	require.NoError(t, err)
+	_, err = c.Wiki.All(context.Background(), "PROJECT")
+	assert.True(t, errors.Is(err, sentinel))
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,144 @@
+package backlog_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/core"
+)
+
+// convertError is unexported, so tests drive it indirectly via wiki.All which
+// calls convertError on every error path. For the root-package wrapper types
+// themselves we construct them by passing a core error through a real service
+// call that returns convertError's output, using errors.As to extract the
+// typed value.
+//
+// Helper: run a Wiki.All call with a doer that returns a given HTTP status,
+// and return the resulting error.
+func callWikiAllWithStatus(t *testing.T, statusCode int) error {
+	t.Helper()
+	c, err := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(&mockDoer{do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: statusCode,
+				Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"not found","code":6,"moreInfo":""}]}`)),
+			}, nil
+		}}),
+	)
+	require.NoError(t, err)
+	_, err = c.Wiki.All(context.Background(), "PROJECT")
+	return err
+}
+
+// ──────────────────────────────────────────────────────────────
+//  APIResponseError
+// ──────────────────────────────────────────────────────────────
+
+func TestAPIResponseError_Error(t *testing.T) {
+	err := callWikiAllWithStatus(t, 404)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Status Code:404")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestAPIResponseError_StatusCode(t *testing.T) {
+	err := callWikiAllWithStatus(t, 403)
+	require.Error(t, err)
+
+	var target *backlog.APIResponseError
+	require.True(t, errors.As(err, &target))
+	assert.Equal(t, 403, target.StatusCode())
+}
+
+func TestAPIResponseError_Errors(t *testing.T) {
+	err := callWikiAllWithStatus(t, 404)
+	require.Error(t, err)
+
+	var target *backlog.APIResponseError
+	require.True(t, errors.As(err, &target))
+
+	errs := target.Errors()
+	require.Len(t, errs, 1)
+	assert.Equal(t, "not found", errs[0].Message)
+	assert.Equal(t, 6, errs[0].Code)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  InvalidOptionKeyError
+// ──────────────────────────────────────────────────────────────
+
+// callWikiAllWithInvalidOption drives convertError via an invalid option key,
+// which the service layer converts to *backlog.InvalidOptionKeyError.
+func callWikiAllWithInvalidOption(t *testing.T) error {
+	t.Helper()
+	c, err := backlog.NewClient("https://example.backlog.com", "token")
+	require.NoError(t, err)
+	// WithCount is not a valid option for Wiki.All — triggers InvalidOptionKeyError.
+	_, err = c.Wiki.All(context.Background(), "PROJECT", c.Wiki.Option.WithContent("x"))
+	return err
+}
+
+func TestInvalidOptionKeyError_Error(t *testing.T) {
+	err := callWikiAllWithInvalidOption(t)
+	require.Error(t, err)
+
+	var target *backlog.InvalidOptionKeyError
+	require.True(t, errors.As(err, &target))
+	assert.Contains(t, target.Error(), "invalid option key")
+}
+
+func TestInvalidOptionKeyError_InvalidKey(t *testing.T) {
+	err := callWikiAllWithInvalidOption(t)
+	require.Error(t, err)
+
+	var target *backlog.InvalidOptionKeyError
+	require.True(t, errors.As(err, &target))
+	assert.Equal(t, core.ParamContent.Value(), target.InvalidKey())
+}
+
+func TestInvalidOptionKeyError_AllowKeys(t *testing.T) {
+	err := callWikiAllWithInvalidOption(t)
+	require.Error(t, err)
+
+	var target *backlog.InvalidOptionKeyError
+	require.True(t, errors.As(err, &target))
+	assert.NotEmpty(t, target.AllowKeys())
+	assert.Contains(t, target.AllowKeys(), core.ParamKeyword.Value())
+}
+
+// ──────────────────────────────────────────────────────────────
+//  ValidationError
+// ──────────────────────────────────────────────────────────────
+
+func TestValidationError_Error(t *testing.T) {
+	c, err := backlog.NewClient("https://example.backlog.com", "token")
+	require.NoError(t, err)
+	// wikiID=0 triggers a ValidationError in the internal layer.
+	_, err = c.Wiki.One(context.Background(), 0)
+	require.Error(t, err)
+
+	var target *backlog.ValidationError
+	require.True(t, errors.As(err, &target))
+	assert.NotEmpty(t, target.Error())
+}
+
+// ──────────────────────────────────────────────────────────────
+//  InternalClientError
+// ──────────────────────────────────────────────────────────────
+
+func TestInternalClientError_Error(t *testing.T) {
+	// Empty baseURL triggers InternalClientError from NewClient.
+	_, err := backlog.NewClient("", "token")
+	require.Error(t, err)
+
+	var target *backlog.InternalClientError
+	require.True(t, errors.As(err, &target))
+	assert.NotEmpty(t, target.Error())
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,8 +1,11 @@
 package backlog_test
 
 import (
+	"context"
 	"errors"
-	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,23 +15,22 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-// convertError is unexported, so tests drive it indirectly via wiki.All which
-// calls convertError on every error path. For the root-package wrapper types
-// themselves we construct them by passing a core error through a real service
-// call that returns convertError's output, using errors.As to extract the
-// typed value.
-//
-// Helper: run a Wiki.All call with a doer that returns a given HTTP status,
-// and return the resulting error.
+// convertError is unexported, so tests drive it indirectly via service methods
+// which call convertError on every error path. errors.As is used to extract
+// the typed wrapper value for assertion.
+
+// callWikiAllWithStatus runs Wiki.All with a doer that returns the given HTTP
+// status code and a single-element errors array, then returns the error.
 func callWikiAllWithStatus(t *testing.T, statusCode int) error {
 	t.Helper()
+	body := `{"errors":[{"message":"not found","code":6,"moreInfo":""}]}`
 	c, err := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(&mockDoer{do: func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: statusCode,
-				Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"not found","code":6,"moreInfo":""}]}`)),
+				Body:       io.NopCloser(strings.NewReader(body)),
 			}, nil
 		}}),
 	)
@@ -74,13 +76,12 @@ func TestAPIResponseError_Errors(t *testing.T) {
 //  InvalidOptionKeyError
 // ──────────────────────────────────────────────────────────────
 
-// callWikiAllWithInvalidOption drives convertError via an invalid option key,
-// which the service layer converts to *backlog.InvalidOptionKeyError.
+// callWikiAllWithInvalidOption drives convertError via an invalid option key.
+// WithContent is not valid for Wiki.All, triggering InvalidOptionKeyError.
 func callWikiAllWithInvalidOption(t *testing.T) error {
 	t.Helper()
 	c, err := backlog.NewClient("https://example.backlog.com", "token")
 	require.NoError(t, err)
-	// WithCount is not a valid option for Wiki.All — triggers InvalidOptionKeyError.
 	_, err = c.Wiki.All(context.Background(), "PROJECT", c.Wiki.Option.WithContent("x"))
 	return err
 }
@@ -120,7 +121,7 @@ func TestInvalidOptionKeyError_AllowKeys(t *testing.T) {
 func TestValidationError_Error(t *testing.T) {
 	c, err := backlog.NewClient("https://example.backlog.com", "token")
 	require.NoError(t, err)
-	// wikiID=0 triggers a ValidationError in the internal layer.
+	// wikiID=0 is invalid and triggers a ValidationError in the internal layer.
 	_, err = c.Wiki.One(context.Background(), 0)
 	require.Error(t, err)
 
@@ -134,7 +135,7 @@ func TestValidationError_Error(t *testing.T) {
 // ──────────────────────────────────────────────────────────────
 
 func TestInternalClientError_Error(t *testing.T) {
-	// Empty baseURL triggers InternalClientError from NewClient.
+	// An empty baseURL triggers InternalClientError from NewClient.
 	_, err := backlog.NewClient("", "token")
 	require.Error(t, err)
 

--- a/error_test.go
+++ b/error_test.go
@@ -15,30 +15,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-// convertError is unexported, so tests drive it indirectly via service methods
-// which call convertError on every error path. errors.As is used to extract
-// the typed wrapper value for assertion.
-
-// callWikiAllWithStatus runs Wiki.All with a doer that returns the given HTTP
-// status code and a single-element errors array, then returns the error.
-func callWikiAllWithStatus(t *testing.T, statusCode int) error {
-	t.Helper()
-	body := `{"errors":[{"message":"not found","code":6,"moreInfo":""}]}`
-	c, err := backlog.NewClient(
-		"https://example.backlog.com",
-		"token",
-		backlog.WithDoer(&mockDoer{do: func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: statusCode,
-				Body:       io.NopCloser(strings.NewReader(body)),
-			}, nil
-		}}),
-	)
-	require.NoError(t, err)
-	_, err = c.Wiki.All(context.Background(), "PROJECT")
-	return err
-}
-
 // ──────────────────────────────────────────────────────────────
 //  APIResponseError
 // ──────────────────────────────────────────────────────────────
@@ -75,16 +51,6 @@ func TestAPIResponseError_Errors(t *testing.T) {
 // ──────────────────────────────────────────────────────────────
 //  InvalidOptionKeyError
 // ──────────────────────────────────────────────────────────────
-
-// callWikiAllWithInvalidOption drives convertError via an invalid option key.
-// WithContent is not valid for Wiki.All, triggering InvalidOptionKeyError.
-func callWikiAllWithInvalidOption(t *testing.T) error {
-	t.Helper()
-	c, err := backlog.NewClient("https://example.backlog.com", "token")
-	require.NoError(t, err)
-	_, err = c.Wiki.All(context.Background(), "PROJECT", c.Wiki.Option.WithContent("x"))
-	return err
-}
 
 func TestInvalidOptionKeyError_Error(t *testing.T) {
 	err := callWikiAllWithInvalidOption(t)
@@ -160,4 +126,42 @@ func Test_convertError_default_passthroughsUnknownError(t *testing.T) {
 	require.NoError(t, err)
 	_, err = c.Wiki.All(context.Background(), "PROJECT")
 	assert.True(t, errors.Is(err, sentinel))
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Test helpers
+// ──────────────────────────────────────────────────────────────
+
+// convertError is unexported, so tests drive it indirectly via service methods
+// which call convertError on every error path. errors.As is used to extract
+// the typed wrapper value for assertion.
+
+// callWikiAllWithStatus runs Wiki.All with a doer that returns the given HTTP
+// status code and a single-element errors array, then returns the error.
+func callWikiAllWithStatus(t *testing.T, statusCode int) error {
+	t.Helper()
+	body := `{"errors":[{"message":"not found","code":6,"moreInfo":""}]}`
+	c, err := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(&mockDoer{do: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: statusCode,
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}}),
+	)
+	require.NoError(t, err)
+	_, err = c.Wiki.All(context.Background(), "PROJECT")
+	return err
+}
+
+// callWikiAllWithInvalidOption drives convertError via an invalid option key.
+// WithContent is not valid for Wiki.All, triggering InvalidOptionKeyError.
+func callWikiAllWithInvalidOption(t *testing.T) error {
+	t.Helper()
+	c, err := backlog.NewClient("https://example.backlog.com", "token")
+	require.NoError(t, err)
+	_, err = c.Wiki.All(context.Background(), "PROJECT", c.Wiki.Option.WithContent("x"))
+	return err
 }

--- a/internal/core/option.go
+++ b/internal/core/option.go
@@ -50,9 +50,6 @@ func (t APIParamOptionType) Value() string {
 // ──────────────────────────────────────────────────────────────
 //
 
-// RequestOption defines a common interface for all option types.
-// It allows unified validation and application handling across different request-level options.
-// Callers can implement this interface to provide custom options (e.g. for mocking in tests).
 type RequestOption interface {
 	Key() string
 	Check() error

--- a/issue.go
+++ b/issue.go
@@ -33,14 +33,16 @@ type IssueAttachmentService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-issue-attachments
 func (s *IssueAttachmentService) List(ctx context.Context, issueIDOrKey string) ([]*model.Attachment, error) {
-	return s.base.List(ctx, issueIDOrKey)
+	v, err := s.base.List(ctx, issueIDOrKey)
+	return v, convertError(err)
 }
 
 // Remove removes a file attached to the issue.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-issue-attachment
 func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string, attachmentID int) (*model.Attachment, error) {
-	return s.base.Remove(ctx, issueIDOrKey, attachmentID)
+	v, err := s.base.Remove(ctx, issueIDOrKey, attachmentID)
+	return v, convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/issue_test.go
+++ b/issue_test.go
@@ -3,8 +3,10 @@ package backlog_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,6 +40,20 @@ func TestIssueAttachmentService(t *testing.T) {
 				assert.Equal(t, 5, got[1].ID)
 			},
 		},
+		"List/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.Attachment.List(ctx, "TEST-1")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"Remove": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
@@ -51,6 +67,20 @@ func TestIssueAttachmentService(t *testing.T) {
 				got, err := c.Issue.Attachment.Remove(ctx, "TEST-1", 8)
 				require.NoError(t, err)
 				assert.Equal(t, 8, got.ID)
+			},
+		},
+		"Remove/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such attachment.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.Attachment.Remove(ctx, "TEST-1", 8)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 	}

--- a/option.go
+++ b/option.go
@@ -7,6 +7,9 @@ import (
 	"github.com/nattokin/go-backlog/internal/model"
 )
 
+// RequestOption defines a common interface for all option types.
+// It allows unified validation and application handling across different request-level options.
+// Callers can implement this interface to provide custom options (e.g. for mocking in tests).
 type RequestOption interface {
 	Key() string
 	Check() error

--- a/project.go
+++ b/project.go
@@ -31,14 +31,16 @@ type ProjectService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-list
 func (s *ProjectService) All(ctx context.Context, opts ...RequestOption) ([]*model.Project, error) {
-	return s.base.All(ctx, toCoreOptions(opts)...)
+	v, err := s.base.All(ctx, toCoreOptions(opts)...)
+	return v, convertError(err)
 }
 
 // One returns one of the projects searched by ID or key.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project
 func (s *ProjectService) One(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
-	return s.base.One(ctx, projectIDOrKey)
+	v, err := s.base.One(ctx, projectIDOrKey)
+	return v, convertError(err)
 }
 
 // Create creates a new project.
@@ -52,7 +54,8 @@ func (s *ProjectService) One(ctx context.Context, projectIDOrKey string) (*model
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project
 func (s *ProjectService) Create(ctx context.Context, key, name string, opts ...RequestOption) (*model.Project, error) {
-	return s.base.Create(ctx, key, name, toCoreOptions(opts)...)
+	v, err := s.base.Create(ctx, key, name, toCoreOptions(opts)...)
+	return v, convertError(err)
 }
 
 // Update updates a project.
@@ -69,14 +72,16 @@ func (s *ProjectService) Create(ctx context.Context, key, name string, opts ...R
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-project
 func (s *ProjectService) Update(ctx context.Context, projectIDOrKey string, opts ...RequestOption) (*model.Project, error) {
-	return s.base.Update(ctx, projectIDOrKey, toCoreOptions(opts)...)
+	v, err := s.base.Update(ctx, projectIDOrKey, toCoreOptions(opts)...)
+	return v, convertError(err)
 }
 
 // Delete deletes a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-project
 func (s *ProjectService) Delete(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
-	return s.base.Delete(ctx, projectIDOrKey)
+	v, err := s.base.Delete(ctx, projectIDOrKey)
+	return v, convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -102,7 +107,8 @@ type ProjectActivityService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates
 func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*model.Activity, error) {
-	return s.base.List(ctx, projectIDOrKey, toCoreOptions(opts)...)
+	v, err := s.base.List(ctx, projectIDOrKey, toCoreOptions(opts)...)
+	return v, convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/project_test.go
+++ b/project_test.go
@@ -3,8 +3,10 @@ package backlog_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,6 +41,20 @@ func TestProjectService(t *testing.T) {
 				assert.Len(t, got, 3)
 			},
 		},
+		"All/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.All(ctx)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"One": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
@@ -52,6 +68,20 @@ func TestProjectService(t *testing.T) {
 				got, err := c.Project.One(ctx, "TEST")
 				require.NoError(t, err)
 				assert.Equal(t, "TEST", got.ProjectKey)
+			},
+		},
+		"One/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.One(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 		"Create": {
@@ -73,6 +103,20 @@ func TestProjectService(t *testing.T) {
 				assert.Equal(t, "TEST", got.ProjectKey)
 			},
 		},
+		"Create/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Create(ctx, "TEST", "test")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"Update": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodPatch, req.Method)
@@ -90,6 +134,20 @@ func TestProjectService(t *testing.T) {
 				assert.Equal(t, "TEST", got.ProjectKey)
 			},
 		},
+		"Update/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Update(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"Delete": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
@@ -103,6 +161,20 @@ func TestProjectService(t *testing.T) {
 				got, err := c.Project.Delete(ctx, "TEST")
 				require.NoError(t, err)
 				assert.Equal(t, "TEST", got.ProjectKey)
+			},
+		},
+		"Delete/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Delete(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 	}
@@ -139,6 +211,20 @@ func TestProjectActivityService(t *testing.T) {
 				got, err := c.Project.Activity.List(ctx, "TEST", c.Project.Activity.Option.WithCount(10))
 				require.NoError(t, err)
 				assert.Len(t, got, 1)
+			},
+		},
+		"List/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Activity.List(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 	}

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -29,14 +29,16 @@ type PullRequestAttachmentService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-pull-request-attachment
 func (s *PullRequestAttachmentService) List(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int) ([]*model.Attachment, error) {
-	return s.base.List(ctx, projectIDOrKey, repositoryIDOrName, prNumber)
+	v, err := s.base.List(ctx, projectIDOrKey, repositoryIDOrName, prNumber)
+	return v, convertError(err)
 }
 
 // Remove removes a file attached to the pull request.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-pull-request-attachments
 func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*model.Attachment, error) {
-	return s.base.Remove(ctx, projectIDOrKey, repositoryIDOrName, prNumber, attachmentID)
+	v, err := s.base.Remove(ctx, projectIDOrKey, repositoryIDOrName, prNumber, attachmentID)
+	return v, convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -3,8 +3,10 @@ package backlog_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,6 +40,20 @@ func TestPullRequestAttachmentService(t *testing.T) {
 				assert.Equal(t, 5, got[1].ID)
 			},
 		},
+		"List/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such repository.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.PullRequest.Attachment.List(ctx, "TEST", "repo", 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"Remove": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
@@ -51,6 +67,20 @@ func TestPullRequestAttachmentService(t *testing.T) {
 				got, err := c.PullRequest.Attachment.Remove(ctx, "TEST", "repo", 1, 8)
 				require.NoError(t, err)
 				assert.Equal(t, 8, got.ID)
+			},
+		},
+		"Remove/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such attachment.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.PullRequest.Attachment.Remove(ctx, "TEST", "repo", 1, 8)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 	}

--- a/space.go
+++ b/space.go
@@ -46,7 +46,8 @@ type SpaceActivityService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-recent-updates
 func (s *SpaceActivityService) List(ctx context.Context, opts ...RequestOption) ([]*model.Activity, error) {
-	return s.base.List(ctx, toCoreOptions(opts)...)
+	v, err := s.base.List(ctx, toCoreOptions(opts)...)
+	return v, convertError(err)
 }
 
 // SpaceAttachmentService handles communication with the space attachment-related methods of the Backlog API.
@@ -60,7 +61,8 @@ type SpaceAttachmentService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/post-attachment-file
 func (s *SpaceAttachmentService) Upload(ctx context.Context, fileName string, r io.Reader) (*model.Attachment, error) {
-	return s.base.Upload(ctx, fileName, r)
+	v, err := s.base.Upload(ctx, fileName, r)
+	return v, convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/space_test.go
+++ b/space_test.go
@@ -3,6 +3,7 @@ package backlog_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -37,6 +38,20 @@ func TestSpaceActivityService(t *testing.T) {
 				got, err := c.Space.Activity.List(ctx, c.Space.Activity.Option.WithCount(20))
 				require.NoError(t, err)
 				assert.Len(t, got, 1)
+			},
+		},
+		"List/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Space.Activity.List(ctx)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 	}
@@ -78,5 +93,22 @@ func TestSpaceAttachmentService(t *testing.T) {
 		assert.Equal(t, 1, got.ID)
 		assert.Equal(t, "test.txt", got.Name)
 		assert.Equal(t, 8857, got.Size)
+	})
+
+	t.Run("Upload/error", func(t *testing.T) {
+		doFunc := func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+			}, nil
+		}
+
+		c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: doFunc}))
+		require.NoError(t, err)
+
+		_, err = c.Space.Attachment.Upload(ctx, "testfile", strings.NewReader("data"))
+		require.Error(t, err)
+		var target *backlog.APIResponseError
+		assert.True(t, errors.As(err, &target))
 	})
 }

--- a/user.go
+++ b/user.go
@@ -25,28 +25,32 @@ type UserService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-list
 func (s *UserService) All(ctx context.Context) ([]*model.User, error) {
-	return s.base.All(ctx)
+	v, err := s.base.All(ctx)
+	return v, convertError(err)
 }
 
 // One returns a user in your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user
 func (s *UserService) One(ctx context.Context, id int) (*model.User, error) {
-	return s.base.One(ctx, id)
+	v, err := s.base.One(ctx, id)
+	return v, convertError(err)
 }
 
 // Own returns your own user.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-own-user
 func (s *UserService) Own(ctx context.Context) (*model.User, error) {
-	return s.base.Own(ctx)
+	v, err := s.base.Own(ctx)
+	return v, convertError(err)
 }
 
 // Add adds a user to your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-user
 func (s *UserService) Add(ctx context.Context, userID, password, name, mailAddress string, roleType model.Role) (*model.User, error) {
-	return s.base.Add(ctx, userID, password, name, mailAddress, roleType)
+	v, err := s.base.Add(ctx, userID, password, name, mailAddress, roleType)
+	return v, convertError(err)
 }
 
 // Update updates a user in your space.
@@ -60,14 +64,16 @@ func (s *UserService) Add(ctx context.Context, userID, password, name, mailAddre
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-user
 func (s *UserService) Update(ctx context.Context, id int, opts ...RequestOption) (*model.User, error) {
-	return s.base.Update(ctx, id, toCoreOptions(opts)...)
+	v, err := s.base.Update(ctx, id, toCoreOptions(opts)...)
+	return v, convertError(err)
 }
 
 // Delete deletes a user from your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-user
 func (s *UserService) Delete(ctx context.Context, id int) (*model.User, error) {
-	return s.base.Delete(ctx, id)
+	v, err := s.base.Delete(ctx, id)
+	return v, convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -93,7 +99,8 @@ type UserActivityService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates
 func (s *UserActivityService) List(ctx context.Context, userID int, opts ...RequestOption) ([]*model.Activity, error) {
-	return s.base.List(ctx, userID, toCoreOptions(opts)...)
+	v, err := s.base.List(ctx, userID, toCoreOptions(opts)...)
+	return v, convertError(err)
 }
 
 // ProjectUserService has methods for user of project.
@@ -105,42 +112,48 @@ type ProjectUserService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-user-list
 func (s *ProjectUserService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*model.User, error) {
-	return s.base.All(ctx, projectIDOrKey, excludeGroupMembers)
+	v, err := s.base.All(ctx, projectIDOrKey, excludeGroupMembers)
+	return v, convertError(err)
 }
 
 // Add adds a user to the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project-user
 func (s *ProjectUserService) Add(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
-	return s.base.Add(ctx, projectIDOrKey, userID)
+	v, err := s.base.Add(ctx, projectIDOrKey, userID)
+	return v, convertError(err)
 }
 
 // Delete deletes a user from the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-project-user
 func (s *ProjectUserService) Delete(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
-	return s.base.Delete(ctx, projectIDOrKey, userID)
+	v, err := s.base.Delete(ctx, projectIDOrKey, userID)
+	return v, convertError(err)
 }
 
 // AddAdmin adds a admin user to the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project-administrator
 func (s *ProjectUserService) AddAdmin(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
-	return s.base.AddAdmin(ctx, projectIDOrKey, userID)
+	v, err := s.base.AddAdmin(ctx, projectIDOrKey, userID)
+	return v, convertError(err)
 }
 
 // AdminAll returns a list of all admin users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-project-administrators
 func (s *ProjectUserService) AdminAll(ctx context.Context, projectIDOrKey string) ([]*model.User, error) {
-	return s.base.AdminAll(ctx, projectIDOrKey)
+	v, err := s.base.AdminAll(ctx, projectIDOrKey)
+	return v, convertError(err)
 }
 
 // DeleteAdmin removes an admin user from the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-project-administrator
 func (s *ProjectUserService) DeleteAdmin(ctx context.Context, projectIDOrKey string, userID int) (*model.User, error) {
-	return s.base.DeleteAdmin(ctx, projectIDOrKey, userID)
+	v, err := s.base.DeleteAdmin(ctx, projectIDOrKey, userID)
+	return v, convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/user_test.go
+++ b/user_test.go
@@ -3,10 +3,12 @@ package backlog_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,6 +41,20 @@ func TestProjectUserService(t *testing.T) {
 				assert.Len(t, got, 4)
 			},
 		},
+		"All/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.User.All(ctx, "TEST", false)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"Add": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodPost, req.Method)
@@ -54,6 +70,20 @@ func TestProjectUserService(t *testing.T) {
 				got, err := c.Project.User.Add(ctx, "TEST", 1)
 				require.NoError(t, err)
 				assert.Equal(t, "admin", got.UserID)
+			},
+		},
+		"Add/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.User.Add(ctx, "TEST", 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 		"Delete": {
@@ -76,6 +106,20 @@ func TestProjectUserService(t *testing.T) {
 				assert.Equal(t, "admin", got.UserID)
 			},
 		},
+		"Delete/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.User.Delete(ctx, "TEST", 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"AddAdmin": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodPost, req.Method)
@@ -93,6 +137,20 @@ func TestProjectUserService(t *testing.T) {
 				assert.Equal(t, "admin", got.UserID)
 			},
 		},
+		"AddAdmin/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.User.AddAdmin(ctx, "TEST", 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"AdminAll": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
@@ -106,6 +164,20 @@ func TestProjectUserService(t *testing.T) {
 				got, err := c.Project.User.AdminAll(ctx, "TEST")
 				require.NoError(t, err)
 				assert.Len(t, got, 4)
+			},
+		},
+		"AdminAll/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.User.AdminAll(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 		"DeleteAdmin": {
@@ -126,6 +198,20 @@ func TestProjectUserService(t *testing.T) {
 				got, err := c.Project.User.DeleteAdmin(ctx, "TEST", 1)
 				require.NoError(t, err)
 				assert.Equal(t, "admin", got.UserID)
+			},
+		},
+		"DeleteAdmin/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.User.DeleteAdmin(ctx, "TEST", 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 	}
@@ -163,6 +249,20 @@ func TestUserService(t *testing.T) {
 				assert.Len(t, got, 4)
 			},
 		},
+		"All/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.User.All(ctx)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"One": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
@@ -178,6 +278,20 @@ func TestUserService(t *testing.T) {
 				assert.Equal(t, "admin", got.UserID)
 			},
 		},
+		"One/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such user.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.User.One(ctx, 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"Own": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
@@ -191,6 +305,20 @@ func TestUserService(t *testing.T) {
 				got, err := c.User.Own(ctx)
 				require.NoError(t, err)
 				assert.Equal(t, "admin", got.UserID)
+			},
+		},
+		"Own/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.User.Own(ctx)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 		"Add": {
@@ -213,6 +341,20 @@ func TestUserService(t *testing.T) {
 				assert.Equal(t, "admin", got.UserID)
 			},
 		},
+		"Add/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.User.Add(ctx, "newuser", "password", "New User", "new@example.com", 2)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"Update": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodPatch, req.Method)
@@ -228,6 +370,20 @@ func TestUserService(t *testing.T) {
 				got, err := c.User.Update(ctx, 1, c.User.Option.WithName("updated-user"))
 				require.NoError(t, err)
 				assert.Equal(t, "admin", got.UserID)
+			},
+		},
+		"Update/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such user.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.User.Update(ctx, 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 		"Delete": {
@@ -248,6 +404,20 @@ func TestUserService(t *testing.T) {
 				got, err := c.User.Delete(ctx, 1)
 				require.NoError(t, err)
 				assert.Equal(t, "admin", got.UserID)
+			},
+		},
+		"Delete/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such user.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.User.Delete(ctx, 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 	}
@@ -284,6 +454,20 @@ func TestUserActivityService(t *testing.T) {
 				got, err := c.User.Activity.List(ctx, 1, c.User.Activity.Option.WithMinID(5))
 				require.NoError(t, err)
 				assert.Len(t, got, 1)
+			},
+		},
+		"List/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such user.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.User.Activity.List(ctx, 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 	}

--- a/wiki.go
+++ b/wiki.go
@@ -29,21 +29,24 @@ type WikiService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-list
 func (s *WikiService) All(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*model.Wiki, error) {
-	return s.base.All(ctx, projectIDOrKey, toCoreOptions(opts)...)
+	v, err := s.base.All(ctx, projectIDOrKey, toCoreOptions(opts)...)
+	return v, convertError(err)
 }
 
 // Count returns the number of wiki pages in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-wiki-page
 func (s *WikiService) Count(ctx context.Context, projectIDOrKey string) (int, error) {
-	return s.base.Count(ctx, projectIDOrKey)
+	v, err := s.base.Count(ctx, projectIDOrKey)
+	return v, convertError(err)
 }
 
 // One returns a wiki page.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page
 func (s *WikiService) One(ctx context.Context, wikiID int) (*model.Wiki, error) {
-	return s.base.One(ctx, wikiID)
+	v, err := s.base.One(ctx, wikiID)
+	return v, convertError(err)
 }
 
 // Create creates a new wiki page.
@@ -54,7 +57,8 @@ func (s *WikiService) One(ctx context.Context, wikiID int) (*model.Wiki, error) 
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-wiki-page
 func (s *WikiService) Create(ctx context.Context, projectID int, name, content string, opts ...RequestOption) (*model.Wiki, error) {
-	return s.base.Create(ctx, projectID, name, content, toCoreOptions(opts)...)
+	v, err := s.base.Create(ctx, projectID, name, content, toCoreOptions(opts)...)
+	return v, convertError(err)
 }
 
 // Update updates a wiki page.
@@ -67,14 +71,16 @@ func (s *WikiService) Create(ctx context.Context, projectID int, name, content s
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-wiki-page
 func (s *WikiService) Update(ctx context.Context, wikiID int, option RequestOption, opts ...RequestOption) (*model.Wiki, error) {
-	return s.base.Update(ctx, wikiID, option, toCoreOptions(opts)...)
+	v, err := s.base.Update(ctx, wikiID, option, toCoreOptions(opts)...)
+	return v, convertError(err)
 }
 
 // Delete deletes a wiki page.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-wiki-page
 func (s *WikiService) Delete(ctx context.Context, wikiID int, opts ...RequestOption) (*model.Wiki, error) {
-	return s.base.Delete(ctx, wikiID, toCoreOptions(opts)...)
+	v, err := s.base.Delete(ctx, wikiID, toCoreOptions(opts)...)
+	return v, convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -90,21 +96,24 @@ type WikiAttachmentService struct {
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/attach-file-to-wiki
 func (s *WikiAttachmentService) Attach(ctx context.Context, wikiID int, attachmentIDs []int) ([]*model.Attachment, error) {
-	return s.base.Attach(ctx, wikiID, attachmentIDs)
+	v, err := s.base.Attach(ctx, wikiID, attachmentIDs)
+	return v, convertError(err)
 }
 
 // List returns a list of files attached to the wiki page.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-wiki-attachments
 func (s *WikiAttachmentService) List(ctx context.Context, wikiID int) ([]*model.Attachment, error) {
-	return s.base.List(ctx, wikiID)
+	v, err := s.base.List(ctx, wikiID)
+	return v, convertError(err)
 }
 
 // Remove removes an attachment from the wiki page.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/remove-wiki-attachment
 func (s *WikiAttachmentService) Remove(ctx context.Context, wikiID, attachmentID int) (*model.Attachment, error) {
-	return s.base.Remove(ctx, wikiID, attachmentID)
+	v, err := s.base.Remove(ctx, wikiID, attachmentID)
+	return v, convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -3,9 +3,11 @@ package backlog_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,6 +41,20 @@ func TestWikiService(t *testing.T) {
 				assert.Len(t, got, 2)
 			},
 		},
+		"All/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.All(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"Count": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
@@ -54,6 +70,20 @@ func TestWikiService(t *testing.T) {
 				assert.Equal(t, 34, got)
 			},
 		},
+		"Count/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No project.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.Count(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"One": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
@@ -67,6 +97,20 @@ func TestWikiService(t *testing.T) {
 				got, err := c.Wiki.One(ctx, 34)
 				require.NoError(t, err)
 				assert.Equal(t, 34, got.ID)
+			},
+		},
+		"One/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.One(ctx, 34)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 		"Create": {
@@ -89,6 +133,20 @@ func TestWikiService(t *testing.T) {
 				assert.Equal(t, "Minimum Wiki Page", got.Name)
 			},
 		},
+		"Create/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.Create(ctx, 56, "Test Wiki", "content")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"Update": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodPatch, req.Method)
@@ -104,6 +162,20 @@ func TestWikiService(t *testing.T) {
 				got, err := c.Wiki.Update(ctx, 34, c.Wiki.Option.WithName("New Name"))
 				require.NoError(t, err)
 				assert.Equal(t, 34, got.ID)
+			},
+		},
+		"Update/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.Update(ctx, 34, c.Wiki.Option.WithName("New Name"))
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 		"Delete": {
@@ -124,6 +196,20 @@ func TestWikiService(t *testing.T) {
 				got, err := c.Wiki.Delete(ctx, 34, c.Wiki.Option.WithMailNotify(true))
 				require.NoError(t, err)
 				assert.Equal(t, 34, got.ID)
+			},
+		},
+		"Delete/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.Delete(ctx, 34)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 	}
@@ -165,6 +251,20 @@ func TestWikiAttachmentService(t *testing.T) {
 				assert.Equal(t, 5, got[1].ID)
 			},
 		},
+		"Attach/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.Attachment.Attach(ctx, 34, []int{2, 5})
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
@@ -182,6 +282,20 @@ func TestWikiAttachmentService(t *testing.T) {
 				assert.Equal(t, 5, got[1].ID)
 			},
 		},
+		"List/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.Attachment.List(ctx, 34)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"Remove": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
@@ -195,6 +309,20 @@ func TestWikiAttachmentService(t *testing.T) {
 				got, err := c.Wiki.Attachment.Remove(ctx, 34, 8)
 				require.NoError(t, err)
 				assert.Equal(t, 8, got.ID)
+			},
+		},
+		"Remove/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such attachment.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.Attachment.Remove(ctx, 34, 8)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Defines the five error types as concrete structs in the root `backlog` package and routes all service method errors through a new `convertError` function, so that `internal/core` types never leak into the public API surface.

Previously, `error.go` exposed all error types as type aliases (`= core.XXX`), which caused `pkg.go.dev` to display `= core.XXX` and made `internal` types visible to users.

## Changes

### `error.go`

- Removed all type aliases; replaced with concrete struct definitions that hold a `core *core.XxxError` field
- `Error` — `error` interface removed; repositioned as a plain data struct for decoding API responses
- `APIResponseError` — exposes values via methods: `Error()`, `StatusCode()`, `Errors()`
- `InvalidOptionKeyError` — exposes values via methods: `Error()`, `InvalidKey()`, `AllowKeys()`
- `ValidationError` — `Error()` delegates to `e.core.Error()`
- `InternalClientError` — `Error()` delegates to `e.core.Error()`
- All `Error()` implementations delegate to `e.core.Error()` — no logic duplication
- Added `convertError(err error) error` — wraps `*core.XXX` in the corresponding root-package type via a type switch; unknown errors pass through unchanged

### `client.go`

- `NewClient`: changed `return nil, err` to `return nil, convertError(err)`

### Service files (`wiki.go`, `project.go`, `user.go`, `space.go`, `issue.go`, `pullrequest.go`)

- All public service methods: changed `return s.base.XXX(...)` to the two-line form `v, err := s.base.XXX(...); return v, convertError(err)`

### `error_test.go` (new)

- `TestAPIResponseError_Error` / `_StatusCode` / `_Errors` — verifies each method via a mock HTTP response
- `TestInvalidOptionKeyError_Error` / `_InvalidKey` / `_AllowKeys` — verifies each method via an invalid option key
- `TestValidationError_Error` — verifies via `wikiID=0` validation
- `TestInternalClientError_Error` — verifies via empty `baseURL`
- `Test_convertError_default_passthroughsUnknownError` — verifies that unknown errors pass through `convertError` unchanged via `errors.Is`

### Service test files (`wiki_test.go`, `project_test.go`, `user_test.go`, `space_test.go`, `issue_test.go`, `pullrequest_test.go`)

- Added `"MethodName/error"` cases to every existing service test to verify that `*backlog.APIResponseError` is returned via `errors.As` when the API returns a non-2xx response
- This ensures `convertError` is not accidentally omitted from any service method

## Breaking changes

- Users who use `errors.As` with `*core.XXX` types must update to `*backlog.XXX`
- `InvalidOptionKeyError.Invalid` / `.ValidList` fields replaced by `InvalidKey()` / `AllowKeys()` methods
- `APIResponseError.StatusCode` / `.Errors` fields replaced by `StatusCode()` / `Errors()` methods
- `Error.Error()` method removed (`Error` is no longer an `error`)

Closes #183