### PR TITLE
docs: improve wiki examples and add Example tests

### DIFF
--- a/example_wiki_test.go
+++ b/example_wiki_test.go
@@ -32,7 +32,7 @@ var (
 	doerWikiDelete = &fixedDoer{body: fixture.Wiki.MinimumJSON}
 )
 
-func ExampleClient_Wiki_All() {
+func ExampleWikiService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
@@ -45,7 +45,7 @@ func ExampleClient_Wiki_All() {
 	// ID: 112, Name: test1
 }
 
-func ExampleClient_Wiki_Count() {
+func ExampleWikiService_Count() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
@@ -58,7 +58,7 @@ func ExampleClient_Wiki_Count() {
 	// Count: 5
 }
 
-func ExampleClient_Wiki_One() {
+func ExampleWikiService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
@@ -71,7 +71,7 @@ func ExampleClient_Wiki_One() {
 	// ID: 34, Name: Minimum Wiki Page
 }
 
-func ExampleClient_Wiki_Create() {
+func ExampleWikiService_Create() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
@@ -84,7 +84,7 @@ func ExampleClient_Wiki_Create() {
 	// ID: 34, Name: Minimum Wiki Page
 }
 
-func ExampleClient_Wiki_Update() {
+func ExampleWikiService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
@@ -101,7 +101,7 @@ func ExampleClient_Wiki_Update() {
 	// ID: 34, Name: Minimum Wiki Page
 }
 
-func ExampleClient_Wiki_Delete() {
+func ExampleWikiService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",

--- a/example_wiki_test.go
+++ b/example_wiki_test.go
@@ -1,0 +1,115 @@
+package backlog_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+// fixedDoer is a Doer that always returns a fixed response body with HTTP 200.
+type fixedDoer struct {
+	body string
+}
+
+func (d *fixedDoer) Do(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString(d.body)),
+	}, nil
+}
+
+var (
+	doerWikiAll    = &fixedDoer{body: fixture.Wiki.ListJSON}
+	doerWikiCount  = &fixedDoer{body: `{"count": 5}`}
+	doerWikiOne    = &fixedDoer{body: fixture.Wiki.MinimumJSON}
+	doerWikiCreate = &fixedDoer{body: fixture.Wiki.MinimumJSON}
+	doerWikiUpdate = &fixedDoer{body: fixture.Wiki.MinimumJSON}
+	doerWikiDelete = &fixedDoer{body: fixture.Wiki.MinimumJSON}
+)
+
+func ExampleClient_Wiki_All() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiAll),
+	)
+
+	wikis, _ := c.Wiki.All(context.Background(), "MYPROJECT")
+	fmt.Printf("ID: %d, Name: %s\n", wikis[0].ID, wikis[0].Name)
+	// Output:
+	// ID: 112, Name: test1
+}
+
+func ExampleClient_Wiki_Count() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiCount),
+	)
+
+	count, _ := c.Wiki.Count(context.Background(), "MYPROJECT")
+	fmt.Printf("Count: %d\n", count)
+	// Output:
+	// Count: 5
+}
+
+func ExampleClient_Wiki_One() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiOne),
+	)
+
+	wiki, _ := c.Wiki.One(context.Background(), 34)
+	fmt.Printf("ID: %d, Name: %s\n", wiki.ID, wiki.Name)
+	// Output:
+	// ID: 34, Name: Minimum Wiki Page
+}
+
+func ExampleClient_Wiki_Create() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiCreate),
+	)
+
+	wiki, _ := c.Wiki.Create(context.Background(), 56, "Minimum Wiki Page", "This is a minimal wiki page.")
+	fmt.Printf("ID: %d, Name: %s\n", wiki.ID, wiki.Name)
+	// Output:
+	// ID: 34, Name: Minimum Wiki Page
+}
+
+func ExampleClient_Wiki_Update() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiUpdate),
+	)
+
+	wiki, _ := c.Wiki.Update(
+		context.Background(),
+		34,
+		c.Wiki.Option.WithName("Minimum Wiki Page"),
+	)
+	fmt.Printf("ID: %d, Name: %s\n", wiki.ID, wiki.Name)
+	// Output:
+	// ID: 34, Name: Minimum Wiki Page
+}
+
+func ExampleClient_Wiki_Delete() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiDelete),
+	)
+
+	wiki, _ := c.Wiki.Delete(context.Background(), 34)
+	fmt.Printf("ID: %d, Name: %s\n", wiki.ID, wiki.Name)
+	// Output:
+	// ID: 34, Name: Minimum Wiki Page
+}

--- a/examples/wiki/all/main.go
+++ b/examples/wiki/all/main.go
@@ -24,7 +24,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// ID or key of the project.
+	// Key of the project.
 	projectKey := "MYPROJECT"
 
 	wikis, err := c.Wiki.All(context.Background(), projectKey)

--- a/examples/wiki/all/main.go
+++ b/examples/wiki/all/main.go
@@ -1,36 +1,40 @@
+// Example: List all Wiki pages in a project.
+// This example demonstrates how to retrieve all Wiki pages
+// in a specified project using the Backlog API client.
 package main
 
 import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/nattokin/go-backlog"
 )
 
 func main() {
-	// The base URL of Backlog API.
-	baseURL := "BACKLOG_BASE_URL"
-	// The token for request to Backlog API.
-	token := "BACKLOG_TOKEN"
-	// Create Backlog API client.
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	token := os.Getenv("BACKLOG_TOKEN")
+	if baseURL == "" || token == "" {
+		log.Fatalln("BACKLOG_BASE_URL and BACKLOG_TOKEN must be set")
+	}
+
 	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	// ID or Key of the project.
-	projectKey := "PROJECTKEY"
-	r, err := c.Wiki.All(context.Background(), projectKey)
-	// projectID := "1234"
-	// r, err := c.Wiki.All(projectID)
 
-	// Search with keyword
-	// r, err := c.Wiki.All(projectKey, c.Wiki.Option.WithKeyword("keyword"))
+	// ID or key of the project.
+	projectKey := "MYPROJECT"
 
+	wikis, err := c.Wiki.All(context.Background(), projectKey)
+	// With keyword filter:
+	// wikis, err := c.Wiki.All(context.Background(), projectKey, c.Wiki.Option.WithKeyword("keyword"))
 	if err != nil {
 		log.Fatalln(err)
 	}
-	for _, w := range r {
-		fmt.Printf("%#v\n", w)
+
+	for _, w := range wikis {
+		fmt.Printf("ID: %d, Name: %s\n", w.ID, w.Name)
 	}
 }

--- a/examples/wiki/all/main.go
+++ b/examples/wiki/all/main.go
@@ -24,7 +24,6 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// Key of the project.
 	projectKey := "MYPROJECT"
 
 	wikis, err := c.Wiki.All(context.Background(), projectKey)

--- a/examples/wiki/count/main.go
+++ b/examples/wiki/count/main.go
@@ -24,7 +24,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// ID or key of the project.
+	// Key of the project.
 	projectKey := "MYPROJECT"
 
 	count, err := c.Wiki.Count(context.Background(), projectKey)

--- a/examples/wiki/count/main.go
+++ b/examples/wiki/count/main.go
@@ -1,37 +1,36 @@
+// Example: Get the number of Wiki pages in a project.
+// This example demonstrates how to count Wiki pages
+// in a specified project using the Backlog API client.
 package main
 
 import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/nattokin/go-backlog"
 )
 
 func main() {
-	// The base URL of Backlog API.
-	baseURL := "BACKLOG_BASE_URL"
-	// The token for request to Backlog API.
-	token := "BACKLOG_TOKEN"
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	token := os.Getenv("BACKLOG_TOKEN")
+	if baseURL == "" || token == "" {
+		log.Fatalln("BACKLOG_BASE_URL and BACKLOG_TOKEN must be set")
+	}
 
-	// Create Backlog API client.
 	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	// ID or Key of the project.
-	projectID := "12345"
-	// projectKey := "ProjectKey"
+	// ID or key of the project.
+	projectKey := "MYPROJECT"
 
-	// Get count of how many Wiki in project.
-	count, err := c.Wiki.Count(context.Background(), projectID)
-	// count, err := c.Wiki.Count(projectKey)
-
+	count, err := c.Wiki.Count(context.Background(), projectKey)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	// Output the number of count.
-	fmt.Printf("%d\n", count)
+	fmt.Printf("Count: %d\n", count)
 }

--- a/examples/wiki/count/main.go
+++ b/examples/wiki/count/main.go
@@ -24,7 +24,6 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// Key of the project.
 	projectKey := "MYPROJECT"
 
 	count, err := c.Wiki.Count(context.Background(), projectKey)

--- a/examples/wiki/create/main.go
+++ b/examples/wiki/create/main.go
@@ -1,32 +1,36 @@
+// Example: Create a new Wiki page in a project.
+// This example demonstrates how to create a Wiki page
+// in a specified project using the Backlog API client.
 package main
 
 import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/nattokin/go-backlog"
 )
 
 func main() {
-	// The base URL of Backlog API.
-	baseURL := "BACKLOG_BASE_URL"
-	// The token for request to Backlog API.
-	token := "BACKLOG_TOKEN"
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	token := os.Getenv("BACKLOG_TOKEN")
+	if baseURL == "" || token == "" {
+		log.Fatalln("BACKLOG_BASE_URL and BACKLOG_TOKEN must be set")
+	}
 
-	// Create Backlog API client.
 	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	// Create a new Wiki by ID of the project.
-	// You get struct where represented the Wiki created.
-	r, err := c.Wiki.Create(context.Background(), 12345, "name", "content")
+	// ID of the project in which to create the Wiki page.
+	projectID := 12345
+
+	wiki, err := c.Wiki.Create(context.Background(), projectID, "My Wiki Page", "Page content here.")
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	// Output result.
-	fmt.Printf("%#v\n", r)
+	fmt.Printf("ID: %d, Name: %s\n", wiki.ID, wiki.Name)
 }

--- a/examples/wiki/create/main.go
+++ b/examples/wiki/create/main.go
@@ -24,7 +24,6 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// ID of the project in which to create the Wiki page.
 	projectID := 12345
 
 	wiki, err := c.Wiki.Create(context.Background(), projectID, "My Wiki Page", "Page content here.")

--- a/examples/wiki/delete/main.go
+++ b/examples/wiki/delete/main.go
@@ -1,32 +1,36 @@
+// Example: Delete a Wiki page by ID.
+// This example demonstrates how to delete a Wiki page
+// using the Backlog API client. The deleted Wiki is returned as a result.
 package main
 
 import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/nattokin/go-backlog"
 )
 
 func main() {
-	// The base URL of Backlog API.
-	baseURL := "BACKLOG_BASE_URL"
-	// The token for request to Backlog API.
-	token := "BACKLOG_TOKEN"
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	token := os.Getenv("BACKLOG_TOKEN")
+	if baseURL == "" || token == "" {
+		log.Fatalln("BACKLOG_BASE_URL and BACKLOG_TOKEN must be set")
+	}
 
-	// Create Backlog API client.
 	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	// Delete a Wiki by ID of the Wiki.
-	// You get struct where represented the Wiki deleted.
-	r, err := c.Wiki.Delete(context.Background(), 1234)
+	// ID of the Wiki page to delete.
+	wikiID := 12345
+
+	wiki, err := c.Wiki.Delete(context.Background(), wikiID)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	// Response
-	fmt.Printf("%#v\n", r)
+	fmt.Printf("ID: %d, Name: %s\n", wiki.ID, wiki.Name)
 }

--- a/examples/wiki/delete/main.go
+++ b/examples/wiki/delete/main.go
@@ -24,7 +24,6 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// ID of the Wiki page to delete.
 	wikiID := 12345
 
 	wiki, err := c.Wiki.Delete(context.Background(), wikiID)

--- a/examples/wiki/one/main.go
+++ b/examples/wiki/one/main.go
@@ -1,28 +1,36 @@
+// Example: Get a single Wiki page by ID.
+// This example demonstrates how to retrieve a specific Wiki page
+// using its ID via the Backlog API client.
 package main
 
 import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/nattokin/go-backlog"
 )
 
 func main() {
-	// The base URL of Backlog API.
-	baseURL := "BACKLOG_BASE_URL"
-	// The token for request to Backlog API.
-	token := "BACKLOG_TOKEN"
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	token := os.Getenv("BACKLOG_TOKEN")
+	if baseURL == "" || token == "" {
+		log.Fatalln("BACKLOG_BASE_URL and BACKLOG_TOKEN must be set")
+	}
 
-	// Create Backlog API client.
 	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	r, err := c.Wiki.One(context.Background(), 12345)
+	// ID of the Wiki page to retrieve.
+	wikiID := 12345
+
+	wiki, err := c.Wiki.One(context.Background(), wikiID)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	fmt.Printf("%#v\n", r)
+
+	fmt.Printf("ID: %d, Name: %s\n", wiki.ID, wiki.Name)
 }

--- a/examples/wiki/one/main.go
+++ b/examples/wiki/one/main.go
@@ -24,7 +24,6 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// ID of the Wiki page to retrieve.
 	wikiID := 12345
 
 	wiki, err := c.Wiki.One(context.Background(), wikiID)

--- a/examples/wiki/update/main.go
+++ b/examples/wiki/update/main.go
@@ -1,27 +1,41 @@
+// Example: Update an existing Wiki page.
+// This example demonstrates how to update the name and content
+// of a Wiki page using the Backlog API client.
 package main
 
 import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/nattokin/go-backlog"
 )
 
 func main() {
-	// The base URL of Backlog API.
-	baseURL := "BACKLOG_BASE_URL"
-	// The token for request to Backlog API.
-	token := "BACKLOG_TOKEN"
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	token := os.Getenv("BACKLOG_TOKEN")
+	if baseURL == "" || token == "" {
+		log.Fatalln("BACKLOG_BASE_URL and BACKLOG_TOKEN must be set")
+	}
 
 	c, err := backlog.NewClient(baseURL, token)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	r, err := c.Wiki.Update(context.Background(), 1234, c.Wiki.Option.WithName("changed name"), c.Wiki.Option.WithContent("changed content"))
+	// ID of the Wiki page to update.
+	wikiID := 12345
+
+	wiki, err := c.Wiki.Update(
+		context.Background(),
+		wikiID,
+		c.Wiki.Option.WithName("Updated Name"),
+		c.Wiki.Option.WithContent("Updated content."),
+	)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	fmt.Printf("%#v\n", r)
+
+	fmt.Printf("ID: %d, Name: %s\n", wiki.ID, wiki.Name)
 }

--- a/examples/wiki/update/main.go
+++ b/examples/wiki/update/main.go
@@ -24,7 +24,6 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// ID of the Wiki page to update.
 	wikiID := 12345
 
 	wiki, err := c.Wiki.Update(


### PR DESCRIPTION
Improve the `examples/wiki/` programs and add `Example` tests for all `WikiService` methods.

## Changes

### `examples/wiki/*/main.go`

- Read `BACKLOG_BASE_URL` and `BACKLOG_TOKEN` from environment variables instead of hardcoded placeholders; fatal if either is unset
- Extract hardcoded numeric IDs into named variables with comments
- Replace `fmt.Printf("%#v\n", ...)` with field-explicit output (`ID`, `Name`)
- Add a descriptive file-level comment to each file explaining what it demonstrates

### `example_wiki_test.go` (new)

Add `Example` functions for all six `WikiService` methods (`All`, `Count`, `One`, `Create`, `Update`, `Delete`) in `package backlog_test`:

- `fixedDoer` — a file-local `Doer` implementation that returns a fixed response body with HTTP 200
- Package-level `doerWikiXxx` variables keep `Example` function bodies concise
- Fixtures reuse `fixture.Wiki.ListJSON` / `fixture.Wiki.MinimumJSON` from `internal/testutil/fixture`
- Each function has a `// Output:` assertion, making them runnable by `go test` and visible on `pkg.go.dev`

Part of #86