### PR TITLE
docs: add Example tests for ProjectService, ProjectActivityService, ProjectUserService

### DIFF
--- a/example_project_test.go
+++ b/example_project_test.go
@@ -1,45 +1,31 @@
 package backlog_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"net/http"
 
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 )
 
-type projectFixedDoer struct {
-	body string
-}
-
-func (d *projectFixedDoer) Do(_ *http.Request) (*http.Response, error) {
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(bytes.NewBufferString(d.body)),
-	}, nil
-}
-
 var (
 	// ProjectService
-	doerProjectAll    = &projectFixedDoer{body: fixture.Project.ListJSON}
-	doerProjectOne    = &projectFixedDoer{body: fixture.Project.SingleJSON}
-	doerProjectCreate = &projectFixedDoer{body: fixture.Project.SingleJSON}
-	doerProjectUpdate = &projectFixedDoer{body: fixture.Project.SingleJSON}
-	doerProjectDelete = &projectFixedDoer{body: fixture.Project.SingleJSON}
+	doerProjectAll    = newMockDoer(fixture.Project.ListJSON)
+	doerProjectOne    = newMockDoer(fixture.Project.SingleJSON)
+	doerProjectCreate = newMockDoer(fixture.Project.SingleJSON)
+	doerProjectUpdate = newMockDoer(fixture.Project.SingleJSON)
+	doerProjectDelete = newMockDoer(fixture.Project.SingleJSON)
 
 	// ProjectActivityService
-	doerProjectActivityList = &projectFixedDoer{body: fixture.Activity.ListJSON}
+	doerProjectActivityList = newMockDoer(fixture.Activity.ListJSON)
 
 	// ProjectUserService
-	doerProjectUserAll         = &projectFixedDoer{body: fixture.User.ListJSON}
-	doerProjectUserAdd         = &projectFixedDoer{body: fixture.User.SingleJSON}
-	doerProjectUserDelete      = &projectFixedDoer{body: fixture.User.SingleJSON}
-	doerProjectUserAddAdmin    = &projectFixedDoer{body: fixture.User.SingleJSON}
-	doerProjectUserAdminAll    = &projectFixedDoer{body: fixture.User.ListJSON}
-	doerProjectUserDeleteAdmin = &projectFixedDoer{body: fixture.User.SingleJSON}
+	doerProjectUserAll         = newMockDoer(fixture.User.ListJSON)
+	doerProjectUserAdd         = newMockDoer(fixture.User.SingleJSON)
+	doerProjectUserDelete      = newMockDoer(fixture.User.SingleJSON)
+	doerProjectUserAddAdmin    = newMockDoer(fixture.User.SingleJSON)
+	doerProjectUserAdminAll    = newMockDoer(fixture.User.ListJSON)
+	doerProjectUserDeleteAdmin = newMockDoer(fixture.User.SingleJSON)
 )
 
 func ExampleProjectService_All() {

--- a/example_project_test.go
+++ b/example_project_test.go
@@ -1,0 +1,201 @@
+package backlog_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+type projectFixedDoer struct {
+	body string
+}
+
+func (d *projectFixedDoer) Do(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString(d.body)),
+	}, nil
+}
+
+var (
+	// ProjectService
+	doerProjectAll    = &projectFixedDoer{body: fixture.Project.ListJSON}
+	doerProjectOne    = &projectFixedDoer{body: fixture.Project.SingleJSON}
+	doerProjectCreate = &projectFixedDoer{body: fixture.Project.SingleJSON}
+	doerProjectUpdate = &projectFixedDoer{body: fixture.Project.SingleJSON}
+	doerProjectDelete = &projectFixedDoer{body: fixture.Project.SingleJSON}
+
+	// ProjectActivityService
+	doerProjectActivityList = &projectFixedDoer{body: fixture.Activity.ListJSON}
+
+	// ProjectUserService
+	doerProjectUserAll         = &projectFixedDoer{body: fixture.User.ListJSON}
+	doerProjectUserAdd         = &projectFixedDoer{body: fixture.User.SingleJSON}
+	doerProjectUserDelete      = &projectFixedDoer{body: fixture.User.SingleJSON}
+	doerProjectUserAddAdmin    = &projectFixedDoer{body: fixture.User.SingleJSON}
+	doerProjectUserAdminAll    = &projectFixedDoer{body: fixture.User.ListJSON}
+	doerProjectUserDeleteAdmin = &projectFixedDoer{body: fixture.User.SingleJSON}
+)
+
+func ExampleProjectService_All() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectAll),
+	)
+
+	projects, _ := c.Project.All(context.Background())
+	fmt.Printf("ID: %d, Key: %s\n", projects[0].ID, projects[0].ProjectKey)
+	// Output:
+	// ID: 1, Key: TEST
+}
+
+func ExampleProjectService_One() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectOne),
+	)
+
+	project, _ := c.Project.One(context.Background(), "TEST")
+	fmt.Printf("ID: %d, Key: %s\n", project.ID, project.ProjectKey)
+	// Output:
+	// ID: 6, Key: TEST
+}
+
+func ExampleProjectService_Create() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectCreate),
+	)
+
+	project, _ := c.Project.Create(context.Background(), "TEST", "test")
+	fmt.Printf("ID: %d, Key: %s\n", project.ID, project.ProjectKey)
+	// Output:
+	// ID: 6, Key: TEST
+}
+
+func ExampleProjectService_Update() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectUpdate),
+	)
+
+	project, _ := c.Project.Update(context.Background(), "TEST",
+		c.Project.Option.WithName("test"),
+	)
+	fmt.Printf("ID: %d, Key: %s\n", project.ID, project.ProjectKey)
+	// Output:
+	// ID: 6, Key: TEST
+}
+
+func ExampleProjectService_Delete() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectDelete),
+	)
+
+	project, _ := c.Project.Delete(context.Background(), "TEST")
+	fmt.Printf("ID: %d, Key: %s\n", project.ID, project.ProjectKey)
+	// Output:
+	// ID: 6, Key: TEST
+}
+
+func ExampleProjectActivityService_List() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectActivityList),
+	)
+
+	activities, _ := c.Project.Activity.List(context.Background(), "TEST")
+	fmt.Printf("ID: %d, Type: %d\n", activities[0].ID, activities[0].Type)
+	// Output:
+	// ID: 3153, Type: 2
+}
+
+func ExampleProjectUserService_All() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectUserAll),
+	)
+
+	users, _ := c.Project.User.All(context.Background(), "TEST", false)
+	fmt.Printf("ID: %d, UserID: %s\n", users[0].ID, users[0].UserID)
+	// Output:
+	// ID: 1, UserID: admin
+}
+
+func ExampleProjectUserService_Add() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectUserAdd),
+	)
+
+	user, _ := c.Project.User.Add(context.Background(), "TEST", 1)
+	fmt.Printf("ID: %d, UserID: %s\n", user.ID, user.UserID)
+	// Output:
+	// ID: 1, UserID: admin
+}
+
+func ExampleProjectUserService_Delete() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectUserDelete),
+	)
+
+	user, _ := c.Project.User.Delete(context.Background(), "TEST", 1)
+	fmt.Printf("ID: %d, UserID: %s\n", user.ID, user.UserID)
+	// Output:
+	// ID: 1, UserID: admin
+}
+
+func ExampleProjectUserService_AddAdmin() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectUserAddAdmin),
+	)
+
+	user, _ := c.Project.User.AddAdmin(context.Background(), "TEST", 1)
+	fmt.Printf("ID: %d, UserID: %s\n", user.ID, user.UserID)
+	// Output:
+	// ID: 1, UserID: admin
+}
+
+func ExampleProjectUserService_AdminAll() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectUserAdminAll),
+	)
+
+	users, _ := c.Project.User.AdminAll(context.Background(), "TEST")
+	fmt.Printf("ID: %d, UserID: %s\n", users[0].ID, users[0].UserID)
+	// Output:
+	// ID: 1, UserID: admin
+}
+
+func ExampleProjectUserService_DeleteAdmin() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectUserDeleteAdmin),
+	)
+
+	user, _ := c.Project.User.DeleteAdmin(context.Background(), "TEST", 1)
+	fmt.Printf("ID: %d, UserID: %s\n", user.ID, user.UserID)
+	// Output:
+	// ID: 1, UserID: admin
+}

--- a/example_wiki_test.go
+++ b/example_wiki_test.go
@@ -1,39 +1,24 @@
 package backlog_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"net/http"
 
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 )
 
-// fixedDoer is a Doer that always returns a fixed response body with HTTP 200.
-type fixedDoer struct {
-	body string
-}
-
-func (d *fixedDoer) Do(_ *http.Request) (*http.Response, error) {
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(bytes.NewBufferString(d.body)),
-	}, nil
-}
-
 var (
-	doerWikiAll    = &fixedDoer{body: fixture.Wiki.ListJSON}
-	doerWikiCount  = &fixedDoer{body: `{"count": 5}`}
-	doerWikiOne    = &fixedDoer{body: fixture.Wiki.MinimumJSON}
-	doerWikiCreate = &fixedDoer{body: fixture.Wiki.MinimumJSON}
-	doerWikiUpdate = &fixedDoer{body: fixture.Wiki.MinimumJSON}
-	doerWikiDelete = &fixedDoer{body: fixture.Wiki.MinimumJSON}
+	doerWikiAll    = newMockDoer(fixture.Wiki.ListJSON)
+	doerWikiCount  = newMockDoer(`{"count": 5}`)
+	doerWikiOne    = newMockDoer(fixture.Wiki.MinimumJSON)
+	doerWikiCreate = newMockDoer(fixture.Wiki.MinimumJSON)
+	doerWikiUpdate = newMockDoer(fixture.Wiki.MinimumJSON)
+	doerWikiDelete = newMockDoer(fixture.Wiki.MinimumJSON)
 
-	doerWikiAttachmentAttach = &fixedDoer{body: fixture.Attachment.ListJSON}
-	doerWikiAttachmentList   = &fixedDoer{body: fixture.Attachment.ListJSON}
-	doerWikiAttachmentRemove = &fixedDoer{body: fixture.Attachment.SingleJSON}
+	doerWikiAttachmentAttach = newMockDoer(fixture.Attachment.ListJSON)
+	doerWikiAttachmentList   = newMockDoer(fixture.Attachment.ListJSON)
+	doerWikiAttachmentRemove = newMockDoer(fixture.Attachment.SingleJSON)
 )
 
 func ExampleWikiService_All() {

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,6 +1,10 @@
 package backlog_test
 
-import "net/http"
+import (
+	"bytes"
+	"io"
+	"net/http"
+)
 
 type mockDoer struct {
 	do func(req *http.Request) (*http.Response, error)
@@ -8,4 +12,16 @@ type mockDoer struct {
 
 func (d *mockDoer) Do(req *http.Request) (*http.Response, error) {
 	return d.do(req)
+}
+
+// newMockDoer returns a mockDoer that always responds with HTTP 200 and the given body.
+func newMockDoer(body string) *mockDoer {
+	return &mockDoer{
+		do: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(body)),
+			}, nil
+		},
+	}
 }


### PR DESCRIPTION
Add `example_project_test.go` with `Example` tests for all methods of `ProjectService`, `ProjectActivityService`, and `ProjectUserService`.

Note: `fixedDoer` is already defined in `example_wiki_test.go`, so this file defines `projectFixedDoer` as a separate type to avoid a duplicate symbol in the same package. A follow-up can extract the shared helper into a common file.

Part of #86