### PR TITLE
docs: add Example tests for attachment services (Space, Issue, PullRequest)

### DIFF
--- a/example_issue_test.go
+++ b/example_issue_test.go
@@ -1,0 +1,41 @@
+package backlog_test
+
+import (
+	"context"
+	"fmt"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+var (
+	// IssueAttachmentService
+	doerIssueAttachmentList   = newMockDoer(fixture.Attachment.ListJSON)
+	doerIssueAttachmentRemove = newMockDoer(fixture.Attachment.SingleJSON)
+)
+
+func ExampleIssueAttachmentService_List() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerIssueAttachmentList),
+	)
+
+	attachments, _ := c.Issue.Attachment.List(context.Background(), "TEST-1")
+	fmt.Printf("ID: %d, Name: %s\n", attachments[0].ID, attachments[0].Name)
+	// Output:
+	// ID: 2, Name: A.png
+}
+
+func ExampleIssueAttachmentService_Remove() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerIssueAttachmentRemove),
+	)
+
+	attachment, _ := c.Issue.Attachment.Remove(context.Background(), "TEST-1", 8)
+	fmt.Printf("ID: %d, Name: %s\n", attachment.ID, attachment.Name)
+	// Output:
+	// ID: 8, Name: IMG0088.png
+}

--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -1,0 +1,41 @@
+package backlog_test
+
+import (
+	"context"
+	"fmt"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+var (
+	// PullRequestAttachmentService
+	doerPullRequestAttachmentList   = newMockDoer(fixture.Attachment.ListJSON)
+	doerPullRequestAttachmentRemove = newMockDoer(fixture.Attachment.SingleJSON)
+)
+
+func ExamplePullRequestAttachmentService_List() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerPullRequestAttachmentList),
+	)
+
+	attachments, _ := c.PullRequest.Attachment.List(context.Background(), "TEST", "myrepo", 1)
+	fmt.Printf("ID: %d, Name: %s\n", attachments[0].ID, attachments[0].Name)
+	// Output:
+	// ID: 2, Name: A.png
+}
+
+func ExamplePullRequestAttachmentService_Remove() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerPullRequestAttachmentRemove),
+	)
+
+	attachment, _ := c.PullRequest.Attachment.Remove(context.Background(), "TEST", "myrepo", 1, 8)
+	fmt.Printf("ID: %d, Name: %s\n", attachment.ID, attachment.Name)
+	// Output:
+	// ID: 8, Name: IMG0088.png
+}

--- a/example_space_test.go
+++ b/example_space_test.go
@@ -1,0 +1,28 @@
+package backlog_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+var (
+	// SpaceAttachmentService
+	doerSpaceAttachmentUpload = newMockDoer(fixture.Attachment.UploadJSON)
+)
+
+func ExampleSpaceAttachmentService_Upload() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerSpaceAttachmentUpload),
+	)
+
+	attachment, _ := c.Space.Attachment.Upload(context.Background(), "test.txt", strings.NewReader("hello"))
+	fmt.Printf("ID: %d, Name: %s\n", attachment.ID, attachment.Name)
+	// Output:
+	// ID: 1, Name: test.txt
+}


### PR DESCRIPTION
## Summary

Add Example tests for the attachment services of `SpaceService`, `IssueService`, and `PullRequestService`.

## Changes

- Add `example_space_test.go`: `ExampleSpaceAttachmentService_Upload`
- Add `example_issue_test.go`: `ExampleIssueAttachmentService_List`, `ExampleIssueAttachmentService_Remove`
- Add `example_pullrequest_test.go`: `ExamplePullRequestAttachmentService_List`, `ExamplePullRequestAttachmentService_Remove`

Closes #86