### PR TITLE
docs: add ExampleSpaceActivityService_List

### DIFF
--- a/example_space_test.go
+++ b/example_space_test.go
@@ -10,9 +10,25 @@ import (
 )
 
 var (
+	// SpaceActivityService
+	doerSpaceActivityList = newMockDoer(fixture.Activity.ListJSON)
+
 	// SpaceAttachmentService
 	doerSpaceAttachmentUpload = newMockDoer(fixture.Attachment.UploadJSON)
 )
+
+func ExampleSpaceActivityService_List() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerSpaceActivityList),
+	)
+
+	activities, _ := c.Space.Activity.List(context.Background())
+	fmt.Printf("ID: %d, Type: %d\n", activities[0].ID, activities[0].Type)
+	// Output:
+	// ID: 3153, Type: 2
+}
 
 func ExampleSpaceAttachmentService_Upload() {
 	c, _ := backlog.NewClient(


### PR DESCRIPTION
`SpaceActivityService.List` の Example テストが `example_space_test.go` に含まれていなかったため追加する。

## Changes

- Add `ExampleSpaceActivityService_List` to `example_space_test.go`
- Add `doerSpaceActivityList` to the `var` block

Part of #86