### PR TITLE
chore: add NewMethod helper to mock package

### DIFF
--- a/internal/activity/service_test.go
+++ b/internal/activity/service_test.go
@@ -31,12 +31,12 @@ func TestProjectActivityService_List(t *testing.T) {
 		spath: "projects/" + projectKey + "/activities",
 	}
 
-	s := activity.NewProjectService(&core.Method{
-		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-			assert.Equal(t, want.spath, spath)
-			return nil, errors.New("error")
-		},
-	})
+	method := mock.NewMethod(t)
+	method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+		assert.Equal(t, want.spath, spath)
+		return nil, errors.New("error")
+	}
+	s := activity.NewProjectService(method)
 
 	_, err := s.List(context.Background(), projectKey)
 	assert.Error(t, err)
@@ -46,12 +46,8 @@ func TestProjectActivityService_List_projectIDOrKeyIsEmpty(t *testing.T) {
 	t.Parallel()
 
 	projectKey := ""
-	s := activity.NewProjectService(&core.Method{
-		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-			t.Error("s.method.Get must never be called")
-			return nil, errors.New("error")
-		},
-	})
+	method := mock.NewMethod(t)
+	s := activity.NewProjectService(method)
 
 	_, err := s.List(context.Background(), projectKey)
 	assert.Error(t, err)
@@ -60,15 +56,15 @@ func TestProjectActivityService_List_projectIDOrKeyIsEmpty(t *testing.T) {
 func TestProjectActivityService_List_invalidJson(t *testing.T) {
 	t.Parallel()
 
-	s := activity.NewProjectService(&core.Method{
-		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-			resp := &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-			}
-			return resp, nil
-		},
-	})
+	method := mock.NewMethod(t)
+	method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+		}
+		return resp, nil
+	}
+	s := activity.NewProjectService(method)
 
 	projects, err := s.List(context.Background(), "TEST")
 	assert.Nil(t, projects)
@@ -84,12 +80,12 @@ func TestSpaceActivityService_List(t *testing.T) {
 		spath: "space/activities",
 	}
 
-	s := activity.NewSpaceService(&core.Method{
-		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-			assert.Equal(t, want.spath, spath)
-			return nil, errors.New("error")
-		},
-	})
+	method := mock.NewMethod(t)
+	method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+		assert.Equal(t, want.spath, spath)
+		return nil, errors.New("error")
+	}
+	s := activity.NewSpaceService(method)
 
 	_, err := s.List(context.Background())
 	assert.Error(t, err)
@@ -106,12 +102,12 @@ func TestUserActivityService_List(t *testing.T) {
 		spath: "users/" + strconv.Itoa(id) + "/activities",
 	}
 
-	s := activity.NewUserService(&core.Method{
-		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-			assert.Equal(t, want.spath, spath)
-			return nil, errors.New("error")
-		},
-	})
+	method := mock.NewMethod(t)
+	method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+		assert.Equal(t, want.spath, spath)
+		return nil, errors.New("error")
+	}
+	s := activity.NewUserService(method)
 
 	_, err := s.List(context.Background(), id)
 	assert.Error(t, err)
@@ -121,12 +117,8 @@ func TestUserActivityService_List_invalidID(t *testing.T) {
 	t.Parallel()
 
 	id := 0
-	s := activity.NewUserService(&core.Method{
-		Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-			t.Error("s.method.Get must never be called")
-			return nil, errors.New("error")
-		},
-	})
+	method := mock.NewMethod(t)
+	s := activity.NewUserService(method)
 
 	_, err := s.List(context.Background(), id)
 	assert.Error(t, err)
@@ -263,21 +255,21 @@ func TestBaseActivityService_GetList(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			t.Parallel()
 
-			s := activity.NewSpaceService(&core.Method{
-				Get: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-					assert.Equal(t, tc.want.activityTypeID, (query)["activityTypeId[]"])
-					assert.Equal(t, tc.want.minID, query.Get("minId"))
-					assert.Equal(t, tc.want.maxID, query.Get("maxId"))
-					assert.Equal(t, tc.want.count, query.Get("count"))
-					assert.Equal(t, tc.want.order, query.Get("order"))
+			method := mock.NewMethod(t)
+			method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, tc.want.activityTypeID, (query)["activityTypeId[]"])
+				assert.Equal(t, tc.want.minID, query.Get("minId"))
+				assert.Equal(t, tc.want.maxID, query.Get("maxId"))
+				assert.Equal(t, tc.want.count, query.Get("count"))
+				assert.Equal(t, tc.want.order, query.Get("order"))
 
-					resp := &http.Response{
-						StatusCode: http.StatusOK,
-						Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.ListJSON))),
-					}
-					return resp, nil
-				},
-			})
+				resp := &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.ListJSON))),
+				}
+				return resp, nil
+			}
+			s := activity.NewSpaceService(method)
 
 			if resp, err := s.List(context.Background(), tc.opts...); tc.wantError {
 				require.Error(t, err)
@@ -304,30 +296,32 @@ func TestActivityService_contextPropagation(t *testing.T) {
 		call func(t *testing.T)
 	}{
 		{"ProjectActivityService.List", func(t *testing.T) {
-			s := activity.NewProjectService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := activity.NewProjectService(method)
+
 			s.List(ctx, "TEST") //nolint:errcheck
 		}},
 		{"SpaceActivityService.List", func(t *testing.T) {
-			s := activity.NewSpaceService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := activity.NewSpaceService(method)
+
 			s.List(ctx) //nolint:errcheck
 		}},
 		{"UserActivityService.List", func(t *testing.T) {
-			s := activity.NewUserService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := activity.NewUserService(method)
 
 			s.List(ctx, 1) //nolint:errcheck
 		}},

--- a/internal/activity/service_test.go
+++ b/internal/activity/service_test.go
@@ -320,7 +320,7 @@ func TestActivityService_contextPropagation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t, mock.NewMethod(t))
+			tc.call(t, &core.Method{})
 		})
 	}
 }

--- a/internal/activity/service_test.go
+++ b/internal/activity/service_test.go
@@ -291,9 +291,11 @@ func TestActivityService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
-	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-		assert.Same(t, sentinel, got.Value(ctxKey{}))
-		return nil, errors.New("stop")
+	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
 	}
 
 	cases := []struct {
@@ -301,17 +303,17 @@ func TestActivityService_contextPropagation(t *testing.T) {
 		call func(t *testing.T, m *core.Method)
 	}{
 		{"ProjectActivityService.List", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := activity.NewProjectService(m)
 			s.List(ctx, "TEST") //nolint:errcheck
 		}},
 		{"SpaceActivityService.List", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := activity.NewSpaceService(m)
 			s.List(ctx) //nolint:errcheck
 		}},
 		{"UserActivityService.List", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := activity.NewUserService(m)
 			s.List(ctx, 1) //nolint:errcheck
 		}},

--- a/internal/activity/service_test.go
+++ b/internal/activity/service_test.go
@@ -291,38 +291,28 @@ func TestActivityService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
+	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+		assert.Same(t, sentinel, got.Value(ctxKey{}))
+		return nil, errors.New("stop")
+	}
+
 	cases := []struct {
 		name string
-		call func(t *testing.T)
+		call func(t *testing.T, m *core.Method)
 	}{
-		{"ProjectActivityService.List", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := activity.NewProjectService(method)
-
+		{"ProjectActivityService.List", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := activity.NewProjectService(m)
 			s.List(ctx, "TEST") //nolint:errcheck
 		}},
-		{"SpaceActivityService.List", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := activity.NewSpaceService(method)
-
+		{"SpaceActivityService.List", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := activity.NewSpaceService(m)
 			s.List(ctx) //nolint:errcheck
 		}},
-		{"UserActivityService.List", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := activity.NewUserService(method)
-
+		{"UserActivityService.List", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := activity.NewUserService(m)
 			s.List(ctx, 1) //nolint:errcheck
 		}},
 	}
@@ -330,7 +320,7 @@ func TestActivityService_contextPropagation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t)
+			tc.call(t, mock.NewMethod(t))
 		})
 	}
 }

--- a/internal/attachment/service_test.go
+++ b/internal/attachment/service_test.go
@@ -907,13 +907,11 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
-	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-		assert.Same(t, sentinel, got.Value(ctxKey{}))
-		return nil, errors.New("stop")
-	}
-	uploadMockFn := func(got context.Context, _, _ string, _ io.Reader) (*http.Response, error) {
-		assert.Same(t, sentinel, got.Value(ctxKey{}))
-		return nil, errors.New("stop")
+	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
 	}
 
 	cases := []struct {
@@ -921,42 +919,45 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 		call func(t *testing.T, m *core.Method)
 	}{
 		{"SpaceService.Upload", func(t *testing.T, m *core.Method) {
-			m.Upload = uploadMockFn
+			m.Upload = func(got context.Context, _, _ string, _ io.Reader) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
 			s := attachment.NewSpaceService(m)
 			s.Upload(ctx, "f", bytes.NewReader(nil)) //nolint:errcheck
 		}},
 		{"WikiService.Attach", func(t *testing.T, m *core.Method) {
-			m.Post = mockFn
+			m.Post = makeMockFn(t)
 			s := attachment.NewWikiService(m)
 			s.Attach(ctx, 1, []int{1}) //nolint:errcheck
 		}},
 		{"WikiService.List", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := attachment.NewWikiService(m)
 			s.List(ctx, 1) //nolint:errcheck
 		}},
 		{"WikiService.Remove", func(t *testing.T, m *core.Method) {
-			m.Delete = mockFn
+			m.Delete = makeMockFn(t)
 			s := attachment.NewWikiService(m)
 			s.Remove(ctx, 1, 1) //nolint:errcheck
 		}},
 		{"IssueService.List", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := attachment.NewIssueService(m)
 			s.List(ctx, "TEST-1") //nolint:errcheck
 		}},
 		{"IssueService.Remove", func(t *testing.T, m *core.Method) {
-			m.Delete = mockFn
+			m.Delete = makeMockFn(t)
 			s := attachment.NewIssueService(m)
 			s.Remove(ctx, "TEST-1", 1) //nolint:errcheck
 		}},
 		{"PullRequestService.List", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := attachment.NewPullRequestService(m)
 			s.List(ctx, "TEST", "repo", 1) //nolint:errcheck
 		}},
 		{"PullRequestService.Remove", func(t *testing.T, m *core.Method) {
-			m.Delete = mockFn
+			m.Delete = makeMockFn(t)
 			s := attachment.NewPullRequestService(m)
 			s.Remove(ctx, "TEST", "repo", 1, 1) //nolint:errcheck
 		}},

--- a/internal/attachment/service_test.go
+++ b/internal/attachment/service_test.go
@@ -968,7 +968,7 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t, mock.NewMethod(t))
+			tc.call(t, &core.Method{})
 		})
 	}
 }

--- a/internal/attachment/service_test.go
+++ b/internal/attachment/service_test.go
@@ -936,10 +936,7 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 			s.List(ctx, 1) //nolint:errcheck
 		}},
 		{"WikiService.Remove", func(t *testing.T, m *core.Method) {
-			m.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Delete = mockFn
 			s := attachment.NewWikiService(m)
 			s.Remove(ctx, 1, 1) //nolint:errcheck
 		}},

--- a/internal/attachment/service_test.go
+++ b/internal/attachment/service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nattokin/go-backlog/internal/attachment"
+	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
@@ -906,88 +907,60 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
+	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+		assert.Same(t, sentinel, got.Value(ctxKey{}))
+		return nil, errors.New("stop")
+	}
+	uploadMockFn := func(got context.Context, _, _ string, _ io.Reader) (*http.Response, error) {
+		assert.Same(t, sentinel, got.Value(ctxKey{}))
+		return nil, errors.New("stop")
+	}
+
 	cases := []struct {
 		name string
-		call func(t *testing.T)
+		call func(t *testing.T, m *core.Method)
 	}{
-		{"SpaceService.Upload", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Upload = func(got context.Context, _, _ string, _ io.Reader) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := attachment.NewSpaceService(method)
-
+		{"SpaceService.Upload", func(t *testing.T, m *core.Method) {
+			m.Upload = uploadMockFn
+			s := attachment.NewSpaceService(m)
 			s.Upload(ctx, "f", bytes.NewReader(nil)) //nolint:errcheck
 		}},
-		{"WikiService.Attach", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := attachment.NewWikiService(method)
-
+		{"WikiService.Attach", func(t *testing.T, m *core.Method) {
+			m.Post = mockFn
+			s := attachment.NewWikiService(m)
 			s.Attach(ctx, 1, []int{1}) //nolint:errcheck
 		}},
-		{"WikiService.List", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := attachment.NewWikiService(method)
-
+		{"WikiService.List", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := attachment.NewWikiService(m)
 			s.List(ctx, 1) //nolint:errcheck
 		}},
-		{"WikiService.Remove", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+		{"WikiService.Remove", func(t *testing.T, m *core.Method) {
+			m.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
 				assert.Same(t, sentinel, got.Value(ctxKey{}))
 				return nil, errors.New("stop")
 			}
-			s := attachment.NewWikiService(method)
-
+			s := attachment.NewWikiService(m)
 			s.Remove(ctx, 1, 1) //nolint:errcheck
 		}},
-		{"IssueService.List", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := attachment.NewIssueService(method)
-
+		{"IssueService.List", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := attachment.NewIssueService(m)
 			s.List(ctx, "TEST-1") //nolint:errcheck
 		}},
-		{"IssueService.Remove", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := attachment.NewIssueService(method)
-
+		{"IssueService.Remove", func(t *testing.T, m *core.Method) {
+			m.Delete = mockFn
+			s := attachment.NewIssueService(m)
 			s.Remove(ctx, "TEST-1", 1) //nolint:errcheck
 		}},
-		{"PullRequestService.List", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := attachment.NewPullRequestService(method)
-
+		{"PullRequestService.List", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := attachment.NewPullRequestService(m)
 			s.List(ctx, "TEST", "repo", 1) //nolint:errcheck
 		}},
-		{"PullRequestService.Remove", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := attachment.NewPullRequestService(method)
-
+		{"PullRequestService.Remove", func(t *testing.T, m *core.Method) {
+			m.Delete = mockFn
+			s := attachment.NewPullRequestService(m)
 			s.Remove(ctx, "TEST", "repo", 1, 1) //nolint:errcheck
 		}},
 	}
@@ -995,7 +968,7 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t)
+			tc.call(t, mock.NewMethod(t))
 		})
 	}
 }

--- a/internal/attachment/service_test.go
+++ b/internal/attachment/service_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nattokin/go-backlog/internal/attachment"
-	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
@@ -139,9 +138,9 @@ func TestSpaceAttachmentService_Upload(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewSpaceService(&core.Method{
-				Upload: tc.mockUploadFn,
-			})
+			method := mock.NewMethod(t)
+			method.Upload = tc.mockUploadFn
+			s := attachment.NewSpaceService(method)
 
 			f, err := os.Open("../../testdata/testfile")
 			require.NoError(t, err)
@@ -257,7 +256,9 @@ func TestWikiAttachmentService_Attach(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewWikiService(&core.Method{Post: tc.mockPostFn})
+			method := mock.NewMethod(t)
+			method.Post = tc.mockPostFn
+			s := attachment.NewWikiService(method)
 
 			attachments, err := s.Attach(context.Background(), tc.wikiID, tc.attachmentIDs)
 
@@ -344,7 +345,9 @@ func TestWikiAttachmentService_List(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewWikiService(&core.Method{Get: tc.mockGetFn})
+			method := mock.NewMethod(t)
+			method.Get = tc.mockGetFn
+			s := attachment.NewWikiService(method)
 
 			attachments, err := s.List(context.Background(), tc.wikiID)
 
@@ -451,7 +454,9 @@ func TestWikiAttachmentService_Remove(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewWikiService(&core.Method{Delete: tc.mockDeleteFn})
+			method := mock.NewMethod(t)
+			method.Delete = tc.mockDeleteFn
+			s := attachment.NewWikiService(method)
 
 			attachment, err := s.Remove(context.Background(), tc.wikiID, tc.attachmentID)
 
@@ -528,9 +533,9 @@ func TestIssueAttachmentService_List(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewIssueService(&core.Method{
-				Get: tc.mockGetFn,
-			})
+			method := mock.NewMethod(t)
+			method.Get = tc.mockGetFn
+			s := attachment.NewIssueService(method)
 
 			attachments, err := s.List(context.Background(), tc.issueIDOrKey)
 
@@ -623,9 +628,9 @@ func TestIssueAttachmentService_Remove(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewIssueService(&core.Method{
-				Delete: tc.mockDeleteFn,
-			})
+			method := mock.NewMethod(t)
+			method.Delete = tc.mockDeleteFn
+			s := attachment.NewIssueService(method)
 
 			attachment, err := s.Remove(context.Background(), tc.issueIDOrKey, tc.attachmentID)
 
@@ -732,9 +737,9 @@ func TestPullRequestAttachmentService_List(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewPullRequestService(&core.Method{
-				Get: tc.mockGetFn,
-			})
+			method := mock.NewMethod(t)
+			method.Get = tc.mockGetFn
+			s := attachment.NewPullRequestService(method)
 
 			attachments, err := s.List(context.Background(),
 				tc.projectIDOrKey,
@@ -865,9 +870,9 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := attachment.NewPullRequestService(&core.Method{
-				Delete: tc.mockDeleteFn,
-			})
+			method := mock.NewMethod(t)
+			method.Delete = tc.mockDeleteFn
+			s := attachment.NewPullRequestService(method)
 
 			attachment, err := s.Remove(
 				context.Background(),
@@ -906,75 +911,83 @@ func TestAttachmentService_contextPropagation(t *testing.T) {
 		call func(t *testing.T)
 	}{
 		{"SpaceService.Upload", func(t *testing.T) {
-			s := attachment.NewSpaceService(&core.Method{
-				Upload: func(got context.Context, _, _ string, _ io.Reader) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Upload = func(got context.Context, _, _ string, _ io.Reader) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := attachment.NewSpaceService(method)
+
 			s.Upload(ctx, "f", bytes.NewReader(nil)) //nolint:errcheck
 		}},
 		{"WikiService.Attach", func(t *testing.T) {
-			s := attachment.NewWikiService(&core.Method{
-				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := attachment.NewWikiService(method)
+
 			s.Attach(ctx, 1, []int{1}) //nolint:errcheck
 		}},
 		{"WikiService.List", func(t *testing.T) {
-			s := attachment.NewWikiService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := attachment.NewWikiService(method)
+
 			s.List(ctx, 1) //nolint:errcheck
 		}},
 		{"WikiService.Remove", func(t *testing.T) {
-			s := attachment.NewWikiService(&core.Method{
-				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := attachment.NewWikiService(method)
+
 			s.Remove(ctx, 1, 1) //nolint:errcheck
 		}},
 		{"IssueService.List", func(t *testing.T) {
-			s := attachment.NewIssueService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := attachment.NewIssueService(method)
+
 			s.List(ctx, "TEST-1") //nolint:errcheck
 		}},
 		{"IssueService.Remove", func(t *testing.T) {
-			s := attachment.NewIssueService(&core.Method{
-				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := attachment.NewIssueService(method)
+
 			s.Remove(ctx, "TEST-1", 1) //nolint:errcheck
 		}},
 		{"PullRequestService.List", func(t *testing.T) {
-			s := attachment.NewPullRequestService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := attachment.NewPullRequestService(method)
+
 			s.List(ctx, "TEST", "repo", 1) //nolint:errcheck
 		}},
 		{"PullRequestService.Remove", func(t *testing.T) {
-			s := attachment.NewPullRequestService(&core.Method{
-				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := attachment.NewPullRequestService(method)
+
 			s.Remove(ctx, "TEST", "repo", 1, 1) //nolint:errcheck
 		}},
 	}

--- a/internal/issue/service_test.go
+++ b/internal/issue/service_test.go
@@ -749,9 +749,11 @@ func TestIssueService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
-	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-		assert.Same(t, sentinel, got.Value(ctxKey{}))
-		return nil, errors.New("stop")
+	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
 	}
 
 	o := &core.OptionService{}
@@ -761,32 +763,32 @@ func TestIssueService_contextPropagation(t *testing.T) {
 		call func(t *testing.T, m *core.Method)
 	}{
 		{"All", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := issue.NewService(m)
 			s.All(ctx) //nolint:errcheck
 		}},
 		{"Count", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := issue.NewService(m)
 			s.Count(ctx) //nolint:errcheck
 		}},
 		{"One", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := issue.NewService(m)
 			s.One(ctx, "PRJ-1") //nolint:errcheck
 		}},
 		{"Create", func(t *testing.T, m *core.Method) {
-			m.Post = mockFn
+			m.Post = makeMockFn(t)
 			s := issue.NewService(m)
 			s.Create(ctx, 10, "summary", 2, 3) //nolint:errcheck
 		}},
 		{"Update", func(t *testing.T, m *core.Method) {
-			m.Patch = mockFn
+			m.Patch = makeMockFn(t)
 			s := issue.NewService(m)
 			s.Update(ctx, "PRJ-1", o.WithSummary("x")) //nolint:errcheck
 		}},
 		{"Delete", func(t *testing.T, m *core.Method) {
-			m.Delete = mockFn
+			m.Delete = makeMockFn(t)
 			s := issue.NewService(m)
 			s.Delete(ctx, "PRJ-1") //nolint:errcheck
 		}},

--- a/internal/issue/service_test.go
+++ b/internal/issue/service_test.go
@@ -808,7 +808,7 @@ func TestIssueService_contextPropagation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t, &core.Method{})
+			tc.call(t, mock.NewMethod(t))
 		})
 	}
 }

--- a/internal/issue/service_test.go
+++ b/internal/issue/service_test.go
@@ -175,7 +175,7 @@ func TestIssueService_All(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			method := &core.Method{Get: mock.NewUnexpectedGetFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -275,7 +275,7 @@ func TestIssueService_Count(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			method := &core.Method{Get: mock.NewUnexpectedGetFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -359,7 +359,7 @@ func TestIssueService_One(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			method := &core.Method{Get: mock.NewUnexpectedGetFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -508,7 +508,7 @@ func TestIssueService_Create(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			method := &core.Method{Post: mock.NewUnexpectedPostFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockPostFn != nil {
 				method.Post = tc.mockPostFn
 			}
@@ -636,7 +636,7 @@ func TestIssueService_Update(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			method := &core.Method{Patch: mock.NewUnexpectedPatchFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockPatchFn != nil {
 				method.Patch = tc.mockPatchFn
 			}
@@ -721,7 +721,7 @@ func TestIssueService_Delete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			method := &core.Method{Delete: mock.NewUnexpectedDeleteFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockDeleteFn != nil {
 				method.Delete = tc.mockDeleteFn
 			}

--- a/internal/issue/service_test.go
+++ b/internal/issue/service_test.go
@@ -749,6 +749,11 @@ func TestIssueService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
+	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+		assert.Same(t, sentinel, got.Value(ctxKey{}))
+		return nil, errors.New("stop")
+	}
+
 	o := &core.OptionService{}
 
 	cases := []struct {
@@ -756,50 +761,32 @@ func TestIssueService_contextPropagation(t *testing.T) {
 		call func(t *testing.T, m *core.Method)
 	}{
 		{"All", func(t *testing.T, m *core.Method) {
-			m.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Get = mockFn
 			s := issue.NewService(m)
 			s.All(ctx) //nolint:errcheck
 		}},
 		{"Count", func(t *testing.T, m *core.Method) {
-			m.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Get = mockFn
 			s := issue.NewService(m)
 			s.Count(ctx) //nolint:errcheck
 		}},
 		{"One", func(t *testing.T, m *core.Method) {
-			m.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Get = mockFn
 			s := issue.NewService(m)
 			s.One(ctx, "PRJ-1") //nolint:errcheck
 		}},
 		{"Create", func(t *testing.T, m *core.Method) {
-			m.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Post = mockFn
 			s := issue.NewService(m)
 			s.Create(ctx, 10, "summary", 2, 3) //nolint:errcheck
 		}},
 		{"Update", func(t *testing.T, m *core.Method) {
-			m.Patch = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Patch = mockFn
 			s := issue.NewService(m)
 			s.Update(ctx, "PRJ-1", o.WithSummary("x")) //nolint:errcheck
 		}},
 		{"Delete", func(t *testing.T, m *core.Method) {
-			m.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Delete = mockFn
 			s := issue.NewService(m)
 			s.Delete(ctx, "PRJ-1") //nolint:errcheck
 		}},

--- a/internal/issue/service_test.go
+++ b/internal/issue/service_test.go
@@ -795,7 +795,7 @@ func TestIssueService_contextPropagation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t, mock.NewMethod(t))
+			tc.call(t, &core.Method{})
 		})
 	}
 }

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -648,9 +648,11 @@ func TestProjectService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
-	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-		assert.Same(t, sentinel, got.Value(ctxKey{}))
-		return nil, errors.New("stop")
+	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
 	}
 
 	o := &core.OptionService{}
@@ -660,27 +662,27 @@ func TestProjectService_contextPropagation(t *testing.T) {
 		call func(t *testing.T, m *core.Method)
 	}{
 		{"All", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := project.NewService(m)
 			s.All(ctx) //nolint:errcheck
 		}},
 		{"One", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := project.NewService(m)
 			s.One(ctx, "TEST") //nolint:errcheck
 		}},
 		{"Create", func(t *testing.T, m *core.Method) {
-			m.Post = mockFn
+			m.Post = makeMockFn(t)
 			s := project.NewService(m)
 			s.Create(ctx, "KEY", "name", o.WithChartEnabled(true)) //nolint:errcheck
 		}},
 		{"Update", func(t *testing.T, m *core.Method) {
-			m.Patch = mockFn
+			m.Patch = makeMockFn(t)
 			s := project.NewService(m)
 			s.Update(ctx, "TEST") //nolint:errcheck
 		}},
 		{"Delete", func(t *testing.T, m *core.Method) {
-			m.Delete = mockFn
+			m.Delete = makeMockFn(t)
 			s := project.NewService(m)
 			s.Delete(ctx, "TEST") //nolint:errcheck
 		}}}

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -648,67 +648,47 @@ func TestProjectService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
+	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+		assert.Same(t, sentinel, got.Value(ctxKey{}))
+		return nil, errors.New("stop")
+	}
+
 	o := &core.OptionService{}
 
 	cases := []struct {
 		name string
-		call func(t *testing.T)
+		call func(t *testing.T, m *core.Method)
 	}{
-		{"All", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := project.NewService(method)
-
+		{"All", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := project.NewService(m)
 			s.All(ctx) //nolint:errcheck
 		}},
-		{"One", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := project.NewService(method)
-
+		{"One", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := project.NewService(m)
 			s.One(ctx, "TEST") //nolint:errcheck
 		}},
-		{"Create", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := project.NewService(method)
-
+		{"Create", func(t *testing.T, m *core.Method) {
+			m.Post = mockFn
+			s := project.NewService(m)
 			s.Create(ctx, "KEY", "name", o.WithChartEnabled(true)) //nolint:errcheck
 		}},
-		{"Update", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Patch = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := project.NewService(method)
-
+		{"Update", func(t *testing.T, m *core.Method) {
+			m.Patch = mockFn
+			s := project.NewService(m)
 			s.Update(ctx, "TEST") //nolint:errcheck
 		}},
-		{"Delete", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := project.NewService(method)
-
+		{"Delete", func(t *testing.T, m *core.Method) {
+			m.Delete = mockFn
+			s := project.NewService(m)
 			s.Delete(ctx, "TEST") //nolint:errcheck
 		}}}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t)
+			tc.call(t, mock.NewMethod(t))
 		})
 	}
 }

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -688,7 +688,7 @@ func TestProjectService_contextPropagation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t, mock.NewMethod(t))
+			tc.call(t, &core.Method{})
 		})
 	}
 }

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -107,10 +107,7 @@ func TestProjectService_All(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Get: mock.NewUnexpectedGetFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -205,10 +202,7 @@ func TestProjectService_One(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Get: mock.NewUnexpectedGetFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -374,10 +368,7 @@ func TestProjectService_Create(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Post: mock.NewUnexpectedPostFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockPostFn != nil {
 				method.Post = tc.mockPostFn
 			}
@@ -532,10 +523,7 @@ func TestProjectService_Update(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Patch: mock.NewUnexpectedPatchFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockPatchFn != nil {
 				method.Patch = tc.mockPatchFn
 			}
@@ -630,10 +618,7 @@ func TestProjectService_Delete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Delete: mock.NewUnexpectedDeleteFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockDeleteFn != nil {
 				method.Delete = tc.mockDeleteFn
 			}

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -655,48 +655,53 @@ func TestProjectService_contextPropagation(t *testing.T) {
 		call func(t *testing.T)
 	}{
 		{"All", func(t *testing.T) {
-			s := project.NewService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := project.NewService(method)
+
 			s.All(ctx) //nolint:errcheck
 		}},
 		{"One", func(t *testing.T) {
-			s := project.NewService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := project.NewService(method)
+
 			s.One(ctx, "TEST") //nolint:errcheck
 		}},
 		{"Create", func(t *testing.T) {
-			s := project.NewService(&core.Method{
-				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := project.NewService(method)
+
 			s.Create(ctx, "KEY", "name", o.WithChartEnabled(true)) //nolint:errcheck
 		}},
 		{"Update", func(t *testing.T) {
-			s := project.NewService(&core.Method{
-				Patch: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Patch = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := project.NewService(method)
+
 			s.Update(ctx, "TEST") //nolint:errcheck
 		}},
 		{"Delete", func(t *testing.T) {
-			s := project.NewService(&core.Method{
-				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := project.NewService(method)
+
 			s.Delete(ctx, "TEST") //nolint:errcheck
 		}}}
 

--- a/internal/testutil/mock/mock.go
+++ b/internal/testutil/mock/mock.go
@@ -93,6 +93,25 @@ func NewInvalidTypeOption() *core.APIParamOption {
 	}
 }
 
+// ──────────────────────────────────────────────────────────────
+//  Method mock helpers
+// ──────────────────────────────────────────────────────────────
+
+// NewMethod returns a *core.Method with all fields initialized to their
+// corresponding NewUnexpected*Fn(t) functions. Tests should replace only the
+// fields they intend to exercise, so that any accidental call to an unintended
+// HTTP method causes an immediate test failure instead of a nil-pointer panic.
+func NewMethod(t *testing.T) *core.Method {
+	t.Helper()
+	return &core.Method{
+		Get:    NewUnexpectedGetFn(t),
+		Post:   NewUnexpectedPostFn(t),
+		Patch:  NewUnexpectedPatchFn(t),
+		Delete: NewUnexpectedDeleteFn(t),
+		Upload: NewUnexpectedUploadFn(t),
+	}
+}
+
 // NewUnexpectedGetFn returns a mock function for http GET that fails if called.
 func NewUnexpectedGetFn(t *testing.T) func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 	t.Helper()

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -72,10 +72,7 @@ func TestUserService_One(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Get: mock.NewUnexpectedGetFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -163,8 +160,6 @@ func TestUserService_Add(t *testing.T) {
 			mailAddress: "admin@example.com",
 			roleType:    model.RoleAdministrator,
 
-			mockPostFn: mock.NewUnexpectedPostFn(t),
-
 			wantErrType: &core.ValidationError{},
 		},
 		"error-validation-password-empty": {
@@ -173,8 +168,6 @@ func TestUserService_Add(t *testing.T) {
 			name:        "admin",
 			mailAddress: "admin@example.com",
 			roleType:    model.RoleAdministrator,
-
-			mockPostFn: mock.NewUnexpectedPostFn(t),
 
 			wantErrType: &core.ValidationError{},
 		},
@@ -185,8 +178,6 @@ func TestUserService_Add(t *testing.T) {
 			mailAddress: "admin@example.com",
 			roleType:    model.RoleAdministrator,
 
-			mockPostFn: mock.NewUnexpectedPostFn(t),
-
 			wantErrType: &core.ValidationError{},
 		},
 		"error-validation-mailAddress-empty": {
@@ -196,8 +187,6 @@ func TestUserService_Add(t *testing.T) {
 			mailAddress: "",
 			roleType:    model.RoleAdministrator,
 
-			mockPostFn: mock.NewUnexpectedPostFn(t),
-
 			wantErrType: &core.ValidationError{},
 		},
 		"error-validation-multiple-empty": {
@@ -206,8 +195,6 @@ func TestUserService_Add(t *testing.T) {
 			name:        "",
 			mailAddress: "",
 			roleType:    model.RoleAdministrator,
-
-			mockPostFn: mock.NewUnexpectedPostFn(t),
 
 			wantErrType: &core.ValidationError{},
 		},
@@ -233,10 +220,7 @@ func TestUserService_Add(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Post: mock.NewUnexpectedPostFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockPostFn != nil {
 				method.Post = tc.mockPostFn
 			}
@@ -317,10 +301,7 @@ func TestUserService_All(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Get: mock.NewUnexpectedGetFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -508,10 +489,7 @@ func TestUserService_Update(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Patch: mock.NewUnexpectedPatchFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockPatchFn != nil {
 				method.Patch = tc.mockPatchFn
 			}
@@ -588,10 +566,7 @@ func TestUserService_Own(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Get: mock.NewUnexpectedPatchFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -677,10 +652,7 @@ func TestUserService_Delete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Delete: mock.NewUnexpectedPatchFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockDeleteFn != nil {
 				method.Delete = tc.mockDeleteFn
 			}
@@ -802,10 +774,7 @@ func TestProjectUserService_All(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Get: mock.NewUnexpectedGetFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -913,10 +882,7 @@ func TestProjectUserService_Add(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Post: mock.NewUnexpectedPostFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockPostFn != nil {
 				method.Post = tc.mockPostFn
 			}
@@ -990,7 +956,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 				MailAddress: "eguchi@nulab.example",
 				RoleType:    model.RoleAdministrator,
 			},
-		},
+tml	},
 		"error-validation-projectKey-empty": {
 			projectKey: "",
 			userID:     1,
@@ -1044,10 +1010,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Delete: mock.NewUnexpectedDeleteFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockDeleteFn != nil {
 				method.Delete = tc.mockDeleteFn
 			}
@@ -1154,10 +1117,7 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Post: mock.NewUnexpectedPostFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockPostFn != nil {
 				method.Post = tc.mockPostFn
 			}
@@ -1212,10 +1172,7 @@ func TestProjectUserService_AdminAll(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Get: mock.NewUnexpectedGetFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -1281,10 +1238,7 @@ func TestProjectUserService_DeleteAdmin(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{
-				Delete: mock.NewUnexpectedDeleteFn(t),
-			}
+			method := mock.NewMethod(t)
 			if tc.mockDeleteFn != nil {
 				method.Delete = tc.mockDeleteFn
 			}

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -1339,7 +1339,7 @@ func TestUserService_contextPropagation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t, mock.NewMethod(t))
+			tc.call(t, &core.Method{})
 		})
 	}
 }

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -1270,111 +1270,111 @@ func TestUserService_contextPropagation(t *testing.T) {
 		call func(t *testing.T)
 	}{
 		{"UserService.All", func(t *testing.T) {
-			s := user.NewService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewService(method)
 			s.All(ctx) //nolint:errcheck
 		}},
 		{"UserService.One", func(t *testing.T) {
-			s := user.NewService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewService(method)
 			s.One(ctx, 1) //nolint:errcheck
 		}},
 		{"UserService.Own", func(t *testing.T) {
-			s := user.NewService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewService(method)
 			s.Own(ctx) //nolint:errcheck
 		}},
 		{"UserService.Add", func(t *testing.T) {
-			s := user.NewService(&core.Method{
-				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewService(method)
 			s.Add(ctx, "u", "p", "n", "m@m.com", model.RoleAdministrator) //nolint:errcheck
 		}},
 		{"UserService.Update", func(t *testing.T) {
-			s := user.NewService(&core.Method{
-				Patch: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Patch = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewService(method)
 			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
 		}},
 		{"UserService.Delete", func(t *testing.T) {
-			s := user.NewService(&core.Method{
-				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewService(method)
 			s.Delete(ctx, 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.All", func(t *testing.T) {
-			s := user.NewProjectService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewProjectService(method)
 			s.All(ctx, "TEST", false) //nolint:errcheck
 		}},
 		{"ProjectUserService.Add", func(t *testing.T) {
-			s := user.NewProjectService(&core.Method{
-				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewProjectService(method)
 			s.Add(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.Delete", func(t *testing.T) {
-			s := user.NewProjectService(&core.Method{
-				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewProjectService(method)
 			s.Delete(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.AddAdmin", func(t *testing.T) {
-			s := user.NewProjectService(&core.Method{
-				Post: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewProjectService(method)
 			s.AddAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.AdminAll", func(t *testing.T) {
-			s := user.NewProjectService(&core.Method{
-				Get: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewProjectService(method)
 			s.AdminAll(ctx, "TEST") //nolint:errcheck
 		}},
 		{"ProjectUserService.DeleteAdmin", func(t *testing.T) {
-			s := user.NewProjectService(&core.Method{
-				Delete: func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-					assert.Same(t, sentinel, got.Value(ctxKey{}))
-					return nil, errors.New("stop")
-				},
-			})
+			method := mock.NewMethod(t)
+			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+				assert.Same(t, sentinel, got.Value(ctxKey{}))
+				return nil, errors.New("stop")
+			}
+			s := user.NewProjectService(method)
 			s.DeleteAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},
 	}

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -1263,118 +1263,75 @@ func TestUserService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
+	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+		assert.Same(t, sentinel, got.Value(ctxKey{}))
+		return nil, errors.New("stop")
+	}
+
 	o := &core.OptionService{}
 
 	cases := []struct {
 		name string
-		call func(t *testing.T)
+		call func(t *testing.T, m *core.Method)
 	}{
-		{"UserService.All", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewService(method)
+		{"UserService.All", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := user.NewService(m)
 			s.All(ctx) //nolint:errcheck
 		}},
-		{"UserService.One", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewService(method)
+		{"UserService.One", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := user.NewService(m)
 			s.One(ctx, 1) //nolint:errcheck
 		}},
-		{"UserService.Own", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewService(method)
+		{"UserService.Own", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := user.NewService(m)
 			s.Own(ctx) //nolint:errcheck
 		}},
-		{"UserService.Add", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewService(method)
+		{"UserService.Add", func(t *testing.T, m *core.Method) {
+			m.Post = mockFn
+			s := user.NewService(m)
 			s.Add(ctx, "u", "p", "n", "m@m.com", model.RoleAdministrator) //nolint:errcheck
 		}},
-		{"UserService.Update", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Patch = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewService(method)
+		{"UserService.Update", func(t *testing.T, m *core.Method) {
+			m.Patch = mockFn
+			s := user.NewService(m)
 			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
 		}},
-		{"UserService.Delete", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewService(method)
+		{"UserService.Delete", func(t *testing.T, m *core.Method) {
+			m.Delete = mockFn
+			s := user.NewService(m)
 			s.Delete(ctx, 1) //nolint:errcheck
 		}},
-		{"ProjectUserService.All", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewProjectService(method)
+		{"ProjectUserService.All", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := user.NewProjectService(m)
 			s.All(ctx, "TEST", false) //nolint:errcheck
 		}},
-		{"ProjectUserService.Add", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewProjectService(method)
+		{"ProjectUserService.Add", func(t *testing.T, m *core.Method) {
+			m.Post = mockFn
+			s := user.NewProjectService(m)
 			s.Add(ctx, "TEST", 1) //nolint:errcheck
 		}},
-		{"ProjectUserService.Delete", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewProjectService(method)
+		{"ProjectUserService.Delete", func(t *testing.T, m *core.Method) {
+			m.Delete = mockFn
+			s := user.NewProjectService(m)
 			s.Delete(ctx, "TEST", 1) //nolint:errcheck
 		}},
-		{"ProjectUserService.AddAdmin", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewProjectService(method)
+		{"ProjectUserService.AddAdmin", func(t *testing.T, m *core.Method) {
+			m.Post = mockFn
+			s := user.NewProjectService(m)
 			s.AddAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},
-		{"ProjectUserService.AdminAll", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewProjectService(method)
+		{"ProjectUserService.AdminAll", func(t *testing.T, m *core.Method) {
+			m.Get = mockFn
+			s := user.NewProjectService(m)
 			s.AdminAll(ctx, "TEST") //nolint:errcheck
 		}},
-		{"ProjectUserService.DeleteAdmin", func(t *testing.T) {
-			method := mock.NewMethod(t)
-			method.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
-			s := user.NewProjectService(method)
+		{"ProjectUserService.DeleteAdmin", func(t *testing.T, m *core.Method) {
+			m.Delete = mockFn
+			s := user.NewProjectService(m)
 			s.DeleteAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},
 	}
@@ -1382,7 +1339,7 @@ func TestUserService_contextPropagation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t)
+			tc.call(t, mock.NewMethod(t))
 		})
 	}
 }

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -1263,9 +1263,11 @@ func TestUserService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
-	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-		assert.Same(t, sentinel, got.Value(ctxKey{}))
-		return nil, errors.New("stop")
+	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
 	}
 
 	o := &core.OptionService{}
@@ -1275,62 +1277,62 @@ func TestUserService_contextPropagation(t *testing.T) {
 		call func(t *testing.T, m *core.Method)
 	}{
 		{"UserService.All", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := user.NewService(m)
 			s.All(ctx) //nolint:errcheck
 		}},
 		{"UserService.One", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := user.NewService(m)
 			s.One(ctx, 1) //nolint:errcheck
 		}},
 		{"UserService.Own", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := user.NewService(m)
 			s.Own(ctx) //nolint:errcheck
 		}},
 		{"UserService.Add", func(t *testing.T, m *core.Method) {
-			m.Post = mockFn
+			m.Post = makeMockFn(t)
 			s := user.NewService(m)
 			s.Add(ctx, "u", "p", "n", "m@m.com", model.RoleAdministrator) //nolint:errcheck
 		}},
 		{"UserService.Update", func(t *testing.T, m *core.Method) {
-			m.Patch = mockFn
+			m.Patch = makeMockFn(t)
 			s := user.NewService(m)
 			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
 		}},
 		{"UserService.Delete", func(t *testing.T, m *core.Method) {
-			m.Delete = mockFn
+			m.Delete = makeMockFn(t)
 			s := user.NewService(m)
 			s.Delete(ctx, 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.All", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.All(ctx, "TEST", false) //nolint:errcheck
 		}},
 		{"ProjectUserService.Add", func(t *testing.T, m *core.Method) {
-			m.Post = mockFn
+			m.Post = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.Add(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.Delete", func(t *testing.T, m *core.Method) {
-			m.Delete = mockFn
+			m.Delete = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.Delete(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.AddAdmin", func(t *testing.T, m *core.Method) {
-			m.Post = mockFn
+			m.Post = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.AddAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"ProjectUserService.AdminAll", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.AdminAll(ctx, "TEST") //nolint:errcheck
 		}},
 		{"ProjectUserService.DeleteAdmin", func(t *testing.T, m *core.Method) {
-			m.Delete = mockFn
+			m.Delete = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.DeleteAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -956,7 +956,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 				MailAddress: "eguchi@nulab.example",
 				RoleType:    model.RoleAdministrator,
 			},
-tml	},
+		},
 		"error-validation-projectKey-empty": {
 			projectKey: "",
 			userID:     1,

--- a/internal/wiki/service_test.go
+++ b/internal/wiki/service_test.go
@@ -126,8 +126,7 @@ func TestWikiService_All(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{Get: mock.NewUnexpectedGetFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -227,8 +226,7 @@ func TestWikiService_Count(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{Get: mock.NewUnexpectedGetFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -314,8 +312,7 @@ func TestWikiService_One(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{Get: mock.NewUnexpectedGetFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockGetFn != nil {
 				method.Get = tc.mockGetFn
 			}
@@ -476,8 +473,7 @@ func TestWikiService_Create(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{Post: mock.NewUnexpectedPostFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockPostFn != nil {
 				method.Post = tc.mockPostFn
 			}
@@ -658,8 +654,7 @@ func TestWikiService_Update(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{Patch: mock.NewUnexpectedPatchFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockPatchFn != nil {
 				method.Patch = tc.mockPatchFn
 			}
@@ -772,8 +767,7 @@ func TestWikiService_Delete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// default: unexpected API call
-			method := &core.Method{Delete: mock.NewUnexpectedDeleteFn(t)}
+			method := mock.NewMethod(t)
 			if tc.mockDeleteFn != nil {
 				method.Delete = tc.mockDeleteFn
 			}

--- a/internal/wiki/service_test.go
+++ b/internal/wiki/service_test.go
@@ -800,6 +800,11 @@ func TestWikiService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
+	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+		assert.Same(t, sentinel, got.Value(ctxKey{}))
+		return nil, errors.New("stop")
+	}
+
 	o := &core.OptionService{}
 
 	cases := []struct {
@@ -807,50 +812,32 @@ func TestWikiService_contextPropagation(t *testing.T) {
 		call func(t *testing.T, m *core.Method)
 	}{
 		{"All", func(t *testing.T, m *core.Method) {
-			m.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Get = mockFn
 			s := wiki.NewService(m)
 			s.All(ctx, "TEST") //nolint:errcheck
 		}},
 		{"Count", func(t *testing.T, m *core.Method) {
-			m.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Get = mockFn
 			s := wiki.NewService(m)
 			s.Count(ctx, "TEST") //nolint:errcheck
 		}},
 		{"One", func(t *testing.T, m *core.Method) {
-			m.Get = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Get = mockFn
 			s := wiki.NewService(m)
 			s.One(ctx, 1) //nolint:errcheck
 		}},
 		{"Create", func(t *testing.T, m *core.Method) {
-			m.Post = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Post = mockFn
 			s := wiki.NewService(m)
 			s.Create(ctx, 1, "name", "content") //nolint:errcheck
 		}},
 		{"Update", func(t *testing.T, m *core.Method) {
-			m.Patch = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Patch = mockFn
 			s := wiki.NewService(m)
 			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
 		}},
 		{"Delete", func(t *testing.T, m *core.Method) {
-			m.Delete = func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-				assert.Same(t, sentinel, got.Value(ctxKey{}))
-				return nil, errors.New("stop")
-			}
+			m.Delete = mockFn
 			s := wiki.NewService(m)
 			s.Delete(ctx, 1) //nolint:errcheck
 		}},

--- a/internal/wiki/service_test.go
+++ b/internal/wiki/service_test.go
@@ -800,9 +800,11 @@ func TestWikiService_contextPropagation(t *testing.T) {
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
 
-	mockFn := func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-		assert.Same(t, sentinel, got.Value(ctxKey{}))
-		return nil, errors.New("stop")
+	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
 	}
 
 	o := &core.OptionService{}
@@ -812,32 +814,32 @@ func TestWikiService_contextPropagation(t *testing.T) {
 		call func(t *testing.T, m *core.Method)
 	}{
 		{"All", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.All(ctx, "TEST") //nolint:errcheck
 		}},
 		{"Count", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Count(ctx, "TEST") //nolint:errcheck
 		}},
 		{"One", func(t *testing.T, m *core.Method) {
-			m.Get = mockFn
+			m.Get = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.One(ctx, 1) //nolint:errcheck
 		}},
 		{"Create", func(t *testing.T, m *core.Method) {
-			m.Post = mockFn
+			m.Post = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Create(ctx, 1, "name", "content") //nolint:errcheck
 		}},
 		{"Update", func(t *testing.T, m *core.Method) {
-			m.Patch = mockFn
+			m.Patch = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
 		}},
 		{"Delete", func(t *testing.T, m *core.Method) {
-			m.Delete = mockFn
+			m.Delete = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Delete(ctx, 1) //nolint:errcheck
 		}},

--- a/internal/wiki/service_test.go
+++ b/internal/wiki/service_test.go
@@ -846,7 +846,7 @@ func TestWikiService_contextPropagation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t, mock.NewMethod(t))
+			tc.call(t, &core.Method{})
 		})
 	}
 }

--- a/internal/wiki/service_test.go
+++ b/internal/wiki/service_test.go
@@ -859,7 +859,7 @@ func TestWikiService_contextPropagation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.call(t, &core.Method{})
+			tc.call(t, mock.NewMethod(t))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Adds `mock.NewMethod(t)` — a helper that initializes a `*core.Method` with all fields set to their corresponding `NewUnexpected*Fn(t)` function. This ensures that any accidental call to an unintended HTTP method fails the test immediately with a clear message, rather than causing a nil-pointer panic.

Migrates all existing internal service tests to use the new helper in place of the previous ad-hoc `&core.Method{<single-field>: mock.NewUnexpected*Fn(t)}` pattern.

## Changes

- `internal/testutil/mock/mock.go`: add `NewMethod(t *testing.T) *core.Method`
- `internal/wiki/service_test.go`: migrate to `mock.NewMethod(t)`
- `internal/issue/service_test.go`: migrate to `mock.NewMethod(t)`
- `internal/project/service_test.go`: migrate to `mock.NewMethod(t)`
- `internal/user/service_test.go`: migrate to `mock.NewMethod(t)`; also fix two bugs where `NewUnexpectedPatchFn` was incorrectly assigned to `Get` in `TestUserService_Own` and to `Delete` in `TestUserService_Delete`

## Notes

`contextPropagation` tests are not migrated. Each case receives a `*core.Method{}` zero value and sets exactly one field inline, so only one HTTP method is ever called per case. The helper is unnecessary there.

Closes #201