### PR TITLE
feat: implement PullRequestService core methods

### DIFF
--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -1,11 +1,212 @@
 package pullrequest
 
 import (
+	"context"
+	"net/url"
+	"path"
+	"strconv"
+
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/validate"
 )
 
 type Service struct {
 	method *core.Method
+}
+
+// All returns a list of pull requests.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
+func (s *Service) All(ctx context.Context, projectIDOrKey string, repoIDOrName string, opts ...core.RequestOption) ([]*model.PullRequest, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return nil, err
+	}
+
+	query := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamStatusIDs,
+		core.ParamAssigneeIDs,
+		core.ParamIssueIDs,
+		core.ParamCreatedUserIDs,
+		core.ParamOffset,
+		core.ParamCount,
+	}
+	if err := core.ApplyOptions(query, validTypes, opts...); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests")
+	resp, err := s.method.Get(ctx, spath, query)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.PullRequest{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Count returns the number of pull requests.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-number-of-pull-requests
+func (s *Service) Count(ctx context.Context, projectIDOrKey string, repoIDOrName string, opts ...core.RequestOption) (int, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return 0, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return 0, err
+	}
+
+	query := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamStatusIDs,
+		core.ParamAssigneeIDs,
+		core.ParamIssueIDs,
+		core.ParamCreatedUserIDs,
+	}
+	if err := core.ApplyOptions(query, validTypes, opts...); err != nil {
+		return 0, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", "count")
+	resp, err := s.method.Get(ctx, spath, query)
+	if err != nil {
+		return 0, err
+	}
+
+	v := map[string]int{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return 0, err
+	}
+
+	return v["count"], nil
+}
+
+// One returns a single pull request by its number.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request
+func (s *Service) One(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int) (*model.PullRequest, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidatePRNumber(prNumber); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber))
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.PullRequest{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Create creates a new pull request.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-pull-request
+func (s *Service) Create(ctx context.Context, projectIDOrKey string, repoIDOrName string, summary string, description string, base string, branch string, opts ...core.RequestOption) (*model.PullRequest, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return nil, err
+	}
+
+	option := &core.OptionService{}
+	form := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamSummary,
+		core.ParamDescription,
+		core.ParamBase,
+		core.ParamBranch,
+		core.ParamIssueID,
+		core.ParamAssigneeID,
+		core.ParamNotifiedUserIDs,
+		core.ParamAttachmentIDs,
+	}
+	options := append(
+		[]core.RequestOption{
+			option.WithSummary(summary),
+			option.WithDescription(description),
+			option.WithBase(base),
+			option.WithBranch(branch),
+		},
+		opts...,
+	)
+	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests")
+	resp, err := s.method.Post(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.PullRequest{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Update updates an existing pull request.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-pull-request
+func (s *Service) Update(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, option core.RequestOption, opts ...core.RequestOption) (*model.PullRequest, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidatePRNumber(prNumber); err != nil {
+		return nil, err
+	}
+
+	form := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamSummary,
+		core.ParamDescription,
+		core.ParamIssueID,
+		core.ParamAssigneeID,
+		core.ParamNotifiedUserIDs,
+		core.ParamComment,
+	}
+	options := append([]core.RequestOption{option}, opts...)
+	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber))
+	resp, err := s.method.Patch(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.PullRequest{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -1,0 +1,744 @@
+package pullrequest_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/pullrequest"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
+)
+
+const (
+	testProject = "PRJ"
+	testRepo    = "repo1"
+)
+
+func TestPullRequestService_All(t *testing.T) {
+	o := &core.OptionService{}
+
+	cases := map[string]struct {
+		projectIDOrKey string
+		repoIDOrName   string
+		opts           []core.RequestOption
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantNumbers []int
+	}{
+		"success-no-options": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/PRJ/git/repositories/repo1/pullRequests", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.ListJSON))),
+				}, nil
+			},
+			wantNumbers: []int{1, 2},
+		},
+		"success-with-statusIDs": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			opts:           []core.RequestOption{o.WithStatusIDs([]int{1, 2})},
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, []string{"1", "2"}, query["statusId[]"])
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.ListJSON))),
+				}, nil
+			},
+			wantNumbers: []int{1, 2},
+		},
+		"success-with-count-and-offset": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			opts: []core.RequestOption{
+				o.WithCount(50),
+				o.WithOffset(10),
+			},
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "50", query.Get("count"))
+				assert.Equal(t, "10", query.Get("offset"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.ListJSON))),
+				}, nil
+			},
+			wantNumbers: []int{1, 2},
+		},
+		"error-empty-projectIDOrKey": {
+			projectIDOrKey: "",
+			repoIDOrName:   testRepo,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-zero-projectIDOrKey": {
+			projectIDOrKey: "0",
+			repoIDOrName:   testRepo,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-empty-repoIDOrName": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   "",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-zero-repoIDOrName": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   "0",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-option-invalid-type": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			opts:           []core.RequestOption{mock.NewInvalidTypeOption()},
+			wantErrType:    &core.InvalidOptionKeyError{},
+		},
+		"error-option-invalid-statusID": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			opts:           []core.RequestOption{o.WithStatusIDs([]int{0})},
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-option-invalid-count": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			opts:           []core.RequestOption{o.WithCount(0)},
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-option-set-failed": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			opts:           []core.RequestOption{mock.NewFailingSetOption(core.ParamOffset)},
+			wantErrType:    errors.New(""),
+		},
+		"error-client-network": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := pullrequest.NewService(method)
+			prs, err := s.All(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.opts...)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, prs)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, prs)
+			assert.Len(t, prs, len(tc.wantNumbers))
+			for i := range prs {
+				assert.Equal(t, tc.wantNumbers[i], prs[i].Number)
+			}
+		})
+	}
+}
+
+func TestPullRequestService_Count(t *testing.T) {
+	o := &core.OptionService{}
+
+	cases := map[string]struct {
+		projectIDOrKey string
+		repoIDOrName   string
+		opts           []core.RequestOption
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantCount   int
+	}{
+		"success-no-options": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/PRJ/git/repositories/repo1/pullRequests/count", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count":5}`))),
+				}, nil
+			},
+			wantCount: 5,
+		},
+		"success-with-assigneeIDs": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			opts:           []core.RequestOption{o.WithAssigneeIDs([]int{10, 20})},
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, []string{"10", "20"}, query["assigneeId[]"])
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count":2}`))),
+				}, nil
+			},
+			wantCount: 2,
+		},
+		"error-empty-projectIDOrKey": {
+			projectIDOrKey: "",
+			repoIDOrName:   testRepo,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-empty-repoIDOrName": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   "",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-option-invalid-type": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			opts:           []core.RequestOption{mock.NewInvalidTypeOption()},
+			wantErrType:    &core.InvalidOptionKeyError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := pullrequest.NewService(method)
+			count, err := s.Count(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.opts...)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Zero(t, count)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantCount, count)
+		})
+	}
+}
+
+func TestPullRequestService_One(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+		repoIDOrName   string
+		prNumber       int
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantNumber  int
+	}{
+		"success": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/PRJ/git/repositories/repo1/pullRequests/1", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+				}, nil
+			},
+			wantNumber: 1,
+		},
+		"error-empty-projectIDOrKey": {
+			projectIDOrKey: "",
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-empty-repoIDOrName": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   "",
+			prNumber:       1,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-invalid-prNumber": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       0,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := pullrequest.NewService(method)
+			got, err := s.One(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.prNumber)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantNumber, got.Number)
+		})
+	}
+}
+
+func TestPullRequestService_Create(t *testing.T) {
+	o := &core.OptionService{}
+
+	cases := map[string]struct {
+		projectIDOrKey string
+		repoIDOrName   string
+		summary        string
+		description    string
+		base           string
+		branch         string
+		opts           []core.RequestOption
+
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantNumber  int
+	}{
+		"success-required-only": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			summary:        "test PR",
+			description:    "test description",
+			base:           "main",
+			branch:         "feature/foo",
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/PRJ/git/repositories/repo1/pullRequests", spath)
+				assert.Equal(t, "test PR", form.Get("summary"))
+				assert.Equal(t, "test description", form.Get("description"))
+				assert.Equal(t, "main", form.Get("base"))
+				assert.Equal(t, "feature/foo", form.Get("branch"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+				}, nil
+			},
+			wantNumber: 1,
+		},
+		"success-with-options": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			summary:        "test PR",
+			description:    "test description",
+			base:           "main",
+			branch:         "feature/foo",
+			opts: []core.RequestOption{
+				o.WithAssigneeID(5),
+				o.WithIssueID(10),
+				o.WithNotifiedUserIDs([]int{1, 2}),
+			},
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "5", form.Get("assigneeId"))
+				assert.Equal(t, "10", form.Get("issueId"))
+				assert.Equal(t, []string{"1", "2"}, form["notifiedUserId[]"])
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+				}, nil
+			},
+			wantNumber: 1,
+		},
+		"error-empty-projectIDOrKey": {
+			projectIDOrKey: "",
+			repoIDOrName:   testRepo,
+			summary:        "test PR",
+			description:    "desc",
+			base:           "main",
+			branch:         "feature/foo",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-empty-repoIDOrName": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   "",
+			summary:        "test PR",
+			description:    "desc",
+			base:           "main",
+			branch:         "feature/foo",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-empty-summary": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			summary:        "",
+			description:    "desc",
+			base:           "main",
+			branch:         "feature/foo",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-empty-base": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			summary:        "test PR",
+			description:    "desc",
+			base:           "",
+			branch:         "feature/foo",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-empty-branch": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			summary:        "test PR",
+			description:    "desc",
+			base:           "main",
+			branch:         "",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-option-invalid-type": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			summary:        "test PR",
+			description:    "desc",
+			base:           "main",
+			branch:         "feature/foo",
+			opts:           []core.RequestOption{mock.NewInvalidTypeOption()},
+			wantErrType:    &core.InvalidOptionKeyError{},
+		},
+		"error-option-invalid-assigneeID": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			summary:        "test PR",
+			description:    "desc",
+			base:           "main",
+			branch:         "feature/foo",
+			opts:           []core.RequestOption{o.WithAssigneeID(0)},
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			summary:        "test PR",
+			description:    "desc",
+			base:           "main",
+			branch:         "feature/foo",
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			summary:        "test PR",
+			description:    "desc",
+			base:           "main",
+			branch:         "feature/foo",
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPostFn != nil {
+				method.Post = tc.mockPostFn
+			}
+
+			s := pullrequest.NewService(method)
+			got, err := s.Create(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.summary, tc.description, tc.base, tc.branch, tc.opts...)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantNumber, got.Number)
+		})
+	}
+}
+
+func TestPullRequestService_Update(t *testing.T) {
+	o := &core.OptionService{}
+
+	cases := map[string]struct {
+		projectIDOrKey string
+		repoIDOrName   string
+		prNumber       int
+		option         core.RequestOption
+		opts           []core.RequestOption
+
+		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantNumber  int
+	}{
+		"success-summary": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			option:         o.WithSummary("Updated PR"),
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/PRJ/git/repositories/repo1/pullRequests/1", spath)
+				assert.Equal(t, "Updated PR", form.Get("summary"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+				}, nil
+			},
+			wantNumber: 1,
+		},
+		"success-with-comment": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			option:         o.WithSummary("Updated PR"),
+			opts:           []core.RequestOption{o.WithComment("looks good")},
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "Updated PR", form.Get("summary"))
+				assert.Equal(t, "looks good", form.Get("comment"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+				}, nil
+			},
+			wantNumber: 1,
+		},
+		"success-with-issueID": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			option:         o.WithIssueID(42),
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "42", form.Get("issueId"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+				}, nil
+			},
+			wantNumber: 1,
+		},
+		"error-empty-projectIDOrKey": {
+			projectIDOrKey: "",
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			option:         o.WithSummary("x"),
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-empty-repoIDOrName": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   "",
+			prNumber:       1,
+			option:         o.WithSummary("x"),
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-invalid-prNumber": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       0,
+			option:         o.WithSummary("x"),
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-option-invalid-type": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			option:         mock.NewInvalidTypeOption(),
+			wantErrType:    &core.InvalidOptionKeyError{},
+		},
+		"error-option-invalid-assigneeID": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			option:         o.WithAssigneeID(0),
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			option:         o.WithSummary("x"),
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			prNumber:       1,
+			option:         o.WithSummary("x"),
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPatchFn != nil {
+				method.Patch = tc.mockPatchFn
+			}
+
+			s := pullrequest.NewService(method)
+			got, err := s.Update(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.prNumber, tc.option, tc.opts...)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantNumber, got.Number)
+		})
+	}
+}
+
+func TestPullRequestService_contextPropagation(t *testing.T) {
+	type ctxKey struct{}
+	sentinel := &struct{}{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+
+	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
+	}
+
+	o := &core.OptionService{}
+
+	cases := []struct {
+		name string
+		call func(t *testing.T, m *core.Method)
+	}{
+		{"All", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := pullrequest.NewService(m)
+			s.All(ctx, testProject, testRepo) //nolint:errcheck
+		}},
+		{"Count", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := pullrequest.NewService(m)
+			s.Count(ctx, testProject, testRepo) //nolint:errcheck
+		}},
+		{"One", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := pullrequest.NewService(m)
+			s.One(ctx, testProject, testRepo, 1) //nolint:errcheck
+		}},
+		{"Create", func(t *testing.T, m *core.Method) {
+			m.Post = makeMockFn(t)
+			s := pullrequest.NewService(m)
+			s.Create(ctx, testProject, testRepo, "summary", "desc", "main", "feature/foo") //nolint:errcheck
+		}},
+		{"Update", func(t *testing.T, m *core.Method) {
+			m.Patch = makeMockFn(t)
+			s := pullrequest.NewService(m)
+			s.Update(ctx, testProject, testRepo, 1, o.WithSummary("x")) //nolint:errcheck
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.call(t, &core.Method{})
+		})
+	}
+}

--- a/internal/testutil/fixture/testdata_pullrequest.go
+++ b/internal/testutil/fixture/testdata_pullrequest.go
@@ -1,0 +1,228 @@
+package fixture
+
+import backlog "github.com/nattokin/go-backlog"
+
+type pullRequestFixtures struct {
+	SingleJSON string
+	Single     backlog.PullRequest
+	ListJSON   string
+	List       []*backlog.PullRequest
+}
+
+// PullRequest provides test fixtures for PullRequest-related tests.
+var PullRequest = pullRequestFixtures{
+	SingleJSON: `
+{
+    "id": 2,
+    "projectId": 3,
+    "repositoryId": 5,
+    "number": 1,
+    "summary": "test PR",
+    "description": "test description",
+    "base": "main",
+    "branch": "feature/foo",
+    "status": {
+        "id": 1,
+        "name": "Open"
+    },
+    "assignee": null,
+    "issue": null,
+    "baseCommit": null,
+    "branchCommit": null,
+    "closeAt": null,
+    "mergeAt": null,
+    "createdUser": {
+        "id": 1,
+        "userId": "admin",
+        "name": "admin",
+        "roleType": 1,
+        "lang": "ja",
+        "mailAddress": "admin@example.com"
+    },
+    "created": "2024-01-10T09:00:00Z",
+    "updatedUser": {
+        "id": 1,
+        "userId": "admin",
+        "name": "admin",
+        "roleType": 1,
+        "lang": "ja",
+        "mailAddress": "admin@example.com"
+    },
+    "updated": "2024-01-10T09:00:00Z",
+    "attachments": [],
+    "stars": []
+}
+`,
+	Single: backlog.PullRequest{
+		ID:           2,
+		ProjectID:    3,
+		RepositoryID: 5,
+		Number:       1,
+		Summary:      "test PR",
+		Description:  "test description",
+		Base:         "main",
+		Branch:       "feature/foo",
+		Status:       &backlog.Status{ID: 1, Name: "Open"},
+		CreatedUser: &backlog.User{
+			ID:          1,
+			UserID:      "admin",
+			Name:        "admin",
+			RoleType:    backlog.RoleAdministrator,
+			Lang:        "ja",
+			MailAddress: "admin@example.com",
+		},
+		Created: mustTime("2024-01-10T09:00:00Z"),
+		UpdatedUser: &backlog.User{
+			ID:          1,
+			UserID:      "admin",
+			Name:        "admin",
+			RoleType:    backlog.RoleAdministrator,
+			Lang:        "ja",
+			MailAddress: "admin@example.com",
+		},
+		Updated: mustTime("2024-01-10T09:00:00Z"),
+	},
+	ListJSON: `
+[
+    {
+        "id": 2,
+        "projectId": 3,
+        "repositoryId": 5,
+        "number": 1,
+        "summary": "test PR",
+        "description": "test description",
+        "base": "main",
+        "branch": "feature/foo",
+        "status": {
+            "id": 1,
+            "name": "Open"
+        },
+        "assignee": null,
+        "issue": null,
+        "baseCommit": null,
+        "branchCommit": null,
+        "closeAt": null,
+        "mergeAt": null,
+        "createdUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "admin@example.com"
+        },
+        "created": "2024-01-10T09:00:00Z",
+        "updatedUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "admin@example.com"
+        },
+        "updated": "2024-01-10T09:00:00Z",
+        "attachments": [],
+        "stars": []
+    },
+    {
+        "id": 3,
+        "projectId": 3,
+        "repositoryId": 5,
+        "number": 2,
+        "summary": "second PR",
+        "description": "",
+        "base": "main",
+        "branch": "feature/bar",
+        "status": {
+            "id": 2,
+            "name": "Closed"
+        },
+        "assignee": null,
+        "issue": null,
+        "baseCommit": null,
+        "branchCommit": null,
+        "closeAt": null,
+        "mergeAt": null,
+        "createdUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "admin@example.com"
+        },
+        "created": "2024-01-11T10:00:00Z",
+        "updatedUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "admin@example.com"
+        },
+        "updated": "2024-01-11T10:00:00Z",
+        "attachments": [],
+        "stars": []
+    }
+]
+`,
+	List: []*backlog.PullRequest{
+		{
+			ID:           2,
+			ProjectID:    3,
+			RepositoryID: 5,
+			Number:       1,
+			Summary:      "test PR",
+			Description:  "test description",
+			Base:         "main",
+			Branch:       "feature/foo",
+			Status:       &backlog.Status{ID: 1, Name: "Open"},
+			CreatedUser: &backlog.User{
+				ID:          1,
+				UserID:      "admin",
+				Name:        "admin",
+				RoleType:    backlog.RoleAdministrator,
+				Lang:        "ja",
+				MailAddress: "admin@example.com",
+			},
+			Created: mustTime("2024-01-10T09:00:00Z"),
+			UpdatedUser: &backlog.User{
+				ID:          1,
+				UserID:      "admin",
+				Name:        "admin",
+				RoleType:    backlog.RoleAdministrator,
+				Lang:        "ja",
+				MailAddress: "admin@example.com",
+			},
+			Updated: mustTime("2024-01-10T09:00:00Z"),
+		},
+		{
+			ID:           3,
+			ProjectID:    3,
+			RepositoryID: 5,
+			Number:       2,
+			Summary:      "second PR",
+			Base:         "main",
+			Branch:       "feature/bar",
+			Status:       &backlog.Status{ID: 2, Name: "Closed"},
+			CreatedUser: &backlog.User{
+				ID:          1,
+				UserID:      "admin",
+				Name:        "admin",
+				RoleType:    backlog.RoleAdministrator,
+				Lang:        "ja",
+				MailAddress: "admin@example.com",
+			},
+			Created: mustTime("2024-01-11T10:00:00Z"),
+			UpdatedUser: &backlog.User{
+				ID:          1,
+				UserID:      "admin",
+				Name:        "admin",
+				RoleType:    backlog.RoleAdministrator,
+				Lang:        "ja",
+				MailAddress: "admin@example.com",
+			},
+			Updated: mustTime("2024-01-11T10:00:00Z"),
+		},
+	},
+}


### PR DESCRIPTION
Implement `All`, `Count`, `One`, `Create`, `Update` on `internal/pullrequest.Service`.

## Changes

### `internal/pullrequest/service.go`

| Method | HTTP | Path |
|---|---|---|
| `All(ctx, projectIDOrKey, repoIDOrName, opts...)` | GET | `projects/:p/git/repositories/:r/pullRequests` |
| `Count(ctx, projectIDOrKey, repoIDOrName, opts...)` | GET | `projects/:p/git/repositories/:r/pullRequests/count` |
| `One(ctx, projectIDOrKey, repoIDOrName, prNumber)` | GET | `projects/:p/git/repositories/:r/pullRequests/:n` |
| `Create(ctx, projectIDOrKey, repoIDOrName, summary, description, base, branch, opts...)` | POST | `projects/:p/git/repositories/:r/pullRequests` |
| `Update(ctx, projectIDOrKey, repoIDOrName, prNumber, option, opts...)` | PATCH | `projects/:p/git/repositories/:r/pullRequests/:n` |

Validation via existing `validate` helpers: `ValidateProjectIDOrKey`, `ValidateRepositoryIDOrName`, `ValidatePRNumber`.

### `internal/testutil/fixture/testdata_pullrequest.go`

New fixture with `SingleJSON`, `Single`, `ListJSON`, `List`.

### `internal/pullrequest/service_test.go`

Table-driven tests covering success paths, validation errors, option errors, network errors, and JSON decode errors for all five methods. Includes `contextPropagation` test.

Part of #197