### PR TITLE
feat: implement PullRequestService core methods (#197)

### DIFF
--- a/client.go
+++ b/client.go
@@ -75,7 +75,7 @@ func initServices(c *Client) {
 
 	c.Project = newProjectService(c.core.Method, baseOptionService)
 
-	c.PullRequest = newPullRequestService(c.core.Method)
+	c.PullRequest = newPullRequestService(c.core.Method, baseOptionService)
 
 	c.Space = newSpaceService(c.core.Method, baseOptionService)
 

--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -9,10 +9,82 @@ import (
 )
 
 var (
+	// PullRequestService
+	doerPullRequestAll    = newMockDoer(fixture.PullRequest.ListJSON)
+	doerPullRequestCount  = newMockDoer(`{"count":2}`)
+	doerPullRequestOne    = newMockDoer(fixture.PullRequest.SingleJSON)
+	doerPullRequestCreate = newMockDoer(fixture.PullRequest.SingleJSON)
+	doerPullRequestUpdate = newMockDoer(fixture.PullRequest.SingleJSON)
+
 	// PullRequestAttachmentService
 	doerPullRequestAttachmentList   = newMockDoer(fixture.Attachment.ListJSON)
 	doerPullRequestAttachmentRemove = newMockDoer(fixture.Attachment.SingleJSON)
 )
+
+func ExamplePullRequestService_All() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerPullRequestAll),
+	)
+
+	prs, _ := c.PullRequest.All(context.Background(), "TEST", "myrepo")
+	fmt.Printf("Count: %d, ID: %d, Summary: %s\n", len(prs), prs[0].ID, prs[0].Summary)
+	// Output:
+	// Count: 2, ID: 2, Summary: test PR
+}
+
+func ExamplePullRequestService_Count() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerPullRequestCount),
+	)
+
+	count, _ := c.PullRequest.Count(context.Background(), "TEST", "myrepo")
+	fmt.Printf("Count: %d\n", count)
+	// Output:
+	// Count: 2
+}
+
+func ExamplePullRequestService_One() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerPullRequestOne),
+	)
+
+	pr, _ := c.PullRequest.One(context.Background(), "TEST", "myrepo", 1)
+	fmt.Printf("ID: %d, Summary: %s\n", pr.ID, pr.Summary)
+	// Output:
+	// ID: 2, Summary: test PR
+}
+
+func ExamplePullRequestService_Create() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerPullRequestCreate),
+	)
+
+	pr, _ := c.PullRequest.Create(context.Background(), "TEST", "myrepo", "test PR", "test description", "main", "feature/foo")
+	fmt.Printf("ID: %d, Summary: %s\n", pr.ID, pr.Summary)
+	// Output:
+	// ID: 2, Summary: test PR
+}
+
+func ExamplePullRequestService_Update() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerPullRequestUpdate),
+	)
+
+	pr, _ := c.PullRequest.Update(context.Background(), "TEST", "myrepo", 1, c.PullRequest.Option.WithSummary("test PR"))
+	fmt.Printf("ID: %d, Summary: %s\n", pr.ID, pr.Summary)
+	// Output:
+	// ID: 2, Summary: test PR
+}
 
 func ExamplePullRequestAttachmentService_List() {
 	c, _ := backlog.NewClient(

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -44,7 +44,84 @@ type PullRequestService struct {
 	base *pullrequest.Service
 
 	Attachment *PullRequestAttachmentService
+	Option     *PullRequestOptionService
 }
+
+// All returns a list of pull requests.
+//
+// This method supports options returned by methods in "*Client.PullRequest.Option",
+// such as:
+//   - WithStatusIDs
+//   - WithAssigneeIDs
+//   - WithIssueIDs
+//   - WithCreatedUserIDs
+//   - WithOffset
+//   - WithCount
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
+func (s *PullRequestService) All(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, opts ...RequestOption) ([]*PullRequest, error) {
+	v, err := s.base.All(ctx, projectIDOrKey, repositoryIDOrName, toCoreOptions(opts)...)
+	return pullRequestsFromModel(v), convertError(err)
+}
+
+// Count returns the number of pull requests.
+//
+// This method supports options returned by methods in "*Client.PullRequest.Option",
+// such as:
+//   - WithStatusIDs
+//   - WithAssigneeIDs
+//   - WithIssueIDs
+//   - WithCreatedUserIDs
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-number-of-pull-requests
+func (s *PullRequestService) Count(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, opts ...RequestOption) (int, error) {
+	count, err := s.base.Count(ctx, projectIDOrKey, repositoryIDOrName, toCoreOptions(opts)...)
+	return count, convertError(err)
+}
+
+// One returns a single pull request by its number.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request
+func (s *PullRequestService) One(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int) (*PullRequest, error) {
+	v, err := s.base.One(ctx, projectIDOrKey, repositoryIDOrName, prNumber)
+	return pullRequestFromModel(v), convertError(err)
+}
+
+// Create creates a new pull request.
+//
+// This method supports options returned by methods in "*Client.PullRequest.Option",
+// such as:
+//   - WithIssueID
+//   - WithAssigneeID
+//   - WithNotifiedUserIDs
+//   - WithAttachmentIDs
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-pull-request
+func (s *PullRequestService) Create(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, summary string, description string, base string, branch string, opts ...RequestOption) (*PullRequest, error) {
+	v, err := s.base.Create(ctx, projectIDOrKey, repositoryIDOrName, summary, description, base, branch, toCoreOptions(opts)...)
+	return pullRequestFromModel(v), convertError(err)
+}
+
+// Update updates an existing pull request.
+//
+// At least one option is required. This method supports options returned by
+// methods in "*Client.PullRequest.Option", such as:
+//   - WithSummary
+//   - WithDescription
+//   - WithIssueID
+//   - WithAssigneeID
+//   - WithNotifiedUserIDs
+//   - WithComment
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-pull-request
+func (s *PullRequestService) Update(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, option RequestOption, opts ...RequestOption) (*PullRequest, error) {
+	v, err := s.base.Update(ctx, projectIDOrKey, repositoryIDOrName, prNumber, option, toCoreOptions(opts)...)
+	return pullRequestFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  PullRequestAttachmentService
+// ──────────────────────────────────────────────────────────────
 
 // PullRequestAttachmentService handles communication with the pull request attachment-related methods of the Backlog API.
 type PullRequestAttachmentService struct {
@@ -68,19 +145,101 @@ func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKe
 }
 
 // ──────────────────────────────────────────────────────────────
+//  PullRequestOptionService
+// ──────────────────────────────────────────────────────────────
+
+// PullRequestOptionService provides a domain-specific set of option builders
+// for operations within the PullRequestService.
+type PullRequestOptionService struct {
+	base *core.OptionService
+}
+
+// WithAssigneeID returns an option to set the `assigneeId` parameter.
+func (s *PullRequestOptionService) WithAssigneeID(id int) RequestOption {
+	return s.base.WithAssigneeID(id)
+}
+
+// WithAssigneeIDs filters pull requests by assignee user IDs.
+func (s *PullRequestOptionService) WithAssigneeIDs(ids []int) RequestOption {
+	return s.base.WithAssigneeIDs(ids)
+}
+
+// WithAttachmentIDs returns an option to set multiple `attachmentId[]` parameters.
+func (s *PullRequestOptionService) WithAttachmentIDs(ids []int) RequestOption {
+	return s.base.WithAttachmentIDs(ids)
+}
+
+// WithComment returns an option to set the `comment` parameter.
+func (s *PullRequestOptionService) WithComment(comment string) RequestOption {
+	return s.base.WithComment(comment)
+}
+
+// WithCount sets the number of pull requests to retrieve.
+func (s *PullRequestOptionService) WithCount(count int) RequestOption {
+	return s.base.WithCount(count)
+}
+
+// WithCreatedUserIDs filters pull requests by created user IDs.
+func (s *PullRequestOptionService) WithCreatedUserIDs(ids []int) RequestOption {
+	return s.base.WithCreatedUserIDs(ids)
+}
+
+// WithDescription returns an option to set the `description` parameter.
+func (s *PullRequestOptionService) WithDescription(description string) RequestOption {
+	return s.base.WithDescription(description)
+}
+
+// WithIssueID returns an option to set the `issueId` parameter.
+func (s *PullRequestOptionService) WithIssueID(id int) RequestOption {
+	return s.base.WithIssueID(id)
+}
+
+// WithIssueIDs filters pull requests by issue IDs.
+func (s *PullRequestOptionService) WithIssueIDs(ids []int) RequestOption {
+	return s.base.WithIssueIDs(ids)
+}
+
+// WithNotifiedUserIDs returns an option to set multiple `notifiedUserId[]` parameters.
+func (s *PullRequestOptionService) WithNotifiedUserIDs(ids []int) RequestOption {
+	return s.base.WithNotifiedUserIDs(ids)
+}
+
+// WithOffset sets the number of pull requests to skip.
+func (s *PullRequestOptionService) WithOffset(offset int) RequestOption {
+	return s.base.WithOffset(offset)
+}
+
+// WithStatusIDs filters pull requests by status IDs.
+func (s *PullRequestOptionService) WithStatusIDs(ids []int) RequestOption {
+	return s.base.WithStatusIDs(ids)
+}
+
+// WithSummary returns an option to set the `summary` parameter.
+func (s *PullRequestOptionService) WithSummary(summary string) RequestOption {
+	return s.base.WithSummary(summary)
+}
+
+// ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
-func newPullRequestService(method *core.Method) *PullRequestService {
+func newPullRequestService(method *core.Method, option *core.OptionService) *PullRequestService {
 	return &PullRequestService{
 		base:       pullrequest.NewService(method),
 		Attachment: newPullRequestAttachmentService(method),
+		Option:     newPullRequestOptionService(option),
 	}
 }
 
 func newPullRequestAttachmentService(method *core.Method) *PullRequestAttachmentService {
 	return &PullRequestAttachmentService{
 		base: attachment.NewPullRequestService(method),
+	}
+}
+
+func newPullRequestOptionService(option *core.OptionService) *PullRequestOptionService {
+	return &PullRequestOptionService{
+		base: option,
 	}
 }
 
@@ -123,4 +282,12 @@ func pullRequestFromModel(m *model.PullRequest) *PullRequest {
 		Attachments:  attachments,
 		Stars:        stars,
 	}
+}
+
+func pullRequestsFromModel(ms []*model.PullRequest) []*PullRequest {
+	result := make([]*PullRequest, len(ms))
+	for i, v := range ms {
+		result[i] = pullRequestFromModel(v)
+	}
+	return result
 }

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -13,8 +13,266 @@ import (
 	"github.com/stretchr/testify/require"
 
 	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 )
+
+func TestPullRequestService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"All": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.ListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.All(ctx, "TEST", "repo")
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, 2, got[0].ID)
+				assert.Equal(t, 3, got[1].ID)
+			},
+		},
+		"All/with-options": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests", req.URL.Path)
+				assert.Equal(t, []string{"1", "2"}, req.URL.Query()["statusId[]"])
+				assert.Equal(t, "10", req.URL.Query().Get("count"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.ListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.All(ctx, "TEST", "repo",
+					c.PullRequest.Option.WithStatusIDs([]int{1, 2}),
+					c.PullRequest.Option.WithCount(10),
+				)
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+			},
+		},
+		"All/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Internal Server Error","code":1,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.PullRequest.All(ctx, "TEST", "repo")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Count": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/count", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"count":5}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.Count(ctx, "TEST", "repo")
+				require.NoError(t, err)
+				assert.Equal(t, 5, got)
+			},
+		},
+		"Count/with-options": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/count", req.URL.Path)
+				assert.Equal(t, []string{"1"}, req.URL.Query()["statusId[]"])
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"count":3}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.Count(ctx, "TEST", "repo",
+					c.PullRequest.Option.WithStatusIDs([]int{1}),
+				)
+				require.NoError(t, err)
+				assert.Equal(t, 3, got)
+			},
+		},
+		"Count/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Internal Server Error","code":1,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.PullRequest.Count(ctx, "TEST", "repo")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"One": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.One(ctx, "TEST", "repo", 1)
+				require.NoError(t, err)
+				assert.Equal(t, 2, got.ID)
+				assert.Equal(t, "test PR", got.Summary)
+			},
+		},
+		"One/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such pull request.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.PullRequest.One(ctx, "TEST", "repo", 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Create": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "new PR", req.PostForm.Get("summary"))
+				assert.Equal(t, "details", req.PostForm.Get("description"))
+				assert.Equal(t, "main", req.PostForm.Get("base"))
+				assert.Equal(t, "feature/foo", req.PostForm.Get("branch"))
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.Create(ctx, "TEST", "repo", "new PR", "details", "main", "feature/foo")
+				require.NoError(t, err)
+				assert.Equal(t, 2, got.ID)
+				assert.Equal(t, "test PR", got.Summary)
+			},
+		},
+		"Create/with-options": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "new PR", req.PostForm.Get("summary"))
+				assert.Equal(t, "5", req.PostForm.Get("assigneeId"))
+				assert.Equal(t, []string{"10", "20"}, req.PostForm["notifiedUserId[]"])
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.Create(ctx, "TEST", "repo", "new PR", "", "main", "feature/foo",
+					c.PullRequest.Option.WithAssigneeID(5),
+					c.PullRequest.Option.WithNotifiedUserIDs([]int{10, 20}),
+				)
+				require.NoError(t, err)
+				assert.Equal(t, 2, got.ID)
+			},
+		},
+		"Create/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.PullRequest.Create(ctx, "TEST", "repo", "new PR", "", "main", "feature/foo")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Update": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPatch, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.Update(ctx, "TEST", "repo", 1, c.PullRequest.Option.WithSummary("Updated summary"))
+				require.NoError(t, err)
+				assert.Equal(t, 2, got.ID)
+			},
+		},
+		"Update/with-options": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPatch, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
+				assert.Equal(t, "a note", req.PostForm.Get("comment"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.Update(ctx, "TEST", "repo", 1,
+					c.PullRequest.Option.WithSummary("Updated summary"),
+					c.PullRequest.Option.WithComment("a note"),
+				)
+				require.NoError(t, err)
+				assert.Equal(t, 2, got.ID)
+			},
+		},
+		"Update/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such pull request.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.PullRequest.Update(ctx, "TEST", "repo", 1, c.PullRequest.Option.WithSummary("Updated summary"))
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}
 
 func TestPullRequestAttachmentService(t *testing.T) {
 	ctx := context.Background()
@@ -92,6 +350,38 @@ func TestPullRequestAttachmentService(t *testing.T) {
 			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
 			require.NoError(t, err)
 			tc.call(t, c)
+		})
+	}
+}
+
+func TestPullRequestOptionService(t *testing.T) {
+	c, err := backlog.NewClient("https://example.backlog.com", "token")
+	require.NoError(t, err)
+	s := c.PullRequest.Option
+
+	cases := map[string]struct {
+		option  backlog.RequestOption
+		wantKey string
+	}{
+		"WithAssigneeID":      {option: s.WithAssigneeID(1), wantKey: core.ParamAssigneeID.Value()},
+		"WithAssigneeIDs":     {option: s.WithAssigneeIDs([]int{1}), wantKey: core.ParamAssigneeIDs.Value()},
+		"WithAttachmentIDs":   {option: s.WithAttachmentIDs([]int{1}), wantKey: core.ParamAttachmentIDs.Value()},
+		"WithComment":         {option: s.WithComment("note"), wantKey: core.ParamComment.Value()},
+		"WithCount":           {option: s.WithCount(20), wantKey: core.ParamCount.Value()},
+		"WithCreatedUserIDs":  {option: s.WithCreatedUserIDs([]int{1}), wantKey: core.ParamCreatedUserIDs.Value()},
+		"WithDescription":     {option: s.WithDescription("desc"), wantKey: core.ParamDescription.Value()},
+		"WithIssueID":         {option: s.WithIssueID(1), wantKey: core.ParamIssueID.Value()},
+		"WithIssueIDs":        {option: s.WithIssueIDs([]int{1}), wantKey: core.ParamIssueIDs.Value()},
+		"WithNotifiedUserIDs": {option: s.WithNotifiedUserIDs([]int{1}), wantKey: core.ParamNotifiedUserIDs.Value()},
+		"WithOffset":          {option: s.WithOffset(0), wantKey: core.ParamOffset.Value()},
+		"WithStatusIDs":       {option: s.WithStatusIDs([]int{1}), wantKey: core.ParamStatusIDs.Value()},
+		"WithSummary":         {option: s.WithSummary("summary"), wantKey: core.ParamSummary.Value()},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.wantKey, tc.option.Key())
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Add `All`, `Count`, `One`, `Create`, and `Update` methods to `PullRequestService` in the root package, along with a new `PullRequestOptionService` that exposes domain-specific option builders.

## Changes

- `pullrequest.go`: Add `All`, `Count`, `One`, `Create`, `Update` wrapper methods on `PullRequestService`
- `pullrequest.go`: Add `PullRequestOptionService` with `WithStatusIDs`, `WithAssigneeIDs`, `WithAssigneeID`, `WithIssueIDs`, `WithIssueID`, `WithCreatedUserIDs`, `WithOffset`, `WithCount`, `WithSummary`, `WithDescription`, `WithComment`, `WithNotifiedUserIDs`, `WithAttachmentIDs`
- `pullrequest.go`: Add `pullRequestsFromModel` helper; update `newPullRequestService` to accept `*core.OptionService`
- `client.go`: Pass `baseOptionService` to `newPullRequestService` in `initServices`
- `pullrequest_test.go`: Add `TestPullRequestService` and `TestPullRequestOptionService`; consolidate existing `TestPullRequestAttachmentService`

Closes #197