### PR TITLE
feat: implement internal/space service (One, DiskUsage, Notification, UpdateNotification)

### DIFF
--- a/internal/space/service.go
+++ b/internal/space/service.go
@@ -1,11 +1,92 @@
 package space
 
 import (
+	"context"
+	"net/url"
+
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
 )
 
 type Service struct {
 	method *core.Method
+}
+
+// One returns information about your space.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-space
+func (s *Service) One(ctx context.Context) (*model.Space, error) {
+	resp, err := s.method.Get(ctx, "space", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Space{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// DiskUsage returns information about the disk usage of your space.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-space-disk-usage
+func (s *Service) DiskUsage(ctx context.Context) (*model.DiskUsageSpace, error) {
+	resp, err := s.method.Get(ctx, "space/diskUsage", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.DiskUsageSpace{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Notification returns the space notification.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-space-notification
+func (s *Service) Notification(ctx context.Context) (*model.SpaceNotification, error) {
+	resp, err := s.method.Get(ctx, "space/notification", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.SpaceNotification{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// UpdateNotification updates the space notification.
+//
+// content must not be empty.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-space-notification
+func (s *Service) UpdateNotification(ctx context.Context, content string) (*model.SpaceNotification, error) {
+	option := &core.OptionService{}
+	form := url.Values{}
+	validTypes := []core.APIParamOptionType{core.ParamContent}
+	if err := core.ApplyOptions(form, validTypes, option.WithContent(content)); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.method.Put(ctx, "space/notification", form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.SpaceNotification{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/internal/space/service_test.go
+++ b/internal/space/service_test.go
@@ -1,0 +1,352 @@
+package space_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
+	"github.com/nattokin/go-backlog/internal/space"
+)
+
+func TestSpaceService_One(t *testing.T) {
+	cases := map[string]struct {
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType  error
+		wantSpaceKey string
+		wantName     string
+	}{
+		"success": {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "space", spath)
+				assert.Nil(t, query)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.SpaceJSON))),
+				}, nil
+			},
+			wantSpaceKey: "nulab",
+			wantName:     "Nulab Inc.",
+		},
+		"error-client-network": {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "space", spath)
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "space", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := space.NewService(method)
+
+			got, err := s.One(context.Background())
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantSpaceKey, got.SpaceKey)
+			assert.Equal(t, tc.wantName, got.Name)
+		})
+	}
+}
+
+func TestSpaceService_DiskUsage(t *testing.T) {
+	cases := map[string]struct {
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType    error
+		wantCapacity   int
+		wantIssue      int
+		wantDetailLen  int
+	}{
+		"success": {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "space/diskUsage", spath)
+				assert.Nil(t, query)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.DiskUsageJSON))),
+				}, nil
+			},
+			wantCapacity:  1073741824,
+			wantIssue:     119511,
+			wantDetailLen: 1,
+		},
+		"error-client-network": {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "space/diskUsage", spath)
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "space/diskUsage", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := space.NewService(method)
+
+			got, err := s.DiskUsage(context.Background())
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantCapacity, got.Capacity)
+			assert.Equal(t, tc.wantIssue, got.Issue)
+			assert.Len(t, got.Details, tc.wantDetailLen)
+		})
+	}
+}
+
+func TestSpaceService_Notification(t *testing.T) {
+	cases := map[string]struct {
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType   error
+		wantContent   string
+	}{
+		"success": {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "space/notification", spath)
+				assert.Nil(t, query)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.NotificationJSON))),
+				}, nil
+			},
+			wantContent: "Backlog is a project management tool.",
+		},
+		"error-client-network": {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "space/notification", spath)
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "space/notification", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := space.NewService(method)
+
+			got, err := s.Notification(context.Background())
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantContent, got.Content)
+		})
+	}
+}
+
+func TestSpaceService_UpdateNotification(t *testing.T) {
+	cases := map[string]struct {
+		content string
+
+		mockPutFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantContent string
+	}{
+		"success": {
+			content: "Backlog is a project management tool.",
+			mockPutFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "space/notification", spath)
+				assert.Equal(t, "Backlog is a project management tool.", form.Get("content"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.NotificationJSON))),
+				}, nil
+			},
+			wantContent: "Backlog is a project management tool.",
+		},
+		"error-validation-content-empty": {
+			content:     "",
+			wantErrType: &core.ValidationError{},
+		},
+		"error-client-network": {
+			content: "some content",
+			mockPutFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "space/notification", spath)
+				assert.Equal(t, "some content", form.Get("content"))
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			content: "some content",
+			mockPutFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "space/notification", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPutFn != nil {
+				method.Put = tc.mockPutFn
+			}
+
+			s := space.NewService(method)
+
+			got, err := s.UpdateNotification(context.Background(), tc.content)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantContent, got.Content)
+		})
+	}
+}
+
+// TestSpaceService_contextPropagation verifies that the context passed to each
+// SpaceService method is correctly relayed to the underlying method call.
+// A sentinel value is embedded in the context and its pointer identity is
+// asserted inside the mock to catch any ctx substitution.
+func TestSpaceService_contextPropagation(t *testing.T) {
+	type ctxKey struct{}
+	sentinel := &struct{}{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+
+	makeGetMock := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
+	}
+
+	makePutMock := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
+	}
+
+	cases := []struct {
+		name string
+		call func(t *testing.T, m *core.Method)
+	}{
+		{"One", func(t *testing.T, m *core.Method) {
+			m.Get = makeGetMock(t)
+			s := space.NewService(m)
+			s.One(ctx) //nolint:errcheck
+		}},
+		{"DiskUsage", func(t *testing.T, m *core.Method) {
+			m.Get = makeGetMock(t)
+			s := space.NewService(m)
+			s.DiskUsage(ctx) //nolint:errcheck
+		}},
+		{"Notification", func(t *testing.T, m *core.Method) {
+			m.Get = makeGetMock(t)
+			s := space.NewService(m)
+			s.Notification(ctx) //nolint:errcheck
+		}},
+		{"UpdateNotification", func(t *testing.T, m *core.Method) {
+			m.Put = makePutMock(t)
+			s := space.NewService(m)
+			s.UpdateNotification(ctx, "content") //nolint:errcheck
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.call(t, &core.Method{})
+		})
+	}
+}

--- a/internal/space/service_test.go
+++ b/internal/space/service_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/space"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
-	"github.com/nattokin/go-backlog/internal/space"
 )
 
 func TestSpaceService_One(t *testing.T) {
@@ -90,10 +90,10 @@ func TestSpaceService_DiskUsage(t *testing.T) {
 	cases := map[string]struct {
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
-		wantErrType    error
-		wantCapacity   int
-		wantIssue      int
-		wantDetailLen  int
+		wantErrType   error
+		wantCapacity  int
+		wantIssue     int
+		wantDetailLen int
 	}{
 		"success": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
@@ -160,8 +160,8 @@ func TestSpaceService_Notification(t *testing.T) {
 	cases := map[string]struct {
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
-		wantErrType   error
-		wantContent   string
+		wantErrType error
+		wantContent string
 	}{
 		"success": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {

--- a/internal/testutil/fixture/testdata_space.go
+++ b/internal/testutil/fixture/testdata_space.go
@@ -1,0 +1,94 @@
+package fixture
+
+import (
+	backlog "github.com/nattokin/go-backlog"
+)
+
+type spaceFixtures struct {
+	SpaceJSON        string
+	Space            *backlog.Space
+	DiskUsageJSON    string
+	DiskUsage        *backlog.DiskUsageSpace
+	NotificationJSON string
+	Notification     *backlog.SpaceNotification
+}
+
+// Space provides test fixtures for Space-related tests.
+var Space = spaceFixtures{
+	SpaceJSON: `
+{
+    "spaceKey": "nulab",
+    "name": "Nulab Inc.",
+    "ownerId": 1,
+    "lang": "ja",
+    "timezone": "Asia/Tokyo",
+    "reportSendTime": "08:00:00",
+    "textFormattingRule": "markdown",
+    "created": "2008-07-06T15:00:00Z",
+    "updated": "2013-06-18T07:55:37Z"
+}
+`,
+	Space: &backlog.Space{
+		SpaceKey:           "nulab",
+		Name:               "Nulab Inc.",
+		OwnerID:            1,
+		Lang:               "ja",
+		Timezone:           "Asia/Tokyo",
+		ReportSendTime:     "08:00:00",
+		TextFormattingRule: backlog.FormatMarkdown,
+		Created:            mustTime("2008-07-06T15:00:00Z"),
+		Updated:            mustTime("2013-06-18T07:55:37Z"),
+	},
+	DiskUsageJSON: `
+{
+    "capacity": 1073741824,
+    "issue": 119511,
+    "wiki": 0,
+    "file": 0,
+    "subversion": 0,
+    "git": 0,
+    "gitLFS": 0,
+    "details": [
+        {
+            "projectId": 1,
+            "issue": 11931,
+            "wiki": 0,
+            "file": 0,
+            "subversion": 0,
+            "git": 0,
+            "gitLFS": 0
+        }
+    ]
+}
+`,
+	DiskUsage: &backlog.DiskUsageSpace{
+		Capacity:   1073741824,
+		Issue:      119511,
+		Wiki:       0,
+		File:       0,
+		Subversion: 0,
+		Git:        0,
+		GitLFS:     0,
+		Details: []*backlog.DiskUsageProject{
+			{
+				ProjectID:  1,
+				Issue:      11931,
+				Wiki:       0,
+				File:       0,
+				Subversion: 0,
+				Git:        0,
+				GitLFS:     0,
+			},
+		},
+	},
+	NotificationJSON: `
+{
+    "content": "Backlog is a project management tool.",
+    "updated": "2013-06-18T07:55:37Z"
+}
+`,
+	Notification: &backlog.SpaceNotification{
+		Content: "Backlog is a project management tool.",
+		Updated: mustTime("2013-06-18T07:55:37Z"),
+	},
+}


### PR DESCRIPTION
## Summary

Implement the four core methods of `internal/space.Service`, along with fixtures and tests.

## Changes

### `internal/space/service.go`
- `One` — GET `/space` → `*model.Space`
- `DiskUsage` — GET `/space/diskUsage` → `*model.DiskUsageSpace`
- `Notification` — GET `/space/notification` → `*model.SpaceNotification`
- `UpdateNotification(content string)` — PUT `/space/notification` → `*model.SpaceNotification`
  - `content` is validated as non-empty via `option.WithContent` + `ApplyOptions`
  - Uses `method.Put` added in the previous PR

### `internal/testutil/fixture/testdata_space.go` (new)
- `fixture.Space.SpaceJSON` / `.Space`
- `fixture.Space.DiskUsageJSON` / `.DiskUsage`
- `fixture.Space.NotificationJSON` / `.Notification`

### `internal/space/service_test.go` (new)
- `TestSpaceService_One` — success, network error, invalid JSON
- `TestSpaceService_DiskUsage` — success, network error, invalid JSON
- `TestSpaceService_Notification` — success, network error, invalid JSON
- `TestSpaceService_UpdateNotification` — success, empty content validation error, network error, invalid JSON
- `TestSpaceService_contextPropagation` — sentinel context identity check for all four methods

Part of #198