### PR TITLE
feat: implement SpaceService public methods (One, DiskUsage, Notification, UpdateNotification)

### DIFF
--- a/models_test.go
+++ b/models_test.go
@@ -469,6 +469,192 @@ func Test_pullRequestFromModel(t *testing.T) {
 	}
 }
 
+func Test_spaceFromModel(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2008, 7, 6, 15, 0, 0, 0, time.UTC)
+	updated := time.Date(2013, 6, 18, 7, 55, 37, 0, time.UTC)
+
+	cases := map[string]struct {
+		input *model.Space
+		want  *Space
+	}{
+		"normal": {
+			input: &model.Space{
+				SpaceKey:           "nulab",
+				Name:               "Nulab Inc.",
+				OwnerID:            1,
+				Lang:               "ja",
+				Timezone:           "Asia/Tokyo",
+				ReportSendTime:     "08:00:00",
+				TextFormattingRule: model.FormatMarkdown,
+				Created:            created,
+				Updated:            updated,
+			},
+			want: &Space{
+				SpaceKey:           "nulab",
+				Name:               "Nulab Inc.",
+				OwnerID:            1,
+				Lang:               "ja",
+				Timezone:           "Asia/Tokyo",
+				ReportSendTime:     "08:00:00",
+				TextFormattingRule: FormatMarkdown,
+				Created:            created,
+				Updated:            updated,
+			},
+		},
+		"nil": {
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, spaceFromModel(tc.input))
+		})
+	}
+}
+
+func Test_diskUsageProjectFromModel(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		input *model.DiskUsageProject
+		want  *DiskUsageProject
+	}{
+		"normal": {
+			input: &model.DiskUsageProject{
+				DiskUsageBase: model.DiskUsageBase{
+					Issue:      11931,
+					Wiki:       0,
+					File:       512,
+					Subversion: 0,
+					Git:        1024,
+					GitLFS:     0,
+				},
+				ProjectID: 1,
+			},
+			want: &DiskUsageProject{
+				ProjectID:  1,
+				Issue:      11931,
+				Wiki:       0,
+				File:       512,
+				Subversion: 0,
+				Git:        1024,
+				GitLFS:     0,
+			},
+		},
+		"nil": {
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, diskUsageProjectFromModel(tc.input))
+		})
+	}
+}
+
+func Test_diskUsageSpaceFromModel(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		input *model.DiskUsageSpace
+		want  *DiskUsageSpace
+	}{
+		"with_details": {
+			input: &model.DiskUsageSpace{
+				DiskUsageBase: model.DiskUsageBase{
+					Issue:      119511,
+					Wiki:       0,
+					File:       0,
+					Subversion: 0,
+					Git:        0,
+					GitLFS:     0,
+				},
+				Capacity: 1073741824,
+				Details: []*model.DiskUsageProject{
+					{
+						DiskUsageBase: model.DiskUsageBase{Issue: 11931},
+						ProjectID:     1,
+					},
+				},
+			},
+			want: &DiskUsageSpace{
+				Capacity:   1073741824,
+				Issue:      119511,
+				Wiki:       0,
+				File:       0,
+				Subversion: 0,
+				Git:        0,
+				GitLFS:     0,
+				Details: []*DiskUsageProject{
+					{ProjectID: 1, Issue: 11931},
+				},
+			},
+		},
+		"empty_details": {
+			input: &model.DiskUsageSpace{
+				Capacity: 512,
+				Details:  []*model.DiskUsageProject{},
+			},
+			want: &DiskUsageSpace{
+				Capacity: 512,
+				Details:  []*DiskUsageProject{},
+			},
+		},
+		"nil": {
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, diskUsageSpaceFromModel(tc.input))
+		})
+	}
+}
+
+func Test_spaceNotificationFromModel(t *testing.T) {
+	t.Parallel()
+
+	updated := time.Date(2013, 6, 18, 7, 55, 37, 0, time.UTC)
+
+	cases := map[string]struct {
+		input *model.SpaceNotification
+		want  *SpaceNotification
+	}{
+		"normal": {
+			input: &model.SpaceNotification{
+				Content: "Backlog is a project management tool.",
+				Updated: updated,
+			},
+			want: &SpaceNotification{
+				Content: "Backlog is a project management tool.",
+				Updated: updated,
+			},
+		},
+		"nil": {
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, spaceNotificationFromModel(tc.input))
+		})
+	}
+}
+
 func Test_starFromModel_nil(t *testing.T) {
 	t.Parallel()
 	assert.Nil(t, starFromModel(nil))

--- a/space.go
+++ b/space.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/space"
 )
 
@@ -67,6 +68,40 @@ type SpaceService struct {
 
 	Activity   *SpaceActivityService
 	Attachment *SpaceAttachmentService
+}
+
+// One returns information about your space.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-space
+func (s *SpaceService) One(ctx context.Context) (*Space, error) {
+	v, err := s.base.One(ctx)
+	return spaceFromModel(v), convertError(err)
+}
+
+// DiskUsage returns information about the disk usage of your space.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-space-disk-usage
+func (s *SpaceService) DiskUsage(ctx context.Context) (*DiskUsageSpace, error) {
+	v, err := s.base.DiskUsage(ctx)
+	return diskUsageSpaceFromModel(v), convertError(err)
+}
+
+// Notification returns the space notification.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-space-notification
+func (s *SpaceService) Notification(ctx context.Context) (*SpaceNotification, error) {
+	v, err := s.base.Notification(ctx)
+	return spaceNotificationFromModel(v), convertError(err)
+}
+
+// UpdateNotification updates the space notification.
+//
+// content must not be empty.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-space-notification
+func (s *SpaceService) UpdateNotification(ctx context.Context, content string) (*SpaceNotification, error) {
+	v, err := s.base.UpdateNotification(ctx, content)
+	return spaceNotificationFromModel(v), convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -133,5 +168,71 @@ func newSpaceActivityService(method *core.Method, option *core.OptionService) *S
 func newSpaceAttachmentService(method *core.Method) *SpaceAttachmentService {
 	return &SpaceAttachmentService{
 		base: attachment.NewSpaceService(method),
+	}
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Model converters
+// ──────────────────────────────────────────────────────────────
+
+func spaceFromModel(m *model.Space) *Space {
+	if m == nil {
+		return nil
+	}
+	return &Space{
+		SpaceKey:           m.SpaceKey,
+		Name:               m.Name,
+		OwnerID:            m.OwnerID,
+		Lang:               m.Lang,
+		Timezone:           m.Timezone,
+		ReportSendTime:     m.ReportSendTime,
+		TextFormattingRule: Format(m.TextFormattingRule),
+		Created:            m.Created,
+		Updated:            m.Updated,
+	}
+}
+
+func diskUsageProjectFromModel(m *model.DiskUsageProject) *DiskUsageProject {
+	if m == nil {
+		return nil
+	}
+	return &DiskUsageProject{
+		ProjectID:  m.ProjectID,
+		Issue:      m.Issue,
+		Wiki:       m.Wiki,
+		File:       m.File,
+		Subversion: m.Subversion,
+		Git:        m.Git,
+		GitLFS:     m.GitLFS,
+	}
+}
+
+func diskUsageSpaceFromModel(m *model.DiskUsageSpace) *DiskUsageSpace {
+	if m == nil {
+		return nil
+	}
+	details := make([]*DiskUsageProject, len(m.Details))
+	for i, v := range m.Details {
+		details[i] = diskUsageProjectFromModel(v)
+	}
+	return &DiskUsageSpace{
+		Capacity:   m.Capacity,
+		Issue:      m.Issue,
+		Wiki:       m.Wiki,
+		File:       m.File,
+		Subversion: m.Subversion,
+		Git:        m.Git,
+		GitLFS:     m.GitLFS,
+		Details:    details,
+	}
+}
+
+func spaceNotificationFromModel(m *model.SpaceNotification) *SpaceNotification {
+	if m == nil {
+		return nil
+	}
+	return &SpaceNotification{
+		Content: m.Content,
+		Updated: m.Updated,
 	}
 }

--- a/space_test.go
+++ b/space_test.go
@@ -17,6 +17,227 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 )
 
+func TestSpaceService_One(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc  func(req *http.Request) (*http.Response, error)
+		wantErr bool
+	}{
+		"success": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/space", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.SpaceJSON))),
+				}, nil
+			},
+		},
+		"error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+
+			got, err := c.Space.One(ctx)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, "nulab", got.SpaceKey)
+			assert.Equal(t, "Nulab Inc.", got.Name)
+			assert.Equal(t, backlog.FormatMarkdown, got.TextFormattingRule)
+		})
+	}
+}
+
+func TestSpaceService_DiskUsage(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc  func(req *http.Request) (*http.Response, error)
+		wantErr bool
+	}{
+		"success": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/space/diskUsage", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.DiskUsageJSON))),
+				}, nil
+			},
+		},
+		"error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+
+			got, err := c.Space.DiskUsage(ctx)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, 1073741824, got.Capacity)
+			assert.Equal(t, 119511, got.Issue)
+			require.Len(t, got.Details, 1)
+			assert.Equal(t, 1, got.Details[0].ProjectID)
+			assert.Equal(t, 11931, got.Details[0].Issue)
+		})
+	}
+}
+
+func TestSpaceService_Notification(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc  func(req *http.Request) (*http.Response, error)
+		wantErr bool
+	}{
+		"success": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/space/notification", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.NotificationJSON))),
+				}, nil
+			},
+		},
+		"error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+
+			got, err := c.Space.Notification(ctx)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, "Backlog is a project management tool.", got.Content)
+		})
+	}
+}
+
+func TestSpaceService_UpdateNotification(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		content string
+		doFunc  func(req *http.Request) (*http.Response, error)
+		wantErr bool
+	}{
+		"success": {
+			content: "Backlog is a project management tool.",
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPut, req.Method)
+				assert.Equal(t, "/api/v2/space/notification", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "Backlog is a project management tool.", req.FormValue("content"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.NotificationJSON))),
+				}, nil
+			},
+		},
+		"error-validation-empty-content": {
+			content:  "",
+			wantErr: true,
+		},
+		"error-api": {
+			content: "content",
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+
+			got, err := c.Space.UpdateNotification(ctx, tc.content)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				var apiErr *backlog.APIResponseError
+				if tc.doFunc != nil {
+					assert.True(t, errors.As(err, &apiErr))
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, "Backlog is a project management tool.", got.Content)
+		})
+	}
+}
+
 func TestSpaceActivityService(t *testing.T) {
 	ctx := context.Background()
 

--- a/space_test.go
+++ b/space_test.go
@@ -198,7 +198,7 @@ func TestSpaceService_UpdateNotification(t *testing.T) {
 			},
 		},
 		"error-validation-empty-content": {
-			content:  "",
+			content: "",
 			wantErr: true,
 		},
 		"error-api": {


### PR DESCRIPTION
## Summary

Expose the four `internal/space.Service` methods on the public `SpaceService`, add the corresponding `fromModel` converters, and cover them with tests.

## Changes

### `space.go`
- Add `One`, `DiskUsage`, `Notification`, `UpdateNotification` methods to `SpaceService`
- Add model converters: `spaceFromModel`, `diskUsageProjectFromModel`, `diskUsageSpaceFromModel`, `spaceNotificationFromModel`

### `space_test.go`
- `TestSpaceService_One` — success (verifies method, path, response fields), API error
- `TestSpaceService_DiskUsage` — success (verifies capacity, issue, details), API error
- `TestSpaceService_Notification` — success (verifies content), API error
- `TestSpaceService_UpdateNotification` — success (verifies PUT method, path, form body, response), empty-content validation error, API error
- Existing `TestSpaceActivityService` and `TestSpaceAttachmentService` retained unchanged

### `models_test.go`
- `Test_spaceFromModel` — normal（全フィールド + `TextFormattingRule` 型変換）、nil
- `Test_diskUsageProjectFromModel` — normal（`DiskUsageBase` 埋め込み展開を確認）、nil
- `Test_diskUsageSpaceFromModel` — with_details、empty_details、nil
- `Test_spaceNotificationFromModel` — normal、nil

Closes #198