### PR TITLE
docs: add Example tests for SpaceService (One, DiskUsage, Notification, UpdateNotification)

### DIFF
--- a/example_space_test.go
+++ b/example_space_test.go
@@ -10,12 +10,70 @@ import (
 )
 
 var (
+	// SpaceService
+	doerSpaceOne                = newMockDoer(fixture.Space.SpaceJSON)
+	doerSpaceDiskUsage          = newMockDoer(fixture.Space.DiskUsageJSON)
+	doerSpaceNotification       = newMockDoer(fixture.Space.NotificationJSON)
+	doerSpaceUpdateNotification = newMockDoer(fixture.Space.NotificationJSON)
+
 	// SpaceActivityService
 	doerSpaceActivityList = newMockDoer(fixture.Activity.ListJSON)
 
 	// SpaceAttachmentService
 	doerSpaceAttachmentUpload = newMockDoer(fixture.Attachment.UploadJSON)
 )
+
+func ExampleSpaceService_One() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerSpaceOne),
+	)
+
+	space, _ := c.Space.One(context.Background())
+	fmt.Printf("SpaceKey: %s, Name: %s\n", space.SpaceKey, space.Name)
+	// Output:
+	// SpaceKey: nulab, Name: Nulab Inc.
+}
+
+func ExampleSpaceService_DiskUsage() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerSpaceDiskUsage),
+	)
+
+	diskUsage, _ := c.Space.DiskUsage(context.Background())
+	fmt.Printf("Capacity: %d, Issue: %d\n", diskUsage.Capacity, diskUsage.Issue)
+	// Output:
+	// Capacity: 1073741824, Issue: 119511
+}
+
+func ExampleSpaceService_Notification() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerSpaceNotification),
+	)
+
+	notification, _ := c.Space.Notification(context.Background())
+	fmt.Printf("Content: %s\n", notification.Content)
+	// Output:
+	// Content: Backlog is a project management tool.
+}
+
+func ExampleSpaceService_UpdateNotification() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerSpaceUpdateNotification),
+	)
+
+	notification, _ := c.Space.UpdateNotification(context.Background(), "Backlog is a project management tool.")
+	fmt.Printf("Content: %s\n", notification.Content)
+	// Output:
+	// Content: Backlog is a project management tool.
+}
 
 func ExampleSpaceActivityService_List() {
 	c, _ := backlog.NewClient(


### PR DESCRIPTION
## Summary

Add Example tests for the four `SpaceService` methods to `example_space_test.go`. This was missed in #198.

## Changes

### `example_space_test.go`
- `ExampleSpaceService_One` — prints `SpaceKey` and `Name`
- `ExampleSpaceService_DiskUsage` — prints `Capacity` and `Issue`
- `ExampleSpaceService_Notification` — prints `Content`
- `ExampleSpaceService_UpdateNotification` — prints `Content`
- Existing `ExampleSpaceActivityService_List` and `ExampleSpaceAttachmentService_Upload` are unchanged (var declarations consolidated at the top)

Part of #198