### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 go-backlog
 ====
-[![GoDoc](https://godoc.org/github.com/nattokin/go-backlog?status.svg)](https://godoc.org/github.com/nattokin/go-backlog)
+[![Go Reference](https://pkg.go.dev/badge/github.com/nattokin/go-backlog.svg)](https://pkg.go.dev/github.com/nattokin/go-backlog)
 [![Go Report Card](https://goreportcard.com/badge/github.com/nattokin/go-backlog)](https://goreportcard.com/report/github.com/nattokin/go-backlog)
 [![Test](https://github.com/nattokin/go-backlog/workflows/Test/badge.svg)](https://github.com/nattokin/go-backlog/actions?query=workflow%3ATest+branch%3Amain)
 [![codecov](https://codecov.io/gh/nattokin/go-backlog/branch/main/graph/badge.svg)](https://codecov.io/gh/nattokin/go-backlog)
@@ -45,15 +45,22 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 
 ## Supported API endpoints
 
-### Client.Space.[Activity](https://godoc.org/github.com/nattokin/go-backlog#SpaceActivityService)
+### Client.[Space](https://pkg.go.dev/github.com/nattokin/go-backlog#SpaceService)
+
+- [Get Space](https://developer.nulab.com/docs/backlog/api/2/get-space) - Returns information about your space.
+- [Get Space Disk Usage](https://developer.nulab.com/docs/backlog/api/2/get-space-disk-usage) - Returns disk usage of your space.
+- [Get Space Notification](https://developer.nulab.com/docs/backlog/api/2/get-space-notification) - Returns the space notification.
+- [Update Space Notification](https://developer.nulab.com/docs/backlog/api/2/update-space-notification) - Updates the space notification.
+
+### Client.Space.[Activity](https://pkg.go.dev/github.com/nattokin/go-backlog#SpaceActivityService)
 
 - [Get Recent Updates](https://developer.nulab.com/docs/backlog/api/2/get-recent-updates) - Returns recent updates in the space.
 
-### Client.Space.[Attachment](https://godoc.org/github.com/nattokin/go-backlog#SpaceAttachmentService)
+### Client.Space.[Attachment](https://pkg.go.dev/github.com/nattokin/go-backlog#SpaceAttachmentService)
 
-- [Post Attachment File](https://developer.nulab-inc.com/docs/backlog/api/2/post-attachment-file/) - Posts an attachment file for issue or wiki, and returns its ID.
+- [Post Attachment File](https://developer.nulab.com/docs/backlog/api/2/post-attachment-file/) - Posts an attachment file for issue or wiki, and returns its ID.
 
-### Client.[User](https://godoc.org/github.com/nattokin/go-backlog#UserService)
+### Client.[User](https://pkg.go.dev/github.com/nattokin/go-backlog#UserService)
 
 - [Get User List](https://developer.nulab.com/docs/backlog/api/2/get-user-list) - Returns a list of users in your space.
 - [Get User](https://developer.nulab.com/docs/backlog/api/2/get-user) - Returns information about a specific user.
@@ -62,10 +69,10 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 - [Delete User](https://developer.nulab.com/docs/backlog/api/2/delete-user) - Deletes a user from the space (Note: Not available at backlog.com).
 - [Get Own User](https://developer.nulab.com/docs/backlog/api/2/get-own-user) - Returns information about the currently authenticated user.
 
-### Client.User.[Activity](https://godoc.org/github.com/nattokin/go-backlog#UserActivityService)
+### Client.User.[Activity](https://pkg.go.dev/github.com/nattokin/go-backlog#UserActivityService)
 - [Get User Recent Updates](https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates) - Returns a user's recent updates.
 
-### Client.[Project](https://godoc.org/github.com/nattokin/go-backlog#ProjectService)
+### Client.[Project](https://pkg.go.dev/github.com/nattokin/go-backlog#ProjectService)
 
 - [Get Project List](https://developer.nulab.com/docs/backlog/api/2/get-project-list) - Returns a list of projects.
 - [Add Project](https://developer.nulab.com/docs/backlog/api/2/add-project) - Adds a new project.
@@ -73,11 +80,11 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 - [Update Project](https://developer.nulab.com/docs/backlog/api/2/update-project) - Updates information about project.
 - [Delete Project](https://developer.nulab.com/docs/backlog/api/2/delete-project) - Deletes a project.
 
-### Client.Project.[Activity](https://godoc.org/github.com/nattokin/go-backlog#ProjectActivityService)
+### Client.Project.[Activity](https://pkg.go.dev/github.com/nattokin/go-backlog#ProjectActivityService)
 
 - [Get Project Recent Updates](https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates) - Returns recent updates in the project.
 
-### Client.Project.[User](https://godoc.org/github.com/nattokin/go-backlog#ProjectUserService)
+### Client.Project.[User](https://pkg.go.dev/github.com/nattokin/go-backlog#ProjectUserService)
 
 - [Add Project User](https://developer.nulab.com/docs/backlog/api/2/add-project-user) - Adds a user to the list of project members.
 - [Get Project User List](https://developer.nulab.com/docs/backlog/api/2/get-project-user-list) - Returns a list of project members.
@@ -86,20 +93,47 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 - [Get List of Project Administrators](https://developer.nulab.com/docs/backlog/api/2/get-list-of-project-administrators) - Returns a list of users with the Project Administrator role.
 - [Delete Project Administrator](https://developer.nulab.com/docs/backlog/api/2/delete-project-administrator) - Removes the Project Administrator role from a user.
 
-### Client.[Wiki](https://godoc.org/github.com/nattokin/go-backlog#WikiService)
+### Client.[Issue](https://pkg.go.dev/github.com/nattokin/go-backlog#IssueService)
 
-- [Get Wiki Page List](https://developer.nulab-inc.com/docs/backlog/api/2/get-wiki-page-list/) - Returns a list of Wiki pages.
-- [Get Wiki Page Tag List](https://developer.nulab-inc.com/docs/backlog/api/2/get-wiki-page-tag-list/) - Returns a list of tags used in the project.
-- [Count Wiki Page](https://developer.nulab-inc.com/docs/backlog/api/2/count-wiki-page/) - Returns the number of Wiki pages.
-- [Get Wiki Page](https://developer.nulab-inc.com/docs/backlog/api/2/get-wiki-page/) - Returns information about a Wiki page.
-- [Add Wiki Page](https://developer.nulab-inc.com/docs/backlog/api/2/add-wiki-page/) - Adds a new Wiki page.
-- [Delete Wiki Page](https://developer.nulab-inc.com/docs/backlog/api/2/delete-wiki-page/) - Deletes a Wiki page.
+- [Get Issue List](https://developer.nulab.com/docs/backlog/api/2/get-issue-list) - Returns a list of issues.
+- [Count Issue](https://developer.nulab.com/docs/backlog/api/2/count-issue) - Returns the number of issues.
+- [Get Issue](https://developer.nulab.com/docs/backlog/api/2/get-issue) - Returns information about a specific issue.
+- [Add Issue](https://developer.nulab.com/docs/backlog/api/2/add-issue) - Adds a new issue.
+- [Update Issue](https://developer.nulab.com/docs/backlog/api/2/update-issue) - Updates information about an issue.
+- [Delete Issue](https://developer.nulab.com/docs/backlog/api/2/delete-issue) - Deletes an issue.
 
-### Client.Wiki.[Attachment](https://godoc.org/github.com/nattokin/go-backlog#WikiAttachmentService)
+### Client.Issue.[Attachment](https://pkg.go.dev/github.com/nattokin/go-backlog#IssueAttachmentService)
 
-- [Get List of Wiki attachments](https://developer.nulab-inc.com/docs/backlog/api/2/get-list-of-wiki-attachments/) - Gets a list of files attached to a Wiki.
-- [Attach File to Wiki](https://developer.nulab-inc.com/docs/backlog/api/2/attach-file-to-wiki/) - Attaches file to Wiki
-- [Remove Wiki Attachment](https://developer.nulab-inc.com/docs/backlog/api/2/remove-wiki-attachment/) - Removes files attached to a Wiki.
+- [Get List of Issue Attachments](https://developer.nulab.com/docs/backlog/api/2/get-list-of-issue-attachments) - Returns a list of files attached to an issue.
+- [Delete Issue Attachment](https://developer.nulab.com/docs/backlog/api/2/delete-issue-attachment) - Removes a file attached to an issue.
+
+### Client.[PullRequest](https://pkg.go.dev/github.com/nattokin/go-backlog#PullRequestService)
+
+- [Get Pull Request List](https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list) - Returns a list of pull requests.
+- [Get Number of Pull Requests](https://developer.nulab.com/docs/backlog/api/2/get-number-of-pull-requests) - Returns the number of pull requests.
+- [Get Pull Request](https://developer.nulab.com/docs/backlog/api/2/get-pull-request) - Returns information about a specific pull request.
+- [Add Pull Request](https://developer.nulab.com/docs/backlog/api/2/add-pull-request) - Creates a new pull request.
+- [Update Pull Request](https://developer.nulab.com/docs/backlog/api/2/update-pull-request) - Updates information about a pull request.
+
+### Client.PullRequest.[Attachment](https://pkg.go.dev/github.com/nattokin/go-backlog#PullRequestAttachmentService)
+
+- [Get List of Pull Request Attachments](https://developer.nulab.com/docs/backlog/api/2/get-list-of-pull-request-attachment) - Returns a list of files attached to a pull request.
+- [Delete Pull Request Attachments](https://developer.nulab.com/docs/backlog/api/2/delete-pull-request-attachments) - Removes a file attached to a pull request.
+
+### Client.[Wiki](https://pkg.go.dev/github.com/nattokin/go-backlog#WikiService)
+
+- [Get Wiki Page List](https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-list/) - Returns a list of Wiki pages.
+- [Get Wiki Page Tag List](https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-tag-list/) - Returns a list of tags used in the project.
+- [Count Wiki Page](https://developer.nulab.com/docs/backlog/api/2/count-wiki-page/) - Returns the number of Wiki pages.
+- [Get Wiki Page](https://developer.nulab.com/docs/backlog/api/2/get-wiki-page/) - Returns information about a Wiki page.
+- [Add Wiki Page](https://developer.nulab.com/docs/backlog/api/2/add-wiki-page/) - Adds a new Wiki page.
+- [Delete Wiki Page](https://developer.nulab.com/docs/backlog/api/2/delete-wiki-page/) - Deletes a Wiki page.
+
+### Client.Wiki.[Attachment](https://pkg.go.dev/github.com/nattokin/go-backlog#WikiAttachmentService)
+
+- [Get List of Wiki Attachments](https://developer.nulab.com/docs/backlog/api/2/get-list-of-wiki-attachments/) - Gets a list of files attached to a Wiki.
+- [Attach File to Wiki](https://developer.nulab.com/docs/backlog/api/2/attach-file-to-wiki/) - Attaches file to Wiki.
+- [Remove Wiki Attachment](https://developer.nulab.com/docs/backlog/api/2/remove-wiki-attachment/) - Removes files attached to a Wiki.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ go-backlog
 
 [Go](https://golang.org) client library for [Nulab Backlog API](https://developer.nulab.com/docs/backlog)
 
-## Feature
+## Features
 
-- You can request each API endpoint using the Backlog API client created from the API base URL and token.
-- Converts API responses to idiomatic Go structs.
-- Structs are provided for all API endpoints and responses.
+- **Type-safe option builders** — Filter and configure requests using strongly-typed option methods (e.g. `WithKeyword`, `WithCount`, `WithOrder`), avoiding raw string/map parameters.
+- **Idiomatic Go structs** — API responses are mapped to Go structs with proper types (`time.Time`, typed constants, etc.) instead of raw JSON.
+- **Context support** — Every API method accepts `context.Context` for cancellation and timeout control.
+- **Structured error types** — Errors are returned as typed values (e.g. `*APIResponseError` for API errors, `*ValidationError` for invalid arguments), enabling precise handling with `errors.As`.
 
 ## Requirements
 


### PR DESCRIPTION
## Changes

- Replace `godoc.org` badge and link with `pkg.go.dev` (godoc.org has been shut down)
- Add missing API endpoints to the Supported API endpoints section:
  - `Client.Space` — One, DiskUsage, Notification, UpdateNotification
  - `Client.Issue` — All, Count, One, Create, Update, Delete
  - `Client.Issue.Attachment` — List, Remove
  - `Client.PullRequest` — All, Count, One, Create, Update
  - `Client.PullRequest.Attachment` — List, Remove
- Unify Nulab API documentation links from `nulab-inc.com` to `nulab.com` (Wiki and Attachment sections)
