### PR TITLE
docs: add missing Update Wiki Page endpoint to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 - [Count Wiki Page](https://developer.nulab.com/docs/backlog/api/2/count-wiki-page/) - Returns the number of Wiki pages.
 - [Get Wiki Page](https://developer.nulab.com/docs/backlog/api/2/get-wiki-page/) - Returns information about a Wiki page.
 - [Add Wiki Page](https://developer.nulab.com/docs/backlog/api/2/add-wiki-page/) - Adds a new Wiki page.
+- [Update Wiki Page](https://developer.nulab.com/docs/backlog/api/2/update-wiki-page/) - Updates a Wiki page.
 - [Delete Wiki Page](https://developer.nulab.com/docs/backlog/api/2/delete-wiki-page/) - Deletes a Wiki page.
 
 ### Client.Wiki.[Attachment](https://pkg.go.dev/github.com/nattokin/go-backlog#WikiAttachmentService)


### PR DESCRIPTION
## Changes

- Add [Update Wiki Page](https://developer.nulab.com/docs/backlog/api/2/update-wiki-page/) to the `Client.Wiki` section

## Background

Cross-checked all implemented services against the official Backlog API documentation. The following were verified as **not yet implemented** (no internal service methods exist) and are correctly omitted from the README:

- Issue/Wiki comment endpoints
- User Star / Recently Viewed endpoints
- Git Repository endpoints (`RepositoryService` has `//nolint:unused // API not implemented yet`)
- PullRequest comment endpoints
- Wiki History, Wiki Shared Files endpoints

`Update Wiki Page` was the only implemented endpoint missing from the README.
