### PR TITLE
feat: implement Get method for activity.SpaceService and SpaceActivityService

### DIFF
--- a/example_space_test.go
+++ b/example_space_test.go
@@ -18,6 +18,7 @@ var (
 
 	// SpaceActivityService
 	doerSpaceActivityList = newMockDoer(fixture.Activity.ListJSON)
+	doerSpaceActivityGet  = newMockDoer(fixture.Activity.SingleJSON)
 
 	// SpaceAttachmentService
 	doerSpaceAttachmentUpload = newMockDoer(fixture.Attachment.UploadJSON)
@@ -84,6 +85,19 @@ func ExampleSpaceActivityService_List() {
 
 	activities, _ := c.Space.Activity.List(context.Background())
 	fmt.Printf("ID: %d, Type: %d\n", activities[0].ID, activities[0].Type)
+	// Output:
+	// ID: 3153, Type: 2
+}
+
+func ExampleSpaceActivityService_Get() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerSpaceActivityGet),
+	)
+
+	activity, _ := c.Space.Activity.Get(context.Background(), 3153)
+	fmt.Printf("ID: %d, Type: %d\n", activity.ID, activity.Type)
 	// Output:
 	// ID: 3153, Type: 2
 }

--- a/internal/activity/service.go
+++ b/internal/activity/service.go
@@ -52,6 +52,28 @@ func (s *SpaceService) List(ctx context.Context, opts ...core.RequestOption) ([]
 	return getList(ctx, s.method, "space/activities", opts...)
 }
 
+// Get returns a single activity by its ID.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-activity
+func (s *SpaceService) Get(ctx context.Context, activityID int) (*model.Activity, error) {
+	if err := validate.ValidateActivityID(activityID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("activities", strconv.Itoa(activityID))
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Activity{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
 type UserService struct {
 	method *core.Method
 }

--- a/internal/activity/service_test.go
+++ b/internal/activity/service_test.go
@@ -91,6 +91,57 @@ func TestSpaceActivityService_List(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestSpaceActivityService_Get(t *testing.T) {
+	t.Parallel()
+
+	activityID := 3153
+
+	want := struct {
+		spath string
+	}{
+		spath: "activities/" + strconv.Itoa(activityID),
+	}
+
+	method := mock.NewMethod(t)
+	method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+		assert.Equal(t, want.spath, spath)
+		assert.Nil(t, query)
+		return nil, errors.New("error")
+	}
+	s := activity.NewSpaceService(method)
+
+	_, err := s.Get(context.Background(), activityID)
+	assert.Error(t, err)
+}
+
+func TestSpaceActivityService_Get_invalidID(t *testing.T) {
+	t.Parallel()
+
+	method := mock.NewMethod(t)
+	s := activity.NewSpaceService(method)
+
+	_, err := s.Get(context.Background(), 0)
+	assert.Error(t, err)
+}
+
+func TestSpaceActivityService_Get_invalidJson(t *testing.T) {
+	t.Parallel()
+
+	method := mock.NewMethod(t)
+	method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+		}
+		return resp, nil
+	}
+	s := activity.NewSpaceService(method)
+
+	got, err := s.Get(context.Background(), 1)
+	assert.Nil(t, got)
+	assert.Error(t, err)
+}
+
 func TestUserActivityService_List(t *testing.T) {
 	t.Parallel()
 
@@ -311,6 +362,11 @@ func TestActivityService_contextPropagation(t *testing.T) {
 			m.Get = makeMockFn(t)
 			s := activity.NewSpaceService(m)
 			s.List(ctx) //nolint:errcheck
+		}},
+		{"SpaceActivityService.Get", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := activity.NewSpaceService(m)
+			s.Get(ctx, 1) //nolint:errcheck
 		}},
 		{"UserActivityService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)

--- a/internal/core/option_slice.go
+++ b/internal/core/option_slice.go
@@ -8,7 +8,7 @@ func (s *OptionService) WithActivityTypeIDs(typeIDs []int) RequestOption {
 		Type: ParamActivityTypeIDs,
 		CheckFunc: func() error {
 			for _, id := range typeIDs {
-				if err := validateActivityID(id, "activityTypeIds"); err != nil {
+				if err := validateActivityTypeID(id, "activityTypeIds"); err != nil {
 					return err
 				}
 			}
@@ -93,8 +93,8 @@ func (s *OptionService) WithParentIssueIDs(ids []int) RequestOption {
 	return intSliceOption(ParamParentIssueIDs, "parentIssueId", ids)
 }
 
-// validateActivityID ensures that the given activity ID is within the valid range [1, 26].
-func validateActivityID(id int, key string) error {
+// validateActivityTypeID ensures that the given activity type ID is within the valid range [1, 26].
+func validateActivityTypeID(id int, key string) error {
 	if id < 1 || id > MaxActivityTypeID {
 		return NewValidationError(fmt.Sprintf("invalid %s: must be between 1 and %d", key, MaxActivityTypeID))
 	}

--- a/internal/testutil/fixture/testdata_activity.go
+++ b/internal/testutil/fixture/testdata_activity.go
@@ -5,8 +5,10 @@ import (
 )
 
 type activityFixtures struct {
-	ListJSON string
-	List     []*backlog.Activity
+	ListJSON   string
+	List       []*backlog.Activity
+	SingleJSON string
+	Single     *backlog.Activity
 }
 
 // Activity provides test fixtures for Activity-related tests.
@@ -200,6 +202,63 @@ var Activity = activityFixtures{
 				Lang:        "ja",
 				MailAddress: "eguchi@nulab.example",
 			},
+		},
+	},
+	SingleJSON: `{
+    "id": 3153,
+    "project": {
+        "id": 92,
+        "projectKey": "SUB",
+        "name": "Subtasking",
+        "chartEnabled": true,
+        "subtaskingEnabled": true,
+        "projectLeaderCanEditProjectLeader": false,
+        "textFormattingRule": null,
+        "archived": false,
+        "displayOrder": 0
+    },
+    "type": 2,
+    "content": {
+        "id": 4809,
+        "key_id": 121,
+        "summary": "Comment",
+        "description": ""
+    },
+    "notifications": [],
+    "createdUser": {
+        "id": 1,
+        "userId": "admin",
+        "name": "admin",
+        "roleType": 1,
+        "lang": "ja",
+        "mailAddress": "eguchi@nulab.example"
+    },
+    "created": "2014-07-21T06:48:40Z"
+}`,
+	Single: &backlog.Activity{
+		ID: 3153,
+		Project: &backlog.Project{
+			ID:                92,
+			ProjectKey:        "SUB",
+			Name:              "Subtasking",
+			ChartEnabled:      true,
+			SubtaskingEnabled: true,
+		},
+		Type: 2,
+		Content: &backlog.ActivityContent{
+			ID:          4809,
+			KeyID:       121,
+			Summary:     "Comment",
+			Description: "",
+		},
+		Notifications: []*backlog.Notification{},
+		CreatedUser: &backlog.User{
+			ID:          1,
+			UserID:      "admin",
+			Name:        "admin",
+			RoleType:    backlog.RoleAdministrator,
+			Lang:        "ja",
+			MailAddress: "eguchi@nulab.example",
 		},
 	},
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -2,6 +2,13 @@ package validate
 
 import "github.com/nattokin/go-backlog/internal/core"
 
+func ValidateActivityID(activityID int) error {
+	if activityID < 1 {
+		return core.NewValidationError("activityID must not be less than 1")
+	}
+	return nil
+}
+
 func ValidateAttachmentID(attachmentID int) error {
 	if attachmentID < 1 {
 		return core.NewValidationError("attachmentID must not be less than 1")

--- a/space.go
+++ b/space.go
@@ -131,6 +131,14 @@ func (s *SpaceActivityService) List(ctx context.Context, opts ...RequestOption) 
 	return activitiesFromModel(v), convertError(err)
 }
 
+// Get returns a single activity by its ID.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-activity
+func (s *SpaceActivityService) Get(ctx context.Context, activityID int) (*Activity, error) {
+	v, err := s.base.Get(ctx, activityID)
+	return activityFromModel(v), convertError(err)
+}
+
 // SpaceAttachmentService handles communication with the space attachment-related methods of the Backlog API.
 type SpaceAttachmentService struct {
 	base *attachment.SpaceService

--- a/space_test.go
+++ b/space_test.go
@@ -318,16 +318,14 @@ func TestSpaceActivityService(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			if tc.doFunc == nil {
-				c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: func(req *http.Request) (*http.Response, error) {
-					return nil, errors.New("should not be called")
-				}}))
-				require.NoError(t, err)
-				tc.call(t, c)
-				return
+			doFunc := func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("should not be called")
+			}
+			if tc.doFunc != nil {
+				doFunc = tc.doFunc
 			}
 
-			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: doFunc}))
 			require.NoError(t, err)
 			tc.call(t, c)
 		})

--- a/space_test.go
+++ b/space_test.go
@@ -275,11 +275,57 @@ func TestSpaceActivityService(t *testing.T) {
 				assert.True(t, errors.As(err, &target))
 			},
 		},
+		"Get": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/activities/3153", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Space.Activity.Get(ctx, 3153)
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				assert.Equal(t, 3153, got.ID)
+				assert.Equal(t, 2, got.Type)
+			},
+		},
+		"Get/error-invalid-id": {
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Space.Activity.Get(ctx, 0)
+				require.Error(t, err)
+			},
+		},
+		"Get/error-api": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Space.Activity.Get(ctx, 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
+			if tc.doFunc == nil {
+				c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("should not be called")
+				}}))
+				require.NoError(t, err)
+				tc.call(t, c)
+				return
+			}
 
 			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
 			require.NoError(t, err)


### PR DESCRIPTION
## Summary

Implements the missing `GET /api/v2/activities/{activityId}` endpoint as described in #213.

## Changes

- `internal/validate/validate.go`: Add `ValidateActivityID` for validating activity IDs (must be >= 1)
- `internal/activity/service.go`: Add `SpaceService.Get(ctx, activityID)` — fetches a single activity by ID from `activities/{activityId}`
- `internal/activity/service_test.go`: Add unit tests for `SpaceService.Get` including path assertion, invalid ID, invalid JSON, and context propagation
- `space.go`: Add `SpaceActivityService.Get(ctx, activityID)` as the public API method, delegating to `activity.SpaceService.Get`
- `space_test.go`: Add integration-style tests for `SpaceActivityService.Get` (success, invalid ID, API error)
- `internal/testutil/fixture/testdata_activity.go`: Add `SingleJSON` and `Single` fixtures for single-activity responses

Closes #213