### PR TITLE
fix: add nil guard to ApplyOptions to prevent panic on nil option

### DIFF
--- a/internal/core/option.go
+++ b/internal/core/option.go
@@ -176,6 +176,9 @@ func ValidateOption(optionKey string, validOptions []APIParamOptionType) error {
 // ApplyOptions validates and applies request options to the given url.Values.
 func ApplyOptions(v url.Values, validTypes []APIParamOptionType, opts ...RequestOption) error {
 	for _, opt := range opts {
+		if opt == nil {
+			return NewValidationError("nil option is not allowed")
+		}
 		if err := ValidateOption(opt.Key(), validTypes); err != nil {
 			return err
 		}

--- a/internal/core/option_test.go
+++ b/internal/core/option_test.go
@@ -1,10 +1,13 @@
 package core_test
 
 import (
+	"errors"
 	"net/url"
 	"testing"
 
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPIParamOption(t *testing.T) {
@@ -49,5 +52,12 @@ func TestAPIParamOption(t *testing.T) {
 			core.ApplyOptions(v, []core.APIParamOptionType{core.ParamKey}, tc.option)
 		})
 	}
+}
 
+func TestApplyOptions_NilOption(t *testing.T) {
+	v := url.Values{}
+	err := core.ApplyOptions(v, []core.APIParamOptionType{core.ParamKey}, nil)
+	require.Error(t, err)
+	var valErr *core.ValidationError
+	assert.True(t, errors.As(err, &valErr))
 }

--- a/internal/core/option_test.go
+++ b/internal/core/option_test.go
@@ -5,9 +5,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nattokin/go-backlog/internal/core"
 )
 
 func TestAPIParamOption(t *testing.T) {

--- a/internal/core/option_test.go
+++ b/internal/core/option_test.go
@@ -55,10 +55,80 @@ func TestAPIParamOption(t *testing.T) {
 	}
 }
 
-func TestApplyOptions_NilOption(t *testing.T) {
-	v := url.Values{}
-	err := core.ApplyOptions(v, []core.APIParamOptionType{core.ParamKey}, nil)
-	require.Error(t, err)
-	var valErr *core.ValidationError
-	assert.True(t, errors.As(err, &valErr))
+func TestApplyOptions(t *testing.T) {
+	validTypes := []core.APIParamOptionType{core.ParamKey}
+
+	cases := map[string]struct {
+		opts        []core.RequestOption
+		wantErr     bool
+		wantErrType any
+	}{
+		"nilOption": {
+			opts:        []core.RequestOption{nil},
+			wantErr:     true,
+			wantErrType: &core.ValidationError{},
+		},
+		"nilOption-second": {
+			opts: []core.RequestOption{
+				&core.APIParamOption{
+					Type:    core.ParamKey,
+					SetFunc: func(_ url.Values) error { return nil },
+				},
+				nil,
+			},
+			wantErr:     true,
+			wantErrType: &core.ValidationError{},
+		},
+		"invalidKey": {
+			opts: []core.RequestOption{
+				&core.APIParamOption{
+					Type:    core.ParamName,
+					SetFunc: func(_ url.Values) error { return nil },
+				},
+			},
+			wantErr:     true,
+			wantErrType: &core.InvalidOptionKeyError{},
+		},
+		"checkError": {
+			opts: []core.RequestOption{
+				&core.APIParamOption{
+					Type:      core.ParamKey,
+					CheckFunc: func() error { return errors.New("check failed") },
+					SetFunc:   func(_ url.Values) error { return nil },
+				},
+			},
+			wantErr: true,
+		},
+		"success": {
+			opts: []core.RequestOption{
+				&core.APIParamOption{
+					Type:    core.ParamKey,
+					SetFunc: func(v url.Values) error { v.Set(core.ParamKey.Value(), "val"); return nil },
+				},
+			},
+			wantErr: false,
+		},
+		"noOptions": {
+			opts:    []core.RequestOption{},
+			wantErr: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			v := url.Values{}
+			err := core.ApplyOptions(v, validTypes, tc.opts...)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrType != nil {
+					assert.True(t, errors.As(err, &tc.wantErrType))
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Add a nil guard at the top of the `ApplyOptions` loop. Previously, passing a nil `RequestOption` caused a panic at `opt.Key()`. The nil is now detected early and returned as a `ValidationError`.

## Changes

- `internal/core/option.go`: return `ValidationError` when a nil option is encountered in `ApplyOptions`
- `internal/core/option_test.go`: add `TestApplyOptions_NilOption` to verify the error type

Closes #226