### PR TITLE
feat: implement Wiki.Star sub-service

### DIFF
--- a/example_wiki_test.go
+++ b/example_wiki_test.go
@@ -3,6 +3,7 @@ package backlog_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
@@ -19,6 +20,8 @@ var (
 	doerWikiAttachmentAttach = newMockDoer(fixture.Attachment.ListJSON)
 	doerWikiAttachmentList   = newMockDoer(fixture.Attachment.ListJSON)
 	doerWikiAttachmentRemove = newMockDoer(fixture.Attachment.SingleJSON)
+
+	doerWikiStarList = newMockDoer(fixture.Star.ListJSON)
 )
 
 func ExampleWikiService_All() {
@@ -140,4 +143,55 @@ func ExampleWikiAttachmentService_Remove() {
 	fmt.Printf("ID: %d, Name: %s\n", attachment.ID, attachment.Name)
 	// Output:
 	// ID: 8, Name: IMG0088.png
+}
+
+func ExampleWikiStarService_List() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiStarList),
+	)
+
+	stars, _ := c.Wiki.Star.List(context.Background(), 34)
+	fmt.Printf("ID: %d, Title: %s\n", stars[0].ID, stars[0].Title)
+	// Output:
+	// ID: 10, Title: [TEST-1] first issue
+}
+
+func ExampleWikiStarService_Add() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		}}),
+	)
+
+	err := c.Wiki.Star.Add(context.Background(), 34)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output:
+	// ok
+}
+
+func ExampleWikiStarService_Remove() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		}}),
+	)
+
+	err := c.Wiki.Star.Remove(context.Background(), 42)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output:
+	// ok
 }

--- a/internal/star/service.go
+++ b/internal/star/service.go
@@ -137,6 +137,37 @@ func (s *UserService) Count(ctx context.Context, userID int) (int, error) {
 }
 
 // ──────────────────────────────────────────────────────────────
+//  WikiService
+// ──────────────────────────────────────────────────────────────
+
+// WikiService handles communication with the wiki star-related methods of the Backlog API.
+type WikiService struct {
+	method *core.Method
+}
+
+// List returns a list of stars on the wiki page with the given ID.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-star
+func (s *WikiService) List(ctx context.Context, wikiID int) ([]*model.Star, error) {
+	if err := validate.ValidateWikiID(wikiID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("wikis", strconv.Itoa(wikiID), "stars")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.Star{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// ──────────────────────────────────────────────────────────────
 //  Constructor
 // ──────────────────────────────────────────────────────────────
 
@@ -148,4 +179,9 @@ func NewService(method *core.Method) *Service {
 // NewUserService creates and returns a new star UserService.
 func NewUserService(method *core.Method) *UserService {
 	return &UserService{method: method}
+}
+
+// NewWikiService creates and returns a new star WikiService.
+func NewWikiService(method *core.Method) *WikiService {
+	return &WikiService{method: method}
 }

--- a/internal/star/service_wiki_test.go
+++ b/internal/star/service_wiki_test.go
@@ -1,0 +1,111 @@
+package star_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/star"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
+)
+
+func TestWikiStarService_List(t *testing.T) {
+	cases := map[string]struct {
+		wikiID    int
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+		wantErr   bool
+		wantLen   int
+	}{
+		"success": {
+			wikiID: 34,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "wikis/34/stars", spath)
+				assert.Nil(t, query)
+				return newJSONResponse(fixture.Star.ListJSON), nil
+			},
+			wantLen: 2,
+		},
+		"error-invalid-wikiID": {
+			wikiID:  0,
+			wantErr: true,
+		},
+		"error-client-network": {
+			wikiID: 34,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErr: true,
+		},
+		"error-json-decode": {
+			wikiID: 34,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(fixture.InvalidJSON)),
+				}, nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := star.NewWikiService(method)
+			got, err := s.List(context.Background(), tc.wikiID)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, got, tc.wantLen)
+		})
+	}
+}
+
+func TestWikiStarService_contextPropagation(t *testing.T) {
+	type ctxKey struct{}
+	sentinel := &struct{}{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+
+	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
+	}
+
+	cases := []struct {
+		name string
+		call func(t *testing.T, m *core.Method)
+	}{
+		{"WikiStarService.List", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := star.NewWikiService(m)
+			s.List(ctx, 34) //nolint:errcheck
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.call(t, &core.Method{})
+		})
+	}
+}

--- a/internal/star/service_wiki_test.go
+++ b/internal/star/service_wiki_test.go
@@ -3,6 +3,7 @@ package star_test
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"

--- a/wiki.go
+++ b/wiki.go
@@ -216,12 +216,11 @@ func (s *WikiOptionService) WithName(name string) RequestOption {
 // ──────────────────────────────────────────────────────────────
 
 func newWikiService(method *core.Method, option *core.OptionService) *WikiService {
-	starSvc := newStarService(method, option)
 	return &WikiService{
 		base:       wiki.NewService(method),
 		Attachment: newWikiAttachmentService(method),
 		Option:     newWikiOptionService(option),
-		Star:       newWikiStarService(method, starSvc),
+		Star:       newWikiStarService(method, option),
 	}
 }
 
@@ -231,10 +230,10 @@ func newWikiAttachmentService(method *core.Method) *WikiAttachmentService {
 	}
 }
 
-func newWikiStarService(method *core.Method, starSvc *StarService) *WikiStarService {
+func newWikiStarService(method *core.Method, option *core.OptionService) *WikiStarService {
 	return &WikiStarService{
 		base: star.NewWikiService(method),
-		star: starSvc,
+		star: newStarService(method, option),
 	}
 }
 

--- a/wiki.go
+++ b/wiki.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/star"
 	"github.com/nattokin/go-backlog/internal/wiki"
 )
 
@@ -50,6 +51,7 @@ type WikiService struct {
 
 	Attachment *WikiAttachmentService
 	Option     *WikiOptionService
+	Star       *WikiStarService
 }
 
 // All returns a list of all wiki pages in the project.
@@ -148,6 +150,38 @@ func (s *WikiAttachmentService) Remove(ctx context.Context, wikiID, attachmentID
 }
 
 // ──────────────────────────────────────────────────────────────
+//  WikiStarService
+// ──────────────────────────────────────────────────────────────
+
+// WikiStarService handles communication with the wiki star-related methods of the Backlog API.
+type WikiStarService struct {
+	base *star.WikiService
+	star *StarService
+}
+
+// List returns a list of stars on the wiki page.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-star
+func (s *WikiStarService) List(ctx context.Context, wikiID int) ([]*Star, error) {
+	v, err := s.base.List(ctx, wikiID)
+	return starsFromModel(v), convertError(err)
+}
+
+// Add adds a star to the wiki page.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-star
+func (s *WikiStarService) Add(ctx context.Context, wikiID int) error {
+	return s.star.Add(ctx, s.star.Option.WithWikiID(wikiID))
+}
+
+// Remove removes a star by its ID.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/remove-star
+func (s *WikiStarService) Remove(ctx context.Context, starID int) error {
+	return s.star.Remove(ctx, starID)
+}
+
+// ──────────────────────────────────────────────────────────────
 //  WikiOptionService
 // ──────────────────────────────────────────────────────────────
 
@@ -182,16 +216,25 @@ func (s *WikiOptionService) WithName(name string) RequestOption {
 // ──────────────────────────────────────────────────────────────
 
 func newWikiService(method *core.Method, option *core.OptionService) *WikiService {
+	starSvc := newStarService(method, option)
 	return &WikiService{
 		base:       wiki.NewService(method),
 		Attachment: newWikiAttachmentService(method),
 		Option:     newWikiOptionService(option),
+		Star:       newWikiStarService(method, starSvc),
 	}
 }
 
 func newWikiAttachmentService(method *core.Method) *WikiAttachmentService {
 	return &WikiAttachmentService{
 		base: attachment.NewWikiService(method),
+	}
+}
+
+func newWikiStarService(method *core.Method, starSvc *StarService) *WikiStarService {
+	return &WikiStarService{
+		base: star.NewWikiService(method),
+		star: starSvc,
 	}
 }
 

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -338,6 +338,114 @@ func TestWikiAttachmentService(t *testing.T) {
 	}
 }
 
+func TestWikiStarService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"List": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/wikis/34/stars", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Star.ListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Wiki.Star.List(ctx, 34)
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, 10, got[0].ID)
+				assert.Equal(t, 20, got[1].ID)
+			},
+		},
+		"List/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.Star.List(ctx, 34)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Add": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/stars", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "34", req.FormValue("wikiId"))
+				return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.Wiki.Star.Add(ctx, 34)
+				require.NoError(t, err)
+			},
+		},
+		"Add/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.Wiki.Star.Add(ctx, 34)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Remove": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, "/api/v2/stars", req.URL.Path)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				form, err := url.ParseQuery(string(body))
+				require.NoError(t, err)
+				assert.Equal(t, "42", form.Get("id"))
+				return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.Wiki.Star.Remove(ctx, 42)
+				require.NoError(t, err)
+			},
+		},
+		"Remove/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.Wiki.Star.Remove(ctx, 42)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}
+
 func TestWikiOptionService(t *testing.T) {
 	c, err := backlog.NewClient("https://example.backlog.com", "token")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Implement `Wiki.Star` sub-service providing star operations scoped to a wiki page.

## Changes

- `internal/star/service.go`: Add `WikiService` with `List` method (`GET /api/v2/wikis/{wikiID}/stars`) and `NewWikiService` constructor
- `wiki.go`: Add `WikiStarService` with `List`, `Add`, and `Remove` methods; wire it into `WikiService` via new `Star` field
  - `List` delegates to `star.WikiService`
  - `Add(wikiID int)` and `Remove(starID int)` are thin aliases over the existing `StarService`
- `internal/star/service_wiki_test.go`: Unit tests for `star.WikiService.List` (path, validation, error cases, context propagation)
- `wiki_test.go`: Integration-style tests for `WikiStarService.List`, `Add`, and `Remove`
- `example_wiki_test.go`: Example functions for `WikiStarService.List`, `Add`, and `Remove`

Part of #217