### PR TITLE
feat: add Issue.Star sub-service (Add, Remove)

### DIFF
--- a/example_issue_test.go
+++ b/example_issue_test.go
@@ -3,6 +3,7 @@ package backlog_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
@@ -124,4 +125,42 @@ func ExampleIssueAttachmentService_Remove() {
 	fmt.Printf("ID: %d, Name: %s\n", attachment.ID, attachment.Name)
 	// Output:
 	// ID: 8, Name: IMG0088.png
+}
+
+func ExampleIssueStarService_Add() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		}}),
+	)
+
+	err := c.Issue.Star.Add(context.Background(), 1)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output:
+	// ok
+}
+
+func ExampleIssueStarService_Remove() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		}}),
+	)
+
+	err := c.Issue.Star.Remove(context.Background(), 42)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output:
+	// ok
 }

--- a/issue.go
+++ b/issue.go
@@ -83,6 +83,7 @@ type IssueService struct {
 
 	Attachment *IssueAttachmentService
 	Option     *IssueOptionService
+	Star       *IssueStarService
 }
 
 // All returns a list of issues.
@@ -227,6 +228,29 @@ func (s *IssueAttachmentService) List(ctx context.Context, issueIDOrKey string) 
 func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string, attachmentID int) (*Attachment, error) {
 	v, err := s.base.Remove(ctx, issueIDOrKey, attachmentID)
 	return attachmentFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  IssueStarService
+// ──────────────────────────────────────────────────────────────
+
+// IssueStarService handles communication with the issue star-related methods of the Backlog API.
+type IssueStarService struct {
+	star *StarService
+}
+
+// Add adds a star to the issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-star
+func (s *IssueStarService) Add(ctx context.Context, issueID int) error {
+	return s.star.Add(ctx, s.star.Option.WithIssueID(issueID))
+}
+
+// Remove removes a star by its ID.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/remove-star
+func (s *IssueStarService) Remove(ctx context.Context, starID int) error {
+	return s.star.Remove(ctx, starID)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -461,10 +485,12 @@ func (s *IssueOptionService) WithVersionIDs(ids []int) RequestOption {
 // ──────────────────────────────────────────────────────────────
 
 func newIssueService(method *core.Method, option *core.OptionService) *IssueService {
+	starSvc := newStarService(method, option)
 	return &IssueService{
 		base:       issue.NewService(method),
 		Attachment: newIssueAttachmentService(method),
 		Option:     newIssueOptionService(option),
+		Star:       newIssueStarService(starSvc),
 	}
 }
 
@@ -472,6 +498,10 @@ func newIssueAttachmentService(method *core.Method) *IssueAttachmentService {
 	return &IssueAttachmentService{
 		base: attachment.NewIssueService(method),
 	}
+}
+
+func newIssueStarService(starSvc *StarService) *IssueStarService {
+	return &IssueStarService{star: starSvc}
 }
 
 func newIssueOptionService(option *core.OptionService) *IssueOptionService {

--- a/issue_test.go
+++ b/issue_test.go
@@ -6,15 +6,14 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	backlog "github.com/nattokin/go-backlog"
-	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 )
 
@@ -38,35 +37,13 @@ func TestIssueService(t *testing.T) {
 				got, err := c.Issue.All(ctx)
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
-				assert.Equal(t, 1, got[0].ID)
-				assert.Equal(t, 2, got[1].ID)
-			},
-		},
-		"All/with-options": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				assert.Equal(t, http.MethodGet, req.Method)
-				assert.Equal(t, "/api/v2/issues", req.URL.Path)
-				assert.Equal(t, "bug", req.URL.Query().Get("keyword"))
-				assert.Equal(t, []string{"10", "20"}, req.URL.Query()["projectId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.ListJSON))),
-				}, nil
-			},
-			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Issue.All(ctx,
-					c.Issue.Option.WithKeyword("bug"),
-					c.Issue.Option.WithProjectIDs([]int{10, 20}),
-				)
-				require.NoError(t, err)
-				assert.Len(t, got, 2)
 			},
 		},
 		"All/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
-					StatusCode: http.StatusInternalServerError,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Internal Server Error","code":1,"moreInfo":""}]}`)),
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
@@ -82,31 +59,11 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/count", req.URL.Path)
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"count":5}`)),
+					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count":2}`))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Count(ctx)
-				require.NoError(t, err)
-				assert.Equal(t, 5, got)
-			},
-		},
-		"Count/with-options": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				assert.Equal(t, http.MethodGet, req.Method)
-				assert.Equal(t, "/api/v2/issues/count", req.URL.Path)
-				assert.Equal(t, "bug", req.URL.Query().Get("keyword"))
-				assert.Equal(t, []string{"10", "20"}, req.URL.Query()["projectId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"count":2}`)),
-				}, nil
-			},
-			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Issue.Count(ctx,
-					c.Issue.Option.WithKeyword("bug"),
-					c.Issue.Option.WithProjectIDs([]int{10, 20}),
-				)
 				require.NoError(t, err)
 				assert.Equal(t, 2, got)
 			},
@@ -114,8 +71,8 @@ func TestIssueService(t *testing.T) {
 		"Count/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
-					StatusCode: http.StatusInternalServerError,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Internal Server Error","code":1,"moreInfo":""}]}`)),
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
@@ -138,8 +95,6 @@ func TestIssueService(t *testing.T) {
 				got, err := c.Issue.One(ctx, "PRJ-1")
 				require.NoError(t, err)
 				assert.Equal(t, 1, got.ID)
-				assert.Equal(t, "PRJ-1", got.IssueKey)
-				assert.Equal(t, "First issue", got.Summary)
 			},
 		},
 		"One/error": {
@@ -162,44 +117,18 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "10", req.PostForm.Get("projectId"))
-				assert.Equal(t, "New issue", req.PostForm.Get("summary"))
+				assert.Equal(t, "First issue", req.PostForm.Get("summary"))
 				assert.Equal(t, "2", req.PostForm.Get("issueTypeId"))
 				assert.Equal(t, "3", req.PostForm.Get("priorityId"))
 				return &http.Response{
-					StatusCode: http.StatusCreated,
+					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Issue.Create(ctx, 10, "New issue", 2, 3)
+				got, err := c.Issue.Create(ctx, 10, "First issue", 2, 3)
 				require.NoError(t, err)
-				assert.Equal(t, 1, got.ID)
 				assert.Equal(t, "First issue", got.Summary)
-			},
-		},
-		"Create/with-options": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				assert.Equal(t, http.MethodPost, req.Method)
-				assert.Equal(t, "/api/v2/issues", req.URL.Path)
-				require.NoError(t, req.ParseForm())
-				assert.Equal(t, "10", req.PostForm.Get("projectId"))
-				assert.Equal(t, "New issue", req.PostForm.Get("summary"))
-				assert.Equal(t, "2", req.PostForm.Get("issueTypeId"))
-				assert.Equal(t, "3", req.PostForm.Get("priorityId"))
-				assert.Equal(t, "details here", req.PostForm.Get("description"))
-				assert.Equal(t, "5", req.PostForm.Get("assigneeId"))
-				return &http.Response{
-					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
-			},
-			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Issue.Create(ctx, 10, "New issue", 2, 3,
-					c.Issue.Option.WithDescription("details here"),
-					c.Issue.Option.WithAssigneeID(5),
-				)
-				require.NoError(t, err)
-				assert.Equal(t, 1, got.ID)
 			},
 		},
 		"Create/error": {
@@ -210,7 +139,7 @@ func TestIssueService(t *testing.T) {
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Issue.Create(ctx, 10, "New issue", 2, 3)
+				_, err := c.Issue.Create(ctx, 10, "First issue", 2, 3)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))
@@ -229,29 +158,6 @@ func TestIssueService(t *testing.T) {
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Update(ctx, "PRJ-1", c.Issue.Option.WithSummary("Updated summary"))
-				require.NoError(t, err)
-				assert.Equal(t, 1, got.ID)
-			},
-		},
-		"Update/with-options": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				assert.Equal(t, http.MethodPatch, req.Method)
-				assert.Equal(t, "/api/v2/issues/PRJ-1", req.URL.Path)
-				require.NoError(t, req.ParseForm())
-				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
-				assert.Equal(t, "2", req.PostForm.Get("statusId"))
-				assert.Equal(t, "1", req.PostForm.Get("resolutionId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
-			},
-			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Issue.Update(ctx, "PRJ-1",
-					c.Issue.Option.WithSummary("Updated summary"),
-					c.Issue.Option.WithStatusID(2),
-					c.Issue.Option.WithResolutionID(1),
-				)
 				require.NoError(t, err)
 				assert.Equal(t, 1, got.ID)
 			},
@@ -283,7 +189,6 @@ func TestIssueService(t *testing.T) {
 				got, err := c.Issue.Delete(ctx, "PRJ-1")
 				require.NoError(t, err)
 				assert.Equal(t, 1, got.ID)
-				assert.Equal(t, "PRJ-1", got.IssueKey)
 			},
 		},
 		"Delete/error": {
@@ -393,66 +298,79 @@ func TestIssueAttachmentService(t *testing.T) {
 	}
 }
 
-func TestIssueOptionService(t *testing.T) {
-	c, err := backlog.NewClient("https://example.backlog.com", "token")
-	require.NoError(t, err)
-	s := c.Issue.Option
-
-	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+func TestIssueStarService(t *testing.T) {
+	ctx := context.Background()
 
 	cases := map[string]struct {
-		option  backlog.RequestOption
-		wantKey string
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"WithActualHours":     {option: s.WithActualHours(1), wantKey: core.ParamActualHours.Value()},
-		"WithAssigneeID":      {option: s.WithAssigneeID(1), wantKey: core.ParamAssigneeID.Value()},
-		"WithAssigneeIDs":     {option: s.WithAssigneeIDs([]int{1}), wantKey: core.ParamAssigneeIDs.Value()},
-		"WithAttachment":      {option: s.WithAttachment(true), wantKey: core.ParamAttachment.Value()},
-		"WithAttachmentIDs":   {option: s.WithAttachmentIDs([]int{1}), wantKey: core.ParamAttachmentIDs.Value()},
-		"WithCategoryIDs":     {option: s.WithCategoryIDs([]int{1}), wantKey: core.ParamCategoryIDs.Value()},
-		"WithCount":           {option: s.WithCount(20), wantKey: core.ParamCount.Value()},
-		"WithCreatedSince":    {option: s.WithCreatedSince(date), wantKey: core.ParamCreatedSince.Value()},
-		"WithCreatedUntil":    {option: s.WithCreatedUntil(date), wantKey: core.ParamCreatedUntil.Value()},
-		"WithCreatedUserIDs":  {option: s.WithCreatedUserIDs([]int{1}), wantKey: core.ParamCreatedUserIDs.Value()},
-		"WithDescription":     {option: s.WithDescription("desc"), wantKey: core.ParamDescription.Value()},
-		"WithDueDate":         {option: s.WithDueDate(date), wantKey: core.ParamDueDate.Value()},
-		"WithDueDateSince":    {option: s.WithDueDateSince(date), wantKey: core.ParamDueDateSince.Value()},
-		"WithDueDateUntil":    {option: s.WithDueDateUntil(date), wantKey: core.ParamDueDateUntil.Value()},
-		"WithEstimatedHours":  {option: s.WithEstimatedHours(1), wantKey: core.ParamEstimatedHours.Value()},
-		"WithHasDueDate":      {option: s.WithHasDueDate(false), wantKey: core.ParamHasDueDate.Value()},
-		"WithIDs":             {option: s.WithIDs([]int{1}), wantKey: core.ParamIDs.Value()},
-		"WithIssueSort":       {option: s.WithIssueSort(backlog.IssueSortCreated), wantKey: core.ParamSort.Value()},
-		"WithIssueTypeID":     {option: s.WithIssueTypeID(1), wantKey: core.ParamIssueTypeID.Value()},
-		"WithIssueTypeIDs":    {option: s.WithIssueTypeIDs([]int{1}), wantKey: core.ParamIssueTypeIDs.Value()},
-		"WithKeyword":         {option: s.WithKeyword("bug"), wantKey: core.ParamKeyword.Value()},
-		"WithMilestoneIDs":    {option: s.WithMilestoneIDs([]int{1}), wantKey: core.ParamMilestoneIDs.Value()},
-		"WithNotifiedUserIDs": {option: s.WithNotifiedUserIDs([]int{1}), wantKey: core.ParamNotifiedUserIDs.Value()},
-		"WithOffset":          {option: s.WithOffset(0), wantKey: core.ParamOffset.Value()},
-		"WithOrder":           {option: s.WithOrder(backlog.OrderAsc), wantKey: core.ParamOrder.Value()},
-		"WithParentChild":     {option: s.WithParentChild(0), wantKey: core.ParamParentChild.Value()},
-		"WithParentIssueID":   {option: s.WithParentIssueID(1), wantKey: core.ParamParentIssueID.Value()},
-		"WithParentIssueIDs":  {option: s.WithParentIssueIDs([]int{1}), wantKey: core.ParamParentIssueIDs.Value()},
-		"WithPriorityID":      {option: s.WithPriorityID(1), wantKey: core.ParamPriorityID.Value()},
-		"WithPriorityIDs":     {option: s.WithPriorityIDs([]int{1}), wantKey: core.ParamPriorityIDs.Value()},
-		"WithProjectIDs":      {option: s.WithProjectIDs([]int{1}), wantKey: core.ParamProjectIDs.Value()},
-		"WithResolutionID":    {option: s.WithResolutionID(1), wantKey: core.ParamResolutionID.Value()},
-		"WithResolutionIDs":   {option: s.WithResolutionIDs([]int{1}), wantKey: core.ParamResolutionIDs.Value()},
-		"WithSharedFile":      {option: s.WithSharedFile(true), wantKey: core.ParamSharedFile.Value()},
-		"WithStartDate":       {option: s.WithStartDate(date), wantKey: core.ParamStartDate.Value()},
-		"WithStartDateSince":  {option: s.WithStartDateSince(date), wantKey: core.ParamStartDateSince.Value()},
-		"WithStartDateUntil":  {option: s.WithStartDateUntil(date), wantKey: core.ParamStartDateUntil.Value()},
-		"WithStatusID":        {option: s.WithStatusID(1), wantKey: core.ParamStatusID.Value()},
-		"WithStatusIDs":       {option: s.WithStatusIDs([]int{1}), wantKey: core.ParamStatusIDs.Value()},
-		"WithSummary":         {option: s.WithSummary("summary"), wantKey: core.ParamSummary.Value()},
-		"WithUpdatedSince":    {option: s.WithUpdatedSince(date), wantKey: core.ParamUpdatedSince.Value()},
-		"WithUpdatedUntil":    {option: s.WithUpdatedUntil(date), wantKey: core.ParamUpdatedUntil.Value()},
-		"WithVersionIDs":      {option: s.WithVersionIDs([]int{1}), wantKey: core.ParamVersionIDs.Value()},
+		"Add": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/stars", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "1", req.FormValue("issueId"))
+				return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.Issue.Star.Add(ctx, 1)
+				require.NoError(t, err)
+			},
+		},
+		"Add/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.Issue.Star.Add(ctx, 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Remove": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, "/api/v2/stars", req.URL.Path)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				form, err := url.ParseQuery(string(body))
+				require.NoError(t, err)
+				assert.Equal(t, "42", form.Get("id"))
+				return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.Issue.Star.Remove(ctx, 42)
+				require.NoError(t, err)
+			},
+		},
+		"Remove/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.Issue.Star.Remove(ctx, 42)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.wantKey, tc.option.Key())
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
 		})
 	}
 }

--- a/issue_test.go
+++ b/issue_test.go
@@ -9,11 +9,13 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 )
 
@@ -37,13 +39,35 @@ func TestIssueService(t *testing.T) {
 				got, err := c.Issue.All(ctx)
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
+				assert.Equal(t, 1, got[0].ID)
+				assert.Equal(t, 2, got[1].ID)
+			},
+		},
+		"All/with-options": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues", req.URL.Path)
+				assert.Equal(t, "bug", req.URL.Query().Get("keyword"))
+				assert.Equal(t, []string{"10", "20"}, req.URL.Query()["projectId[]"])
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.ListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.All(ctx,
+					c.Issue.Option.WithKeyword("bug"),
+					c.Issue.Option.WithProjectIDs([]int{10, 20}),
+				)
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
 			},
 		},
 		"All/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Internal Server Error","code":1,"moreInfo":""}]}`)),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
@@ -59,11 +83,31 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/count", req.URL.Path)
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count":2}`))),
+					Body:       io.NopCloser(strings.NewReader(`{"count":5}`)),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Count(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, 5, got)
+			},
+		},
+		"Count/with-options": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues/count", req.URL.Path)
+				assert.Equal(t, "bug", req.URL.Query().Get("keyword"))
+				assert.Equal(t, []string{"10", "20"}, req.URL.Query()["projectId[]"])
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"count":2}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Count(ctx,
+					c.Issue.Option.WithKeyword("bug"),
+					c.Issue.Option.WithProjectIDs([]int{10, 20}),
+				)
 				require.NoError(t, err)
 				assert.Equal(t, 2, got)
 			},
@@ -71,8 +115,8 @@ func TestIssueService(t *testing.T) {
 		"Count/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Internal Server Error","code":1,"moreInfo":""}]}`)),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
@@ -95,6 +139,8 @@ func TestIssueService(t *testing.T) {
 				got, err := c.Issue.One(ctx, "PRJ-1")
 				require.NoError(t, err)
 				assert.Equal(t, 1, got.ID)
+				assert.Equal(t, "PRJ-1", got.IssueKey)
+				assert.Equal(t, "First issue", got.Summary)
 			},
 		},
 		"One/error": {
@@ -117,18 +163,44 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "10", req.PostForm.Get("projectId"))
-				assert.Equal(t, "First issue", req.PostForm.Get("summary"))
+				assert.Equal(t, "New issue", req.PostForm.Get("summary"))
 				assert.Equal(t, "2", req.PostForm.Get("issueTypeId"))
 				assert.Equal(t, "3", req.PostForm.Get("priorityId"))
 				return &http.Response{
-					StatusCode: http.StatusOK,
+					StatusCode: http.StatusCreated,
 					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Issue.Create(ctx, 10, "First issue", 2, 3)
+				got, err := c.Issue.Create(ctx, 10, "New issue", 2, 3)
 				require.NoError(t, err)
+				assert.Equal(t, 1, got.ID)
 				assert.Equal(t, "First issue", got.Summary)
+			},
+		},
+		"Create/with-options": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/issues", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "10", req.PostForm.Get("projectId"))
+				assert.Equal(t, "New issue", req.PostForm.Get("summary"))
+				assert.Equal(t, "2", req.PostForm.Get("issueTypeId"))
+				assert.Equal(t, "3", req.PostForm.Get("priorityId"))
+				assert.Equal(t, "details here", req.PostForm.Get("description"))
+				assert.Equal(t, "5", req.PostForm.Get("assigneeId"))
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Create(ctx, 10, "New issue", 2, 3,
+					c.Issue.Option.WithDescription("details here"),
+					c.Issue.Option.WithAssigneeID(5),
+				)
+				require.NoError(t, err)
+				assert.Equal(t, 1, got.ID)
 			},
 		},
 		"Create/error": {
@@ -139,7 +211,7 @@ func TestIssueService(t *testing.T) {
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Issue.Create(ctx, 10, "First issue", 2, 3)
+				_, err := c.Issue.Create(ctx, 10, "New issue", 2, 3)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))
@@ -158,6 +230,29 @@ func TestIssueService(t *testing.T) {
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Update(ctx, "PRJ-1", c.Issue.Option.WithSummary("Updated summary"))
+				require.NoError(t, err)
+				assert.Equal(t, 1, got.ID)
+			},
+		},
+		"Update/with-options": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPatch, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
+				assert.Equal(t, "2", req.PostForm.Get("statusId"))
+				assert.Equal(t, "1", req.PostForm.Get("resolutionId"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Update(ctx, "PRJ-1",
+					c.Issue.Option.WithSummary("Updated summary"),
+					c.Issue.Option.WithStatusID(2),
+					c.Issue.Option.WithResolutionID(1),
+				)
 				require.NoError(t, err)
 				assert.Equal(t, 1, got.ID)
 			},
@@ -189,6 +284,7 @@ func TestIssueService(t *testing.T) {
 				got, err := c.Issue.Delete(ctx, "PRJ-1")
 				require.NoError(t, err)
 				assert.Equal(t, 1, got.ID)
+				assert.Equal(t, "PRJ-1", got.IssueKey)
 			},
 		},
 		"Delete/error": {
@@ -371,6 +467,70 @@ func TestIssueStarService(t *testing.T) {
 			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
 			require.NoError(t, err)
 			tc.call(t, c)
+		})
+	}
+}
+
+func TestIssueOptionService(t *testing.T) {
+	c, err := backlog.NewClient("https://example.backlog.com", "token")
+	require.NoError(t, err)
+	s := c.Issue.Option
+
+	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := map[string]struct {
+		option  backlog.RequestOption
+		wantKey string
+	}{
+		"WithActualHours":     {option: s.WithActualHours(1), wantKey: core.ParamActualHours.Value()},
+		"WithAssigneeID":      {option: s.WithAssigneeID(1), wantKey: core.ParamAssigneeID.Value()},
+		"WithAssigneeIDs":     {option: s.WithAssigneeIDs([]int{1}), wantKey: core.ParamAssigneeIDs.Value()},
+		"WithAttachment":      {option: s.WithAttachment(true), wantKey: core.ParamAttachment.Value()},
+		"WithAttachmentIDs":   {option: s.WithAttachmentIDs([]int{1}), wantKey: core.ParamAttachmentIDs.Value()},
+		"WithCategoryIDs":     {option: s.WithCategoryIDs([]int{1}), wantKey: core.ParamCategoryIDs.Value()},
+		"WithCount":           {option: s.WithCount(20), wantKey: core.ParamCount.Value()},
+		"WithCreatedSince":    {option: s.WithCreatedSince(date), wantKey: core.ParamCreatedSince.Value()},
+		"WithCreatedUntil":    {option: s.WithCreatedUntil(date), wantKey: core.ParamCreatedUntil.Value()},
+		"WithCreatedUserIDs":  {option: s.WithCreatedUserIDs([]int{1}), wantKey: core.ParamCreatedUserIDs.Value()},
+		"WithDescription":     {option: s.WithDescription("desc"), wantKey: core.ParamDescription.Value()},
+		"WithDueDate":         {option: s.WithDueDate(date), wantKey: core.ParamDueDate.Value()},
+		"WithDueDateSince":    {option: s.WithDueDateSince(date), wantKey: core.ParamDueDateSince.Value()},
+		"WithDueDateUntil":    {option: s.WithDueDateUntil(date), wantKey: core.ParamDueDateUntil.Value()},
+		"WithEstimatedHours":  {option: s.WithEstimatedHours(1), wantKey: core.ParamEstimatedHours.Value()},
+		"WithHasDueDate":      {option: s.WithHasDueDate(false), wantKey: core.ParamHasDueDate.Value()},
+		"WithIDs":             {option: s.WithIDs([]int{1}), wantKey: core.ParamIDs.Value()},
+		"WithIssueSort":       {option: s.WithIssueSort(backlog.IssueSortCreated), wantKey: core.ParamSort.Value()},
+		"WithIssueTypeID":     {option: s.WithIssueTypeID(1), wantKey: core.ParamIssueTypeID.Value()},
+		"WithIssueTypeIDs":    {option: s.WithIssueTypeIDs([]int{1}), wantKey: core.ParamIssueTypeIDs.Value()},
+		"WithKeyword":         {option: s.WithKeyword("bug"), wantKey: core.ParamKeyword.Value()},
+		"WithMilestoneIDs":    {option: s.WithMilestoneIDs([]int{1}), wantKey: core.ParamMilestoneIDs.Value()},
+		"WithNotifiedUserIDs": {option: s.WithNotifiedUserIDs([]int{1}), wantKey: core.ParamNotifiedUserIDs.Value()},
+		"WithOffset":          {option: s.WithOffset(0), wantKey: core.ParamOffset.Value()},
+		"WithOrder":           {option: s.WithOrder(backlog.OrderAsc), wantKey: core.ParamOrder.Value()},
+		"WithParentChild":     {option: s.WithParentChild(0), wantKey: core.ParamParentChild.Value()},
+		"WithParentIssueID":   {option: s.WithParentIssueID(1), wantKey: core.ParamParentIssueID.Value()},
+		"WithParentIssueIDs":  {option: s.WithParentIssueIDs([]int{1}), wantKey: core.ParamParentIssueIDs.Value()},
+		"WithPriorityID":      {option: s.WithPriorityID(1), wantKey: core.ParamPriorityID.Value()},
+		"WithPriorityIDs":     {option: s.WithPriorityIDs([]int{1}), wantKey: core.ParamPriorityIDs.Value()},
+		"WithProjectIDs":      {option: s.WithProjectIDs([]int{1}), wantKey: core.ParamProjectIDs.Value()},
+		"WithResolutionID":    {option: s.WithResolutionID(1), wantKey: core.ParamResolutionID.Value()},
+		"WithResolutionIDs":   {option: s.WithResolutionIDs([]int{1}), wantKey: core.ParamResolutionIDs.Value()},
+		"WithSharedFile":      {option: s.WithSharedFile(true), wantKey: core.ParamSharedFile.Value()},
+		"WithStartDate":       {option: s.WithStartDate(date), wantKey: core.ParamStartDate.Value()},
+		"WithStartDateSince":  {option: s.WithStartDateSince(date), wantKey: core.ParamStartDateSince.Value()},
+		"WithStartDateUntil":  {option: s.WithStartDateUntil(date), wantKey: core.ParamStartDateUntil.Value()},
+		"WithStatusID":        {option: s.WithStatusID(1), wantKey: core.ParamStatusID.Value()},
+		"WithStatusIDs":       {option: s.WithStatusIDs([]int{1}), wantKey: core.ParamStatusIDs.Value()},
+		"WithSummary":         {option: s.WithSummary("summary"), wantKey: core.ParamSummary.Value()},
+		"WithUpdatedSince":    {option: s.WithUpdatedSince(date), wantKey: core.ParamUpdatedSince.Value()},
+		"WithUpdatedUntil":    {option: s.WithUpdatedUntil(date), wantKey: core.ParamUpdatedUntil.Value()},
+		"WithVersionIDs":      {option: s.WithVersionIDs([]int{1}), wantKey: core.ParamVersionIDs.Value()},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.wantKey, tc.option.Key())
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Add `Issue.Star` sub-service providing resource-scoped star operations on issues, consistent with the `Wiki.Star` pattern introduced in #229.

## Changes

- `issue.go`: Add `IssueStarService` with `Add(issueID int)` and `Remove(starID int)` methods; wire it into `IssueService` via new `Star` field
  - `Add` delegates to `StarService.Add` with `WithIssueID` pre-applied
  - `Remove` delegates to `StarService.Remove`
- `issue_test.go`: Add `TestIssueStarService` covering `Add` and `Remove` (success and error cases)
- `example_issue_test.go`: Add `ExampleIssueStarService_Add` and `ExampleIssueStarService_Remove`

Part of #217