### PR TITLE
feat: add PullRequest.Star sub-service (Add, Remove)

### DIFF
--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -3,6 +3,7 @@ package backlog_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
@@ -110,4 +111,42 @@ func ExamplePullRequestAttachmentService_Remove() {
 	fmt.Printf("ID: %d, Name: %s\n", attachment.ID, attachment.Name)
 	// Output:
 	// ID: 8, Name: IMG0088.png
+}
+
+func ExamplePullRequestStarService_Add() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		}}),
+	)
+
+	err := c.PullRequest.Star.Add(context.Background(), 2)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output:
+	// ok
+}
+
+func ExamplePullRequestStarService_Remove() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+		}}),
+	)
+
+	err := c.PullRequest.Star.Remove(context.Background(), 42)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output:
+	// ok
 }

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -45,6 +45,7 @@ type PullRequestService struct {
 
 	Attachment *PullRequestAttachmentService
 	Option     *PullRequestOptionService
+	Star       *PullRequestStarService
 }
 
 // All returns a list of pull requests.
@@ -145,6 +146,29 @@ func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKe
 }
 
 // ──────────────────────────────────────────────────────────────
+//  PullRequestStarService
+// ──────────────────────────────────────────────────────────────
+
+// PullRequestStarService handles communication with the pull request star-related methods of the Backlog API.
+type PullRequestStarService struct {
+	star *StarService
+}
+
+// Add adds a star to the pull request.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-star
+func (s *PullRequestStarService) Add(ctx context.Context, pullRequestID int) error {
+	return s.star.Add(ctx, s.star.Option.WithPullRequestID(pullRequestID))
+}
+
+// Remove removes a star by its ID.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/remove-star
+func (s *PullRequestStarService) Remove(ctx context.Context, starID int) error {
+	return s.star.Remove(ctx, starID)
+}
+
+// ──────────────────────────────────────────────────────────────
 //  PullRequestOptionService
 // ──────────────────────────────────────────────────────────────
 
@@ -224,10 +248,12 @@ func (s *PullRequestOptionService) WithSummary(summary string) RequestOption {
 // ──────────────────────────────────────────────────────────────
 
 func newPullRequestService(method *core.Method, option *core.OptionService) *PullRequestService {
+	starSvc := newStarService(method, option)
 	return &PullRequestService{
 		base:       pullrequest.NewService(method),
 		Attachment: newPullRequestAttachmentService(method),
 		Option:     newPullRequestOptionService(option),
+		Star:       newPullRequestStarService(starSvc),
 	}
 }
 
@@ -235,6 +261,10 @@ func newPullRequestAttachmentService(method *core.Method) *PullRequestAttachment
 	return &PullRequestAttachmentService{
 		base: attachment.NewPullRequestService(method),
 	}
+}
+
+func newPullRequestStarService(starSvc *StarService) *PullRequestStarService {
+	return &PullRequestStarService{star: starSvc}
 }
 
 func newPullRequestOptionService(option *core.OptionService) *PullRequestOptionService {

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -248,12 +248,11 @@ func (s *PullRequestOptionService) WithSummary(summary string) RequestOption {
 // ──────────────────────────────────────────────────────────────
 
 func newPullRequestService(method *core.Method, option *core.OptionService) *PullRequestService {
-	starSvc := newStarService(method, option)
 	return &PullRequestService{
 		base:       pullrequest.NewService(method),
 		Attachment: newPullRequestAttachmentService(method),
 		Option:     newPullRequestOptionService(option),
-		Star:       newPullRequestStarService(starSvc),
+		Star:       newPullRequestStarService(method, option),
 	}
 }
 
@@ -263,8 +262,8 @@ func newPullRequestAttachmentService(method *core.Method) *PullRequestAttachment
 	}
 }
 
-func newPullRequestStarService(starSvc *StarService) *PullRequestStarService {
-	return &PullRequestStarService{star: starSvc}
+func newPullRequestStarService(method *core.Method, option *core.OptionService) *PullRequestStarService {
+	return &PullRequestStarService{star: newStarService(method, option)}
 }
 
 func newPullRequestOptionService(option *core.OptionService) *PullRequestOptionService {

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -336,6 +337,83 @@ func TestPullRequestAttachmentService(t *testing.T) {
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.Attachment.Remove(ctx, "TEST", "repo", 1, 8)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}
+
+func TestPullRequestStarService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"Add": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/stars", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "2", req.FormValue("pullRequestId"))
+				return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.PullRequest.Star.Add(ctx, 2)
+				require.NoError(t, err)
+			},
+		},
+		"Add/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.PullRequest.Star.Add(ctx, 2)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Remove": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, "/api/v2/stars", req.URL.Path)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				form, err := url.ParseQuery(string(body))
+				require.NoError(t, err)
+				assert.Equal(t, "42", form.Get("id"))
+				return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.PullRequest.Star.Remove(ctx, 42)
+				require.NoError(t, err)
+			},
+		},
+		"Remove/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				err := c.PullRequest.Star.Remove(ctx, 42)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))


### PR DESCRIPTION
## Summary

Add `PullRequest.Star` sub-service providing resource-scoped star operations on pull requests, consistent with the `Issue.Star` pattern introduced in #230.

## Changes

- `pullrequest.go`: Add `PullRequestStarService` with `Add(pullRequestID int)` and `Remove(starID int)` methods; wire it into `PullRequestService` via new `Star` field
  - `Add` delegates to `StarService.Add` with `WithPullRequestID` pre-applied
  - `Remove` delegates to `StarService.Remove`
- `pullrequest_test.go`: Add `TestPullRequestStarService` covering `Add` and `Remove` (success and error cases, with request parameter validation)
- `example_pullrequest_test.go`: Add `ExamplePullRequestStarService_Add` and `ExamplePullRequestStarService_Remove`
