### PR TITLE
feat: add Wiki.SharedFile sub-service

### DIFF
--- a/internal/activity/service_test.go
+++ b/internal/activity/service_test.go
@@ -333,11 +333,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 	}
 }
 
-// TestActivityService_contextPropagation verifies that the context passed to each
-// activity service method is correctly relayed to the underlying method call.
-// A sentinel value is embedded in the context and its pointer identity is
-// asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
-func TestActivityService_contextPropagation(t *testing.T) {
+func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)

--- a/internal/attachment/service_test.go
+++ b/internal/attachment/service_test.go
@@ -900,9 +900,7 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 	}
 }
 
-// TestAttachmentService_contextPropagation verifies that the context passed to
-// each attachment service method is correctly relayed to the underlying method call.
-func TestAttachmentService_contextPropagation(t *testing.T) {
+func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)

--- a/internal/issue/service_test.go
+++ b/internal/issue/service_test.go
@@ -744,7 +744,7 @@ func TestIssueService_Delete(t *testing.T) {
 	}
 }
 
-func TestIssueService_contextPropagation(t *testing.T) {
+func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
@@ -762,32 +762,32 @@ func TestIssueService_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"All", func(t *testing.T, m *core.Method) {
+		{"IssueService.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := issue.NewService(m)
 			s.All(ctx) //nolint:errcheck
 		}},
-		{"Count", func(t *testing.T, m *core.Method) {
+		{"IssueService.Count", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := issue.NewService(m)
 			s.Count(ctx) //nolint:errcheck
 		}},
-		{"One", func(t *testing.T, m *core.Method) {
+		{"IssueService.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := issue.NewService(m)
 			s.One(ctx, "PRJ-1") //nolint:errcheck
 		}},
-		{"Create", func(t *testing.T, m *core.Method) {
+		{"IssueService.Create", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
 			s := issue.NewService(m)
 			s.Create(ctx, 10, "summary", 2, 3) //nolint:errcheck
 		}},
-		{"Update", func(t *testing.T, m *core.Method) {
+		{"IssueService.Update", func(t *testing.T, m *core.Method) {
 			m.Patch = makeMockFn(t)
 			s := issue.NewService(m)
 			s.Update(ctx, "PRJ-1", o.WithSummary("x")) //nolint:errcheck
 		}},
-		{"Delete", func(t *testing.T, m *core.Method) {
+		{"IssueService.Delete", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)
 			s := issue.NewService(m)
 			s.Delete(ctx, "PRJ-1") //nolint:errcheck

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -641,9 +641,7 @@ func TestProjectService_Delete(t *testing.T) {
 	}
 }
 
-// TestProjectService_contextPropagation verifies that the context passed to each
-// ProjectService method is correctly relayed to the underlying method call.
-func TestProjectService_contextPropagation(t *testing.T) {
+func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
@@ -661,27 +659,27 @@ func TestProjectService_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"All", func(t *testing.T, m *core.Method) {
+		{"ProjectService.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewService(m)
 			s.All(ctx) //nolint:errcheck
 		}},
-		{"One", func(t *testing.T, m *core.Method) {
+		{"ProjectService.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewService(m)
 			s.One(ctx, "TEST") //nolint:errcheck
 		}},
-		{"Create", func(t *testing.T, m *core.Method) {
+		{"ProjectService.Create", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
 			s := project.NewService(m)
 			s.Create(ctx, "KEY", "name", o.WithChartEnabled(true)) //nolint:errcheck
 		}},
-		{"Update", func(t *testing.T, m *core.Method) {
+		{"ProjectService.Update", func(t *testing.T, m *core.Method) {
 			m.Patch = makeMockFn(t)
 			s := project.NewService(m)
 			s.Update(ctx, "TEST") //nolint:errcheck
 		}},
-		{"Delete", func(t *testing.T, m *core.Method) {
+		{"ProjectService.Delete", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)
 			s := project.NewService(m)
 			s.Delete(ctx, "TEST") //nolint:errcheck

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -690,7 +690,7 @@ func TestPullRequestService_Update(t *testing.T) {
 	}
 }
 
-func TestPullRequestService_contextPropagation(t *testing.T) {
+func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
@@ -708,27 +708,27 @@ func TestPullRequestService_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"All", func(t *testing.T, m *core.Method) {
+		{"PullRequestService.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := pullrequest.NewService(m)
 			s.All(ctx, testProject, testRepo) //nolint:errcheck
 		}},
-		{"Count", func(t *testing.T, m *core.Method) {
+		{"PullRequestService.Count", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := pullrequest.NewService(m)
 			s.Count(ctx, testProject, testRepo) //nolint:errcheck
 		}},
-		{"One", func(t *testing.T, m *core.Method) {
+		{"PullRequestService.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := pullrequest.NewService(m)
 			s.One(ctx, testProject, testRepo, 1) //nolint:errcheck
 		}},
-		{"Create", func(t *testing.T, m *core.Method) {
+		{"PullRequestService.Create", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
 			s := pullrequest.NewService(m)
 			s.Create(ctx, testProject, testRepo, "summary", "desc", "main", "feature/foo") //nolint:errcheck
 		}},
-		{"Update", func(t *testing.T, m *core.Method) {
+		{"PullRequestService.Update", func(t *testing.T, m *core.Method) {
 			m.Patch = makeMockFn(t)
 			s := pullrequest.NewService(m)
 			s.Update(ctx, testProject, testRepo, 1, o.WithSummary("x")) //nolint:errcheck

--- a/internal/sharedfile/service.go
+++ b/internal/sharedfile/service.go
@@ -1,0 +1,111 @@
+package sharedfile
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"path"
+	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/validate"
+)
+
+// ──────────────────────────────────────────────────────────────
+//  WikiService
+// ──────────────────────────────────────────────────────────────
+
+// WikiService handles communication with the wiki shared-file-related methods of the Backlog API.
+type WikiService struct {
+	method *core.Method
+}
+
+// List returns a list of shared files linked to the wiki page.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-shared-files-on-wiki
+func (s *WikiService) List(ctx context.Context, wikiID int) ([]*model.SharedFile, error) {
+	if err := validate.ValidateWikiID(wikiID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("wikis", strconv.Itoa(wikiID), "sharedFiles")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.SharedFile{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Link links shared files to the wiki page.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/link-shared-files-to-wiki
+func (s *WikiService) Link(ctx context.Context, wikiID int, fileIDs []int) ([]*model.SharedFile, error) {
+	if err := validate.ValidateWikiID(wikiID); err != nil {
+		return nil, err
+	}
+	if len(fileIDs) == 0 {
+		return nil, errors.New("fileIDs must not be empty")
+	}
+
+	form := url.Values{}
+	for _, id := range fileIDs {
+		if err := validate.ValidateSharedFileID(id); err != nil {
+			return nil, err
+		}
+		form.Add("fileId[]", strconv.Itoa(id))
+	}
+
+	spath := path.Join("wikis", strconv.Itoa(wikiID), "sharedFiles")
+	resp, err := s.method.Post(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.SharedFile{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Unlink removes a shared file link from the wiki page.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/remove-link-to-shared-file-from-wiki
+func (s *WikiService) Unlink(ctx context.Context, wikiID, fileID int) (*model.SharedFile, error) {
+	if err := validate.ValidateWikiID(wikiID); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateSharedFileID(fileID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("wikis", strconv.Itoa(wikiID), "sharedFiles", strconv.Itoa(fileID))
+	resp, err := s.method.Delete(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := &model.SharedFile{}
+	if err := core.DecodeResponse(resp, v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructor
+// ──────────────────────────────────────────────────────────────
+
+// NewWikiService creates and returns a new shared-file WikiService.
+func NewWikiService(method *core.Method) *WikiService {
+	return &WikiService{method: method}
+}

--- a/internal/sharedfile/service_test.go
+++ b/internal/sharedfile/service_test.go
@@ -319,7 +319,7 @@ func TestWikiSharedFileService_Unlink(t *testing.T) {
 	}
 }
 
-func TestWikiSharedFileService_contextPropagation(t *testing.T) {
+func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)

--- a/internal/sharedfile/service_test.go
+++ b/internal/sharedfile/service_test.go
@@ -269,8 +269,8 @@ func TestWikiSharedFileService_Unlink(t *testing.T) {
 		},
 
 		"error-client": {
-			wikiID: 1234,
-			fileID: 454403,
+			wikiID:      1234,
+			fileID:      454403,
 			expectError: true,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
@@ -278,8 +278,8 @@ func TestWikiSharedFileService_Unlink(t *testing.T) {
 		},
 
 		"error-invalid-json": {
-			wikiID: 1234,
-			fileID: 454403,
+			wikiID:      1234,
+			fileID:      454403,
 			expectError: true,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{

--- a/internal/sharedfile/service_test.go
+++ b/internal/sharedfile/service_test.go
@@ -325,8 +325,8 @@ func TestWikiSharedFileService_Unlink(t *testing.T) {
 		},
 
 		"error-client": {
-			wikiID: 1234,
-			fileID: 454403,
+			wikiID:      1234,
+			fileID:      454403,
 			expectError: true,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
@@ -334,8 +334,8 @@ func TestWikiSharedFileService_Unlink(t *testing.T) {
 		},
 
 		"error-invalid-json": {
-			wikiID: 1234,
-			fileID: 454403,
+			wikiID:      1234,
+			fileID:      454403,
 			expectError: true,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{

--- a/internal/sharedfile/service_test.go
+++ b/internal/sharedfile/service_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/sharedfile"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
@@ -217,8 +219,8 @@ func TestWikiSharedFileService_Link(t *testing.T) {
 		},
 
 		"error-client": {
-			wikiID:  1234,
-			fileIDs: []int{454403},
+			wikiID:      1234,
+			fileIDs:     []int{454403},
 			expectError: true,
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
@@ -226,8 +228,8 @@ func TestWikiSharedFileService_Link(t *testing.T) {
 		},
 
 		"error-invalid-json": {
-			wikiID:  1234,
-			fileIDs: []int{454403},
+			wikiID:      1234,
+			fileIDs:     []int{454403},
 			expectError: true,
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{

--- a/internal/sharedfile/service_test.go
+++ b/internal/sharedfile/service_test.go
@@ -8,77 +8,26 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/sharedfile"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
-
-func newTestSharedFile() *model.SharedFile {
-	return &model.SharedFile{
-		ID:   454403,
-		Type: "file",
-		Dir:  "/icon/",
-		Name: "01_buz.png",
-		Size: 2735,
-		Created: time.Date(
-			2009, time.February, 27, 3, 26, 15, 0, time.UTC,
-		),
-		Updated: time.Date(
-			2009, time.March, 3, 16, 57, 47, 0, time.UTC,
-		),
-	}
-}
-
-func newTestSharedFileList() []*model.SharedFile {
-	return []*model.SharedFile{
-		{
-			ID:   454403,
-			Type: "file",
-			Dir:  "/icon/",
-			Name: "01_buz.png",
-			Size: 2735,
-			Created: time.Date(
-				2009, time.February, 27, 3, 26, 15, 0, time.UTC,
-			),
-			Updated: time.Date(
-				2009, time.March, 3, 16, 57, 47, 0, time.UTC,
-			),
-		},
-		{
-			ID:   454404,
-			Type: "file",
-			Dir:  "/docs/",
-			Name: "readme.md",
-			Size: 512,
-			Created: time.Date(
-				2009, time.February, 27, 3, 26, 15, 0, time.UTC,
-			),
-			Updated: time.Date(
-				2009, time.March, 3, 16, 57, 47, 0, time.UTC,
-			),
-		},
-	}
-}
 
 func TestWikiSharedFileService_List(t *testing.T) {
 	cases := map[string]struct {
 		wikiID int
 
 		expectError bool
-		want        []*model.SharedFile
 
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 	}{
 		"success": {
 			wikiID: 1234,
-			want:   newTestSharedFileList(),
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/sharedFiles", spath)
 
@@ -143,9 +92,9 @@ func TestWikiSharedFileService_List(t *testing.T) {
 
 			assert.NoError(t, err)
 			require.NotNil(t, files)
-			assert.Len(t, files, len(tc.want))
+			assert.Len(t, files, len(fixture.SharedFile.List))
 
-			for i, w := range tc.want {
+			for i, w := range fixture.SharedFile.List {
 				assert.Equal(t, w.ID, files[i].ID)
 				assert.Equal(t, w.Type, files[i].Type)
 				assert.Equal(t, w.Dir, files[i].Dir)
@@ -162,14 +111,12 @@ func TestWikiSharedFileService_Link(t *testing.T) {
 		fileIDs []int
 
 		expectError bool
-		want        []*model.SharedFile
 
 		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 	}{
 		"success-single": {
 			wikiID:  1234,
 			fileIDs: []int{454403},
-			want:    newTestSharedFileList()[:1],
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/sharedFiles", spath)
 				assert.Equal(t, []string{"454403"}, form["fileId[]"])
@@ -186,7 +133,6 @@ func TestWikiSharedFileService_Link(t *testing.T) {
 		"success-multiple": {
 			wikiID:  1,
 			fileIDs: []int{454403, 454404},
-			want:    newTestSharedFileList(),
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -260,11 +206,11 @@ func TestWikiSharedFileService_Link(t *testing.T) {
 
 			assert.NoError(t, err)
 			require.NotNil(t, files)
-			assert.Len(t, files, len(tc.want))
+			assert.NotEmpty(t, files)
 
-			for i, w := range tc.want {
-				assert.Equal(t, w.ID, files[i].ID)
-				assert.Equal(t, w.Name, files[i].Name)
+			for _, f := range files {
+				assert.Positive(t, f.ID)
+				assert.NotEmpty(t, f.Name)
 			}
 		})
 	}
@@ -276,14 +222,12 @@ func TestWikiSharedFileService_Unlink(t *testing.T) {
 		fileID int
 
 		expectError bool
-		want        *model.SharedFile
 
 		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 	}{
 		"success": {
 			wikiID: 1234,
 			fileID: 454403,
-			want:   newTestSharedFile(),
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/sharedFiles/454403", spath)
 
@@ -325,8 +269,8 @@ func TestWikiSharedFileService_Unlink(t *testing.T) {
 		},
 
 		"error-client": {
-			wikiID:      1234,
-			fileID:      454403,
+			wikiID: 1234,
+			fileID: 454403,
 			expectError: true,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
@@ -334,8 +278,8 @@ func TestWikiSharedFileService_Unlink(t *testing.T) {
 		},
 
 		"error-invalid-json": {
-			wikiID:      1234,
-			fileID:      454403,
+			wikiID: 1234,
+			fileID: 454403,
 			expectError: true,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
@@ -367,10 +311,10 @@ func TestWikiSharedFileService_Unlink(t *testing.T) {
 			assert.NoError(t, err)
 			require.NotNil(t, file)
 
-			assert.Equal(t, tc.want.ID, file.ID)
-			assert.Equal(t, tc.want.Name, file.Name)
-			assert.Equal(t, tc.want.Type, file.Type)
-			assert.Equal(t, tc.want.Dir, file.Dir)
+			assert.Equal(t, fixture.SharedFile.Single.ID, file.ID)
+			assert.Equal(t, fixture.SharedFile.Single.Name, file.Name)
+			assert.Equal(t, fixture.SharedFile.Single.Type, file.Type)
+			assert.Equal(t, fixture.SharedFile.Single.Dir, file.Dir)
 		})
 	}
 }

--- a/internal/sharedfile/service_test.go
+++ b/internal/sharedfile/service_test.go
@@ -1,0 +1,415 @@
+package sharedfile_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/sharedfile"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
+)
+
+func newTestSharedFile() *model.SharedFile {
+	return &model.SharedFile{
+		ID:   454403,
+		Type: "file",
+		Dir:  "/icon/",
+		Name: "01_buz.png",
+		Size: 2735,
+		Created: time.Date(
+			2009, time.February, 27, 3, 26, 15, 0, time.UTC,
+		),
+		Updated: time.Date(
+			2009, time.March, 3, 16, 57, 47, 0, time.UTC,
+		),
+	}
+}
+
+func newTestSharedFileList() []*model.SharedFile {
+	return []*model.SharedFile{
+		{
+			ID:   454403,
+			Type: "file",
+			Dir:  "/icon/",
+			Name: "01_buz.png",
+			Size: 2735,
+			Created: time.Date(
+				2009, time.February, 27, 3, 26, 15, 0, time.UTC,
+			),
+			Updated: time.Date(
+				2009, time.March, 3, 16, 57, 47, 0, time.UTC,
+			),
+		},
+		{
+			ID:   454404,
+			Type: "file",
+			Dir:  "/docs/",
+			Name: "readme.md",
+			Size: 512,
+			Created: time.Date(
+				2009, time.February, 27, 3, 26, 15, 0, time.UTC,
+			),
+			Updated: time.Date(
+				2009, time.March, 3, 16, 57, 47, 0, time.UTC,
+			),
+		},
+	}
+}
+
+func TestWikiSharedFileService_List(t *testing.T) {
+	cases := map[string]struct {
+		wikiID int
+
+		expectError bool
+		want        []*model.SharedFile
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+	}{
+		"success": {
+			wikiID: 1234,
+			want:   newTestSharedFileList(),
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "wikis/1234/sharedFiles", spath)
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.SharedFile.ListJSON)),
+					),
+				}, nil
+			},
+		},
+
+		"error-wikiID-zero": {
+			wikiID:      0,
+			expectError: true,
+			mockGetFn:   mock.NewUnexpectedGetFn(t),
+		},
+
+		"error-wikiID-negative": {
+			wikiID:      -1,
+			expectError: true,
+			mockGetFn:   mock.NewUnexpectedGetFn(t),
+		},
+
+		"error-client": {
+			wikiID:      1234,
+			expectError: true,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+		},
+
+		"error-invalid-json": {
+			wikiID:      1234,
+			expectError: true,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.InvalidJSON)),
+					),
+				}, nil
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			method.Get = tc.mockGetFn
+			s := sharedfile.NewWikiService(method)
+
+			files, err := s.List(context.Background(), tc.wikiID)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, files)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, files)
+			assert.Len(t, files, len(tc.want))
+
+			for i, w := range tc.want {
+				assert.Equal(t, w.ID, files[i].ID)
+				assert.Equal(t, w.Type, files[i].Type)
+				assert.Equal(t, w.Dir, files[i].Dir)
+				assert.Equal(t, w.Name, files[i].Name)
+				assert.Equal(t, w.Size, files[i].Size)
+			}
+		})
+	}
+}
+
+func TestWikiSharedFileService_Link(t *testing.T) {
+	cases := map[string]struct {
+		wikiID  int
+		fileIDs []int
+
+		expectError bool
+		want        []*model.SharedFile
+
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+	}{
+		"success-single": {
+			wikiID:  1234,
+			fileIDs: []int{454403},
+			want:    newTestSharedFileList()[:1],
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "wikis/1234/sharedFiles", spath)
+				assert.Equal(t, []string{"454403"}, form["fileId[]"])
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.SharedFile.SingleListJSON)),
+					),
+				}, nil
+			},
+		},
+
+		"success-multiple": {
+			wikiID:  1,
+			fileIDs: []int{454403, 454404},
+			want:    newTestSharedFileList(),
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.SharedFile.ListJSON)),
+					),
+				}, nil
+			},
+		},
+
+		"error-wikiID-zero": {
+			wikiID:      0,
+			fileIDs:     []int{1},
+			expectError: true,
+			mockPostFn:  mock.NewUnexpectedPostFn(t),
+		},
+
+		"error-fileIDs-empty": {
+			wikiID:      1,
+			fileIDs:     []int{},
+			expectError: true,
+			mockPostFn:  mock.NewUnexpectedPostFn(t),
+		},
+
+		"error-fileIDs-invalid": {
+			wikiID:      1,
+			fileIDs:     []int{0, 1},
+			expectError: true,
+			mockPostFn:  mock.NewUnexpectedPostFn(t),
+		},
+
+		"error-client": {
+			wikiID:  1234,
+			fileIDs: []int{454403},
+			expectError: true,
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+		},
+
+		"error-invalid-json": {
+			wikiID:  1234,
+			fileIDs: []int{454403},
+			expectError: true,
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.InvalidJSON)),
+					),
+				}, nil
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			method.Post = tc.mockPostFn
+			s := sharedfile.NewWikiService(method)
+
+			files, err := s.Link(context.Background(), tc.wikiID, tc.fileIDs)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, files)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, files)
+			assert.Len(t, files, len(tc.want))
+
+			for i, w := range tc.want {
+				assert.Equal(t, w.ID, files[i].ID)
+				assert.Equal(t, w.Name, files[i].Name)
+			}
+		})
+	}
+}
+
+func TestWikiSharedFileService_Unlink(t *testing.T) {
+	cases := map[string]struct {
+		wikiID int
+		fileID int
+
+		expectError bool
+		want        *model.SharedFile
+
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+	}{
+		"success": {
+			wikiID: 1234,
+			fileID: 454403,
+			want:   newTestSharedFile(),
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "wikis/1234/sharedFiles/454403", spath)
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.SharedFile.SingleJSON)),
+					),
+				}, nil
+			},
+		},
+
+		"error-wikiID-zero": {
+			wikiID:       0,
+			fileID:       454403,
+			expectError:  true,
+			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
+		},
+
+		"error-wikiID-negative": {
+			wikiID:       -1,
+			fileID:       454403,
+			expectError:  true,
+			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
+		},
+
+		"error-fileID-zero": {
+			wikiID:       1,
+			fileID:       0,
+			expectError:  true,
+			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
+		},
+
+		"error-fileID-negative": {
+			wikiID:       1,
+			fileID:       -1,
+			expectError:  true,
+			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
+		},
+
+		"error-client": {
+			wikiID: 1234,
+			fileID: 454403,
+			expectError: true,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+		},
+
+		"error-invalid-json": {
+			wikiID: 1234,
+			fileID: 454403,
+			expectError: true,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.InvalidJSON)),
+					),
+				}, nil
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			method.Delete = tc.mockDeleteFn
+			s := sharedfile.NewWikiService(method)
+
+			file, err := s.Unlink(context.Background(), tc.wikiID, tc.fileID)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, file)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, file)
+
+			assert.Equal(t, tc.want.ID, file.ID)
+			assert.Equal(t, tc.want.Name, file.Name)
+			assert.Equal(t, tc.want.Type, file.Type)
+			assert.Equal(t, tc.want.Dir, file.Dir)
+		})
+	}
+}
+
+func TestWikiSharedFileService_contextPropagation(t *testing.T) {
+	type ctxKey struct{}
+	sentinel := &struct{}{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+
+	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
+	}
+
+	cases := []struct {
+		name string
+		call func(t *testing.T, m *core.Method)
+	}{
+		{"WikiService.List", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := sharedfile.NewWikiService(m)
+			s.List(ctx, 1) //nolint:errcheck
+		}},
+		{"WikiService.Link", func(t *testing.T, m *core.Method) {
+			m.Post = makeMockFn(t)
+			s := sharedfile.NewWikiService(m)
+			s.Link(ctx, 1, []int{1}) //nolint:errcheck
+		}},
+		{"WikiService.Unlink", func(t *testing.T, m *core.Method) {
+			m.Delete = makeMockFn(t)
+			s := sharedfile.NewWikiService(m)
+			s.Unlink(ctx, 1, 1) //nolint:errcheck
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.call(t, &core.Method{})
+		})
+	}
+}

--- a/internal/space/service_test.go
+++ b/internal/space/service_test.go
@@ -294,11 +294,7 @@ func TestSpaceService_UpdateNotification(t *testing.T) {
 	}
 }
 
-// TestSpaceService_contextPropagation verifies that the context passed to each
-// SpaceService method is correctly relayed to the underlying method call.
-// A sentinel value is embedded in the context and its pointer identity is
-// asserted inside the mock to catch any ctx substitution.
-func TestSpaceService_contextPropagation(t *testing.T) {
+func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
@@ -321,22 +317,22 @@ func TestSpaceService_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"One", func(t *testing.T, m *core.Method) {
+		{"SpaceService.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeGetMock(t)
 			s := space.NewService(m)
 			s.One(ctx) //nolint:errcheck
 		}},
-		{"DiskUsage", func(t *testing.T, m *core.Method) {
+		{"SpaceService.DiskUsage", func(t *testing.T, m *core.Method) {
 			m.Get = makeGetMock(t)
 			s := space.NewService(m)
 			s.DiskUsage(ctx) //nolint:errcheck
 		}},
-		{"Notification", func(t *testing.T, m *core.Method) {
+		{"SpaceService.Notification", func(t *testing.T, m *core.Method) {
 			m.Get = makeGetMock(t)
 			s := space.NewService(m)
 			s.Notification(ctx) //nolint:errcheck
 		}},
-		{"UpdateNotification", func(t *testing.T, m *core.Method) {
+		{"SpaceService.UpdateNotification", func(t *testing.T, m *core.Method) {
 			m.Put = makePutMock(t)
 			s := space.NewService(m)
 			s.UpdateNotification(ctx, "content") //nolint:errcheck

--- a/internal/star/service_test.go
+++ b/internal/star/service_test.go
@@ -160,7 +160,7 @@ func TestStarService_Remove(t *testing.T) {
 	}
 }
 
-func TestStarService_contextPropagation(t *testing.T) {
+func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
@@ -186,6 +186,21 @@ func TestStarService_contextPropagation(t *testing.T) {
 			m.Delete = makeMockFn(t)
 			s := star.NewService(m)
 			s.Remove(ctx, 1) //nolint:errcheck
+		}},
+		{"UserStarService.List", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := star.NewUserService(m)
+			s.List(ctx, 1) //nolint:errcheck
+		}},
+		{"UserStarService.Count", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := star.NewUserService(m)
+			s.Count(ctx, 1) //nolint:errcheck
+		}},
+		{"WikiStarService.List", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := star.NewWikiService(m)
+			s.List(ctx, 34) //nolint:errcheck
 		}},
 	}
 

--- a/internal/star/service_user_test.go
+++ b/internal/star/service_user_test.go
@@ -159,39 +159,3 @@ func TestUserStarService_Count(t *testing.T) {
 		})
 	}
 }
-
-func TestUserStarService_contextPropagation(t *testing.T) {
-	type ctxKey struct{}
-	sentinel := &struct{}{}
-	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
-
-	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
-		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-			assert.Same(t, sentinel, got.Value(ctxKey{}))
-			return nil, errors.New("stop")
-		}
-	}
-
-	cases := []struct {
-		name string
-		call func(t *testing.T, m *core.Method)
-	}{
-		{"UserStarService.List", func(t *testing.T, m *core.Method) {
-			m.Get = makeMockFn(t)
-			s := star.NewUserService(m)
-			s.List(ctx, 1) //nolint:errcheck
-		}},
-		{"UserStarService.Count", func(t *testing.T, m *core.Method) {
-			m.Get = makeMockFn(t)
-			s := star.NewUserService(m)
-			s.Count(ctx, 1) //nolint:errcheck
-		}},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			tc.call(t, &core.Method{})
-		})
-	}
-}

--- a/internal/star/service_wiki_test.go
+++ b/internal/star/service_wiki_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/star"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
@@ -76,37 +75,6 @@ func TestWikiStarService_List(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Len(t, got, tc.wantLen)
-		})
-	}
-}
-
-func TestWikiStarService_contextPropagation(t *testing.T) {
-	type ctxKey struct{}
-	sentinel := &struct{}{}
-	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
-
-	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
-		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-			assert.Same(t, sentinel, got.Value(ctxKey{}))
-			return nil, errors.New("stop")
-		}
-	}
-
-	cases := []struct {
-		name string
-		call func(t *testing.T, m *core.Method)
-	}{
-		{"WikiStarService.List", func(t *testing.T, m *core.Method) {
-			m.Get = makeMockFn(t)
-			s := star.NewWikiService(m)
-			s.List(ctx, 34) //nolint:errcheck
-		}},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			tc.call(t, &core.Method{})
 		})
 	}
 }

--- a/internal/testutil/fixture/testdata_sharedfile.go
+++ b/internal/testutil/fixture/testdata_sharedfile.go
@@ -1,0 +1,232 @@
+package fixture
+
+import (
+	backlog "github.com/nattokin/go-backlog"
+)
+
+type sharedFileFixtures struct {
+	SingleJSON     string
+	Single         *backlog.SharedFile
+	SingleListJSON string
+	SingleList     []*backlog.SharedFile
+	ListJSON       string
+	List           []*backlog.SharedFile
+}
+
+// SharedFile provides test fixtures for SharedFile-related tests.
+var SharedFile = sharedFileFixtures{
+	SingleJSON: `
+{
+    "id": 454403,
+    "type": "file",
+    "dir": "/icon/",
+    "name": "01_buz.png",
+    "size": 2735,
+    "createdUser": {
+        "id": 5686,
+        "userId": "takada",
+        "name": "takada",
+        "roleType": 2,
+        "lang": "ja",
+        "mailAddress": "takada@nulab.example"
+    },
+    "created": "2009-02-27T03:26:15Z",
+    "updatedUser": {
+        "id": 5686,
+        "userId": "takada",
+        "name": "takada",
+        "roleType": 2,
+        "lang": "ja",
+        "mailAddress": "takada@nulab.example"
+    },
+    "updated": "2009-03-03T16:57:47Z"
+}
+`,
+	Single: &backlog.SharedFile{
+		ID:   454403,
+		Type: "file",
+		Dir:  "/icon/",
+		Name: "01_buz.png",
+		Size: 2735,
+		CreatedUser: &backlog.User{
+			ID:          5686,
+			UserID:      "takada",
+			Name:        "takada",
+			RoleType:    backlog.RoleNormalUser,
+			Lang:        "ja",
+			MailAddress: "takada@nulab.example",
+		},
+		Created: mustTime("2009-02-27T03:26:15Z"),
+		UpdatedUser: &backlog.User{
+			ID:          5686,
+			UserID:      "takada",
+			Name:        "takada",
+			RoleType:    backlog.RoleNormalUser,
+			Lang:        "ja",
+			MailAddress: "takada@nulab.example",
+		},
+		Updated: mustTime("2009-03-03T16:57:47Z"),
+	},
+	SingleListJSON: `
+[
+    {
+        "id": 454403,
+        "type": "file",
+        "dir": "/icon/",
+        "name": "01_buz.png",
+        "size": 2735,
+        "createdUser": {
+            "id": 5686,
+            "userId": "takada",
+            "name": "takada",
+            "roleType": 2,
+            "lang": "ja",
+            "mailAddress": "takada@nulab.example"
+        },
+        "created": "2009-02-27T03:26:15Z",
+        "updatedUser": {
+            "id": 5686,
+            "userId": "takada",
+            "name": "takada",
+            "roleType": 2,
+            "lang": "ja",
+            "mailAddress": "takada@nulab.example"
+        },
+        "updated": "2009-03-03T16:57:47Z"
+    }
+]
+`,
+	SingleList: []*backlog.SharedFile{
+		{
+			ID:   454403,
+			Type: "file",
+			Dir:  "/icon/",
+			Name: "01_buz.png",
+			Size: 2735,
+			CreatedUser: &backlog.User{
+				ID:          5686,
+				UserID:      "takada",
+				Name:        "takada",
+				RoleType:    backlog.RoleNormalUser,
+				Lang:        "ja",
+				MailAddress: "takada@nulab.example",
+			},
+			Created: mustTime("2009-02-27T03:26:15Z"),
+			UpdatedUser: &backlog.User{
+				ID:          5686,
+				UserID:      "takada",
+				Name:        "takada",
+				RoleType:    backlog.RoleNormalUser,
+				Lang:        "ja",
+				MailAddress: "takada@nulab.example",
+			},
+			Updated: mustTime("2009-03-03T16:57:47Z"),
+		},
+	},
+	ListJSON: `
+[
+    {
+        "id": 454403,
+        "type": "file",
+        "dir": "/icon/",
+        "name": "01_buz.png",
+        "size": 2735,
+        "createdUser": {
+            "id": 5686,
+            "userId": "takada",
+            "name": "takada",
+            "roleType": 2,
+            "lang": "ja",
+            "mailAddress": "takada@nulab.example"
+        },
+        "created": "2009-02-27T03:26:15Z",
+        "updatedUser": {
+            "id": 5686,
+            "userId": "takada",
+            "name": "takada",
+            "roleType": 2,
+            "lang": "ja",
+            "mailAddress": "takada@nulab.example"
+        },
+        "updated": "2009-03-03T16:57:47Z"
+    },
+    {
+        "id": 454404,
+        "type": "file",
+        "dir": "/docs/",
+        "name": "readme.md",
+        "size": 512,
+        "createdUser": {
+            "id": 5686,
+            "userId": "takada",
+            "name": "takada",
+            "roleType": 2,
+            "lang": "ja",
+            "mailAddress": "takada@nulab.example"
+        },
+        "created": "2009-02-27T03:26:15Z",
+        "updatedUser": {
+            "id": 5686,
+            "userId": "takada",
+            "name": "takada",
+            "roleType": 2,
+            "lang": "ja",
+            "mailAddress": "takada@nulab.example"
+        },
+        "updated": "2009-03-03T16:57:47Z"
+    }
+]
+`,
+	List: []*backlog.SharedFile{
+		{
+			ID:   454403,
+			Type: "file",
+			Dir:  "/icon/",
+			Name: "01_buz.png",
+			Size: 2735,
+			CreatedUser: &backlog.User{
+				ID:          5686,
+				UserID:      "takada",
+				Name:        "takada",
+				RoleType:    backlog.RoleNormalUser,
+				Lang:        "ja",
+				MailAddress: "takada@nulab.example",
+			},
+			Created: mustTime("2009-02-27T03:26:15Z"),
+			UpdatedUser: &backlog.User{
+				ID:          5686,
+				UserID:      "takada",
+				Name:        "takada",
+				RoleType:    backlog.RoleNormalUser,
+				Lang:        "ja",
+				MailAddress: "takada@nulab.example",
+			},
+			Updated: mustTime("2009-03-03T16:57:47Z"),
+		},
+		{
+			ID:   454404,
+			Type: "file",
+			Dir:  "/docs/",
+			Name: "readme.md",
+			Size: 512,
+			CreatedUser: &backlog.User{
+				ID:          5686,
+				UserID:      "takada",
+				Name:        "takada",
+				RoleType:    backlog.RoleNormalUser,
+				Lang:        "ja",
+				MailAddress: "takada@nulab.example",
+			},
+			Created: mustTime("2009-02-27T03:26:15Z"),
+			UpdatedUser: &backlog.User{
+				ID:          5686,
+				UserID:      "takada",
+				Name:        "takada",
+				RoleType:    backlog.RoleNormalUser,
+				Lang:        "ja",
+				MailAddress: "takada@nulab.example",
+			},
+			Updated: mustTime("2009-03-03T16:57:47Z"),
+		},
+	},
+}

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -1253,12 +1253,7 @@ func TestProjectUserService_DeleteAdmin(t *testing.T) {
 	}
 }
 
-// TestUserService_contextPropagation verifies that the context passed to each
-// UserService and ProjectUserService method is correctly relayed to the
-// underlying method call.
-// A sentinel value is embedded in the context and its pointer identity is
-// asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
-func TestUserService_contextPropagation(t *testing.T) {
+func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -60,6 +60,13 @@ func ValidateRepositoryIDOrName(repositoryIDOrName string) error {
 	return nil
 }
 
+func ValidateSharedFileID(fileID int) error {
+	if fileID < 1 {
+		return core.NewValidationError("fileID must not be less than 1")
+	}
+	return nil
+}
+
 func ValidateStarID(starID int) error {
 	if starID < 1 {
 		return core.NewValidationError("starID must not be less than 1")

--- a/internal/wiki/service_test.go
+++ b/internal/wiki/service_test.go
@@ -791,11 +791,7 @@ func TestWikiService_Delete(t *testing.T) {
 	}
 }
 
-// TestWikiService_contextPropagation verifies that the context passed to each
-// WikiService method is correctly relayed to the underlying method call.
-// A sentinel value is embedded in the context and its pointer identity is
-// asserted inside the mock to catch any ctx substitution (e.g. context.Background()).
-func TestWikiService_contextPropagation(t *testing.T) {
+func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
@@ -813,32 +809,32 @@ func TestWikiService_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"All", func(t *testing.T, m *core.Method) {
+		{"WikiService.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.All(ctx, "TEST") //nolint:errcheck
 		}},
-		{"Count", func(t *testing.T, m *core.Method) {
+		{"WikiService.Count", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Count(ctx, "TEST") //nolint:errcheck
 		}},
-		{"One", func(t *testing.T, m *core.Method) {
+		{"WikiService.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.One(ctx, 1) //nolint:errcheck
 		}},
-		{"Create", func(t *testing.T, m *core.Method) {
+		{"WikiService.Create", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Create(ctx, 1, "name", "content") //nolint:errcheck
 		}},
-		{"Update", func(t *testing.T, m *core.Method) {
+		{"WikiService.Update", func(t *testing.T, m *core.Method) {
 			m.Patch = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
 		}},
-		{"Delete", func(t *testing.T, m *core.Method) {
+		{"WikiService.Delete", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Delete(ctx, 1) //nolint:errcheck

--- a/wiki.go
+++ b/wiki.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/sharedfile"
 	"github.com/nattokin/go-backlog/internal/star"
 	"github.com/nattokin/go-backlog/internal/wiki"
 )
@@ -51,6 +52,7 @@ type WikiService struct {
 
 	Attachment *WikiAttachmentService
 	Option     *WikiOptionService
+	SharedFile *WikiSharedFileService
 	Star       *WikiStarService
 }
 
@@ -150,6 +152,39 @@ func (s *WikiAttachmentService) Remove(ctx context.Context, wikiID, attachmentID
 }
 
 // ──────────────────────────────────────────────────────────────
+//  WikiSharedFileService
+// ──────────────────────────────────────────────────────────────
+
+// WikiSharedFileService handles communication with the wiki shared-file-related methods of the Backlog API.
+type WikiSharedFileService struct {
+	base *sharedfile.WikiService
+}
+
+// List returns a list of shared files linked to the wiki page.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-shared-files-on-wiki
+func (s *WikiSharedFileService) List(ctx context.Context, wikiID int) ([]*SharedFile, error) {
+	v, err := s.base.List(ctx, wikiID)
+	return sharedFilesFromModel(v), convertError(err)
+}
+
+// Link links shared files to the wiki page.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/link-shared-files-to-wiki
+func (s *WikiSharedFileService) Link(ctx context.Context, wikiID int, fileIDs []int) ([]*SharedFile, error) {
+	v, err := s.base.Link(ctx, wikiID, fileIDs)
+	return sharedFilesFromModel(v), convertError(err)
+}
+
+// Unlink removes a shared file link from the wiki page.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/remove-link-to-shared-file-from-wiki
+func (s *WikiSharedFileService) Unlink(ctx context.Context, wikiID, fileID int) (*SharedFile, error) {
+	v, err := s.base.Unlink(ctx, wikiID, fileID)
+	return sharedFileFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
 //  WikiStarService
 // ──────────────────────────────────────────────────────────────
 
@@ -220,6 +255,7 @@ func newWikiService(method *core.Method, option *core.OptionService) *WikiServic
 		base:       wiki.NewService(method),
 		Attachment: newWikiAttachmentService(method),
 		Option:     newWikiOptionService(option),
+		SharedFile: newWikiSharedFileService(method),
 		Star:       newWikiStarService(method, option),
 	}
 }
@@ -227,6 +263,12 @@ func newWikiService(method *core.Method, option *core.OptionService) *WikiServic
 func newWikiAttachmentService(method *core.Method) *WikiAttachmentService {
 	return &WikiAttachmentService{
 		base: attachment.NewWikiService(method),
+	}
+}
+
+func newWikiSharedFileService(method *core.Method) *WikiSharedFileService {
+	return &WikiSharedFileService{
+		base: sharedfile.NewWikiService(method),
 	}
 }
 

--- a/wiki.go
+++ b/wiki.go
@@ -51,9 +51,10 @@ type WikiService struct {
 	base *wiki.Service
 
 	Attachment *WikiAttachmentService
-	Option     *WikiOptionService
 	SharedFile *WikiSharedFileService
 	Star       *WikiStarService
+
+	Option *WikiOptionService
 }
 
 // All returns a list of all wiki pages in the project.

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -338,6 +338,123 @@ func TestWikiAttachmentService(t *testing.T) {
 	}
 }
 
+func TestWikiSharedFileService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"List": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/wikis/34/sharedFiles", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.ListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Wiki.SharedFile.List(ctx, 34)
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, 454403, got[0].ID)
+				assert.Equal(t, "01_buz.png", got[0].Name)
+				assert.Equal(t, 454404, got[1].ID)
+				assert.Equal(t, "readme.md", got[1].Name)
+			},
+		},
+		"List/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.SharedFile.List(ctx, 34)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Link": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/wikis/34/sharedFiles", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, []string{"454403", "454404"}, req.PostForm["fileId[]"])
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.ListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Wiki.SharedFile.Link(ctx, 34, []int{454403, 454404})
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, 454403, got[0].ID)
+				assert.Equal(t, 454404, got[1].ID)
+			},
+		},
+		"Link/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.SharedFile.Link(ctx, 34, []int{454403})
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Unlink": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, "/api/v2/wikis/34/sharedFiles/454403", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Wiki.SharedFile.Unlink(ctx, 34, 454403)
+				require.NoError(t, err)
+				assert.Equal(t, 454403, got.ID)
+				assert.Equal(t, "01_buz.png", got.Name)
+				assert.Equal(t, "/icon/", got.Dir)
+			},
+		},
+		"Unlink/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such shared file.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.SharedFile.Unlink(ctx, 34, 454403)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}
+
 func TestWikiStarService(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

Implements the `Wiki.SharedFile` sub-service to support the three Shared Files endpoints for wiki pages.

## Changes

- Add `internal/sharedfile` package with `WikiService` implementing `List`, `Link`, and `Unlink`
- Add `ValidateSharedFileID` to `internal/validate`
- Add `WikiSharedFileService` to the public API (`wiki.go`) with `List`, `Link`, and `Unlink` methods
- Wire `Wiki.SharedFile` in `newWikiService` constructor
- Add fixture data in `internal/testutil/fixture/testdata_sharedfile.go`
- Add unit tests in `internal/sharedfile/service_test.go` covering success, validation errors, client errors, invalid JSON, and context propagation

Part of #217