### PR TITLE
feat: implement IssueSharedFileService

### DIFF
--- a/internal/sharedfile/service.go
+++ b/internal/sharedfile/service.go
@@ -13,6 +13,100 @@ import (
 )
 
 // ──────────────────────────────────────────────────────────────
+//  IssueService
+// ──────────────────────────────────────────────────────────────
+
+// IssueService handles communication with the issue shared-file-related methods of the Backlog API.
+type IssueService struct {
+	method *core.Method
+}
+
+// List returns a list of shared files linked to the issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-linked-shared-files
+func (s *IssueService) List(ctx context.Context, issueIDOrKey string) ([]*model.SharedFile, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "sharedFiles")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.SharedFile{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Link links shared files to the issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/link-shared-files-to-issue
+func (s *IssueService) Link(ctx context.Context, issueIDOrKey string, fileIDs []int) ([]*model.SharedFile, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if len(fileIDs) == 0 {
+		return nil, errors.New("fileIDs must not be empty")
+	}
+
+	form := url.Values{}
+	for _, id := range fileIDs {
+		if err := validate.ValidateSharedFileID(id); err != nil {
+			return nil, err
+		}
+		form.Add("fileId[]", strconv.Itoa(id))
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "sharedFiles")
+	resp, err := s.method.Post(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.SharedFile{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Unlink removes a shared file link from the issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/remove-link-to-shared-file-from-issue
+func (s *IssueService) Unlink(ctx context.Context, issueIDOrKey string, fileID int) (*model.SharedFile, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateSharedFileID(fileID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "sharedFiles", strconv.Itoa(fileID))
+	resp, err := s.method.Delete(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := &model.SharedFile{}
+	if err := core.DecodeResponse(resp, v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// NewIssueService creates and returns a new shared-file IssueService.
+func NewIssueService(method *core.Method) *IssueService {
+	return &IssueService{method: method}
+}
+
+// ──────────────────────────────────────────────────────────────
 //  WikiService
 // ──────────────────────────────────────────────────────────────
 

--- a/internal/sharedfile/service_test.go
+++ b/internal/sharedfile/service_test.go
@@ -18,6 +18,329 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
+// ──────────────────────────────────────────────────────────────
+//  IssueService tests
+// ──────────────────────────────────────────────────────────────
+
+func TestIssueSharedFileService_List(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+
+		expectError bool
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+	}{
+		"success": {
+			issueIDOrKey: "TEST-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/TEST-1/sharedFiles", spath)
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.SharedFile.ListJSON)),
+					),
+				}, nil
+			},
+		},
+
+		"success-numeric-id": {
+			issueIDOrKey: "1234",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/1234/sharedFiles", spath)
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.SharedFile.ListJSON)),
+					),
+				}, nil
+			},
+		},
+
+		"error-issueIDOrKey-empty": {
+			issueIDOrKey: "",
+			expectError:  true,
+			mockGetFn:    mock.NewUnexpectedGetFn(t),
+		},
+
+		"error-issueIDOrKey-zero": {
+			issueIDOrKey: "0",
+			expectError:  true,
+			mockGetFn:    mock.NewUnexpectedGetFn(t),
+		},
+
+		"error-client": {
+			issueIDOrKey: "TEST-1",
+			expectError:  true,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+		},
+
+		"error-invalid-json": {
+			issueIDOrKey: "TEST-1",
+			expectError:  true,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.InvalidJSON)),
+					),
+				}, nil
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			method.Get = tc.mockGetFn
+			s := sharedfile.NewIssueService(method)
+
+			files, err := s.List(context.Background(), tc.issueIDOrKey)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, files)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, files)
+			assert.Len(t, files, len(fixture.SharedFile.List))
+
+			for i, w := range fixture.SharedFile.List {
+				assert.Equal(t, w.ID, files[i].ID)
+				assert.Equal(t, w.Type, files[i].Type)
+				assert.Equal(t, w.Dir, files[i].Dir)
+				assert.Equal(t, w.Name, files[i].Name)
+				assert.Equal(t, w.Size, files[i].Size)
+			}
+		})
+	}
+}
+
+func TestIssueSharedFileService_Link(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+		fileIDs      []int
+
+		expectError bool
+
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+	}{
+		"success-single": {
+			issueIDOrKey: "TEST-1",
+			fileIDs:      []int{454403},
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/TEST-1/sharedFiles", spath)
+				assert.Equal(t, []string{"454403"}, form["fileId[]"])
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.SharedFile.SingleListJSON)),
+					),
+				}, nil
+			},
+		},
+
+		"success-multiple": {
+			issueIDOrKey: "TEST-1",
+			fileIDs:      []int{454403, 454404},
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.SharedFile.ListJSON)),
+					),
+				}, nil
+			},
+		},
+
+		"error-issueIDOrKey-empty": {
+			issueIDOrKey: "",
+			fileIDs:      []int{1},
+			expectError:  true,
+			mockPostFn:   mock.NewUnexpectedPostFn(t),
+		},
+
+		"error-fileIDs-empty": {
+			issueIDOrKey: "TEST-1",
+			fileIDs:      []int{},
+			expectError:  true,
+			mockPostFn:   mock.NewUnexpectedPostFn(t),
+		},
+
+		"error-fileIDs-invalid": {
+			issueIDOrKey: "TEST-1",
+			fileIDs:      []int{0, 1},
+			expectError:  true,
+			mockPostFn:   mock.NewUnexpectedPostFn(t),
+		},
+
+		"error-client": {
+			issueIDOrKey: "TEST-1",
+			fileIDs:      []int{454403},
+			expectError:  true,
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+		},
+
+		"error-invalid-json": {
+			issueIDOrKey: "TEST-1",
+			fileIDs:      []int{454403},
+			expectError:  true,
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.InvalidJSON)),
+					),
+				}, nil
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			method.Post = tc.mockPostFn
+			s := sharedfile.NewIssueService(method)
+
+			files, err := s.Link(context.Background(), tc.issueIDOrKey, tc.fileIDs)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, files)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, files)
+			assert.NotEmpty(t, files)
+
+			for _, f := range files {
+				assert.Positive(t, f.ID)
+				assert.NotEmpty(t, f.Name)
+			}
+		})
+	}
+}
+
+func TestIssueSharedFileService_Unlink(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+		fileID       int
+
+		expectError bool
+
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+	}{
+		"success": {
+			issueIDOrKey: "TEST-1",
+			fileID:       454403,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/TEST-1/sharedFiles/454403", spath)
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.SharedFile.SingleJSON)),
+					),
+				}, nil
+			},
+		},
+
+		"error-issueIDOrKey-empty": {
+			issueIDOrKey: "",
+			fileID:       454403,
+			expectError:  true,
+			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
+		},
+
+		"error-issueIDOrKey-zero": {
+			issueIDOrKey: "0",
+			fileID:       454403,
+			expectError:  true,
+			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
+		},
+
+		"error-fileID-zero": {
+			issueIDOrKey: "TEST-1",
+			fileID:       0,
+			expectError:  true,
+			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
+		},
+
+		"error-fileID-negative": {
+			issueIDOrKey: "TEST-1",
+			fileID:       -1,
+			expectError:  true,
+			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
+		},
+
+		"error-client": {
+			issueIDOrKey: "TEST-1",
+			fileID:       454403,
+			expectError:  true,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+		},
+
+		"error-invalid-json": {
+			issueIDOrKey: "TEST-1",
+			fileID:       454403,
+			expectError:  true,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.InvalidJSON)),
+					),
+				}, nil
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			method.Delete = tc.mockDeleteFn
+			s := sharedfile.NewIssueService(method)
+
+			file, err := s.Unlink(context.Background(), tc.issueIDOrKey, tc.fileID)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, file)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, file)
+
+			assert.Equal(t, fixture.SharedFile.Single.ID, file.ID)
+			assert.Equal(t, fixture.SharedFile.Single.Name, file.Name)
+			assert.Equal(t, fixture.SharedFile.Single.Type, file.Type)
+			assert.Equal(t, fixture.SharedFile.Single.Dir, file.Dir)
+		})
+	}
+}
+
+// ──────────────────────────────────────────────────────────────
+//  WikiService tests
+// ──────────────────────────────────────────────────────────────
+
 func TestWikiSharedFileService_List(t *testing.T) {
 	cases := map[string]struct {
 		wikiID int
@@ -335,6 +658,21 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
+		{"IssueService.List", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := sharedfile.NewIssueService(m)
+			s.List(ctx, "TEST-1") //nolint:errcheck
+		}},
+		{"IssueService.Link", func(t *testing.T, m *core.Method) {
+			m.Post = makeMockFn(t)
+			s := sharedfile.NewIssueService(m)
+			s.Link(ctx, "TEST-1", []int{1}) //nolint:errcheck
+		}},
+		{"IssueService.Unlink", func(t *testing.T, m *core.Method) {
+			m.Delete = makeMockFn(t)
+			s := sharedfile.NewIssueService(m)
+			s.Unlink(ctx, "TEST-1", 1) //nolint:errcheck
+		}},
 		{"WikiService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := sharedfile.NewWikiService(m)

--- a/issue.go
+++ b/issue.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/issue"
 	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/sharedfile"
 )
 
 // ──────────────────────────────────────────────────────────────
@@ -83,6 +84,7 @@ type IssueService struct {
 
 	Attachment *IssueAttachmentService
 	Option     *IssueOptionService
+	SharedFile *IssueSharedFileService
 	Star       *IssueStarService
 }
 
@@ -228,6 +230,39 @@ func (s *IssueAttachmentService) List(ctx context.Context, issueIDOrKey string) 
 func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string, attachmentID int) (*Attachment, error) {
 	v, err := s.base.Remove(ctx, issueIDOrKey, attachmentID)
 	return attachmentFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  IssueSharedFileService
+// ──────────────────────────────────────────────────────────────
+
+// IssueSharedFileService handles communication with the issue shared-file-related methods of the Backlog API.
+type IssueSharedFileService struct {
+	base *sharedfile.IssueService
+}
+
+// List returns a list of shared files linked to the issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-linked-shared-files
+func (s *IssueSharedFileService) List(ctx context.Context, issueIDOrKey string) ([]*SharedFile, error) {
+	v, err := s.base.List(ctx, issueIDOrKey)
+	return sharedFilesFromModel(v), convertError(err)
+}
+
+// Link links shared files to the issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/link-shared-files-to-issue
+func (s *IssueSharedFileService) Link(ctx context.Context, issueIDOrKey string, fileIDs []int) ([]*SharedFile, error) {
+	v, err := s.base.Link(ctx, issueIDOrKey, fileIDs)
+	return sharedFilesFromModel(v), convertError(err)
+}
+
+// Unlink removes a shared file link from the issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/remove-link-to-shared-file-from-issue
+func (s *IssueSharedFileService) Unlink(ctx context.Context, issueIDOrKey string, fileID int) (*SharedFile, error) {
+	v, err := s.base.Unlink(ctx, issueIDOrKey, fileID)
+	return sharedFileFromModel(v), convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -490,6 +525,7 @@ func newIssueService(method *core.Method, option *core.OptionService) *IssueServ
 		base:       issue.NewService(method),
 		Attachment: newIssueAttachmentService(method),
 		Option:     newIssueOptionService(option),
+		SharedFile: newIssueSharedFileService(method),
 		Star:       newIssueStarService(starSvc),
 	}
 }
@@ -497,6 +533,12 @@ func newIssueService(method *core.Method, option *core.OptionService) *IssueServ
 func newIssueAttachmentService(method *core.Method) *IssueAttachmentService {
 	return &IssueAttachmentService{
 		base: attachment.NewIssueService(method),
+	}
+}
+
+func newIssueSharedFileService(method *core.Method) *IssueSharedFileService {
+	return &IssueSharedFileService{
+		base: sharedfile.NewIssueService(method),
 	}
 }
 

--- a/issue.go
+++ b/issue.go
@@ -83,9 +83,10 @@ type IssueService struct {
 	base *issue.Service
 
 	Attachment *IssueAttachmentService
-	Option     *IssueOptionService
 	SharedFile *IssueSharedFileService
 	Star       *IssueStarService
+
+	Option *IssueOptionService
 }
 
 // All returns a list of issues.
@@ -520,13 +521,14 @@ func (s *IssueOptionService) WithVersionIDs(ids []int) RequestOption {
 // ──────────────────────────────────────────────────────────────
 
 func newIssueService(method *core.Method, option *core.OptionService) *IssueService {
-	starSvc := newStarService(method, option)
 	return &IssueService{
-		base:       issue.NewService(method),
+		base: issue.NewService(method),
+
 		Attachment: newIssueAttachmentService(method),
-		Option:     newIssueOptionService(option),
 		SharedFile: newIssueSharedFileService(method),
-		Star:       newIssueStarService(starSvc),
+		Star:       newIssueStarService(method, option),
+
+		Option: newIssueOptionService(option),
 	}
 }
 
@@ -542,14 +544,12 @@ func newIssueSharedFileService(method *core.Method) *IssueSharedFileService {
 	}
 }
 
-func newIssueStarService(starSvc *StarService) *IssueStarService {
-	return &IssueStarService{star: starSvc}
+func newIssueStarService(method *core.Method, option *core.OptionService) *IssueStarService {
+	return &IssueStarService{star: newStarService(method, option)}
 }
 
 func newIssueOptionService(option *core.OptionService) *IssueOptionService {
-	return &IssueOptionService{
-		base: option,
-	}
+	return &IssueOptionService{base: option}
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/issue_test.go
+++ b/issue_test.go
@@ -394,6 +394,119 @@ func TestIssueAttachmentService(t *testing.T) {
 	}
 }
 
+func TestIssueSharedFileService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"List": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues/TEST-1/sharedFiles", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.ListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.SharedFile.List(ctx, "TEST-1")
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, 454403, got[0].ID)
+				assert.Equal(t, 454404, got[1].ID)
+			},
+		},
+		"List/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.SharedFile.List(ctx, "TEST-1")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Link": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/issues/TEST-1/sharedFiles", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, []string{"454403"}, req.PostForm["fileId[]"])
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.SingleListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.SharedFile.Link(ctx, "TEST-1", []int{454403})
+				require.NoError(t, err)
+				assert.Len(t, got, 1)
+				assert.Equal(t, 454403, got[0].ID)
+			},
+		},
+		"Link/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.SharedFile.Link(ctx, "TEST-1", []int{454403})
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Unlink": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, "/api/v2/issues/TEST-1/sharedFiles/454403", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.SingleJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.SharedFile.Unlink(ctx, "TEST-1", 454403)
+				require.NoError(t, err)
+				assert.Equal(t, 454403, got.ID)
+				assert.Equal(t, "01_buz.png", got.Name)
+			},
+		},
+		"Unlink/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.SharedFile.Unlink(ctx, "TEST-1", 454403)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}
+
 func TestIssueStarService(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

Implements `Issue.SharedFile` sub-service as part of #216, following the same pattern established by `Wiki.SharedFile`.

## Changes

- Add `internal/sharedfile.IssueService` with `List`, `Link`, and `Unlink` methods
- Add `IssueSharedFileService` to `issue.go` exposing the public API
- Wire `SharedFile *IssueSharedFileService` field into `IssueService` and its constructor
- Add unit tests for `internal/sharedfile.IssueService` (mirroring the existing wiki tests)
- Add integration-level tests for `IssueSharedFileService` in `issue_test.go`

API endpoints covered:
- `GET /api/v2/issues/{issueIdOrKey}/sharedFiles` — `List`
- `POST /api/v2/issues/{issueIdOrKey}/sharedFiles` — `Link`
- `DELETE /api/v2/issues/{issueIdOrKey}/sharedFiles/{id}` — `Unlink`

Part of #216