### PR TITLE
feat: implement Wiki.History.List

### DIFF
--- a/example_wiki_test.go
+++ b/example_wiki_test.go
@@ -21,6 +21,8 @@ var (
 	doerWikiAttachmentList   = newMockDoer(fixture.Attachment.ListJSON)
 	doerWikiAttachmentRemove = newMockDoer(fixture.Attachment.SingleJSON)
 
+	doerWikiHistoryList = newMockDoer(fixture.WikiHistory.ListJSON)
+
 	doerWikiStarList = newMockDoer(fixture.Star.ListJSON)
 )
 
@@ -143,6 +145,19 @@ func ExampleWikiAttachmentService_Remove() {
 	fmt.Printf("ID: %d, Name: %s\n", attachment.ID, attachment.Name)
 	// Output:
 	// ID: 8, Name: IMG0088.png
+}
+
+func ExampleWikiHistoryService_List() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiHistoryList),
+	)
+
+	entries, _ := c.Wiki.History.List(context.Background(), 34)
+	fmt.Printf("PageID: %d, Version: %d, Name: %s\n", entries[0].PageID, entries[0].Version, entries[0].Name)
+	// Output:
+	// PageID: 34, Version: 2, Name: Home
 }
 
 func ExampleWikiStarService_List() {

--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -1,0 +1,52 @@
+package history
+
+import (
+	"context"
+	"net/url"
+	"path"
+	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/validate"
+)
+
+// ──────────────────────────────────────────────────────────────
+//  WikiService
+// ──────────────────────────────────────────────────────────────
+
+// WikiService handles communication with the wiki history-related methods of the Backlog API.
+type WikiService struct {
+	method *core.Method
+}
+
+// List returns the version history of a wiki page.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-history/
+func (s *WikiService) List(ctx context.Context, wikiID int) ([]*model.WikiHistory, error) {
+	if err := validate.ValidateWikiID(wikiID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("wikis", strconv.Itoa(wikiID), "history")
+	resp, err := s.method.Get(ctx, spath, url.Values{})
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.WikiHistory{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructor
+// ──────────────────────────────────────────────────────────────
+
+// NewWikiService creates and returns a new history WikiService.
+func NewWikiService(method *core.Method) *WikiService {
+	return &WikiService{method: method}
+}

--- a/internal/history/service_test.go
+++ b/internal/history/service_test.go
@@ -1,0 +1,125 @@
+package history_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nattokin/go-backlog/internal/history"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
+)
+
+func TestWikiHistoryService_List(t *testing.T) {
+	cases := map[string]struct {
+		wikiID int
+
+		expectError bool
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+	}{
+		"success": {
+			wikiID: 1234,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "wikis/1234/history", spath)
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.WikiHistory.ListJSON)),
+					),
+				}, nil
+			},
+		},
+
+		"error-wikiID-zero": {
+			wikiID:      0,
+			expectError: true,
+			mockGetFn:   mock.NewUnexpectedGetFn(t),
+		},
+
+		"error-wikiID-negative": {
+			wikiID:      -1,
+			expectError: true,
+			mockGetFn:   mock.NewUnexpectedGetFn(t),
+		},
+
+		"error-client": {
+			wikiID:      1234,
+			expectError: true,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+		},
+
+		"error-invalid-json": {
+			wikiID:      1234,
+			expectError: true,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						bytes.NewReader([]byte(fixture.InvalidJSON)),
+					),
+				}, nil
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			method.Get = tc.mockGetFn
+			s := history.NewWikiService(method)
+
+			entries, err := s.List(context.Background(), tc.wikiID)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, entries)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, entries)
+			assert.Len(t, entries, len(fixture.WikiHistory.List))
+
+			for i, w := range fixture.WikiHistory.List {
+				assert.Equal(t, w.PageID, entries[i].PageID)
+				assert.Equal(t, w.Version, entries[i].Version)
+				assert.Equal(t, w.Name, entries[i].Name)
+				assert.Equal(t, w.Content, entries[i].Content)
+			}
+		})
+	}
+}
+
+func Test_WikiHistoryService_contextPropagation(t *testing.T) {
+	type ctxKey struct{}
+	sentinel := &struct{}{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+
+	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
+	}
+
+	t.Run("WikiService.List", func(t *testing.T) {
+		t.Parallel()
+		m := mock.NewMethod(t)
+		m.Get = makeMockFn(t)
+		s := history.NewWikiService(m)
+		s.List(ctx, 1) //nolint:errcheck
+	})
+}

--- a/internal/testutil/fixture/testdata_wikihistory.go
+++ b/internal/testutil/fixture/testdata_wikihistory.go
@@ -1,0 +1,78 @@
+package fixture
+
+import "github.com/nattokin/go-backlog/internal/model"
+
+type wikiHistoryFixtures struct {
+	ListJSON string
+	List     []*model.WikiHistory
+}
+
+// WikiHistory provides test fixtures for WikiHistory-related tests.
+var WikiHistory = wikiHistoryFixtures{
+	ListJSON: `
+[
+    {
+        "pageId": 34,
+        "version": 2,
+        "name": "Home",
+        "content": "## Updated content",
+        "createdUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "eguchi@nulab.example"
+        },
+        "created": "2014-06-10T09:00:00Z"
+    },
+    {
+        "pageId": 34,
+        "version": 1,
+        "name": "Home",
+        "content": "## Initial content",
+        "createdUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "eguchi@nulab.example"
+        },
+        "created": "2014-06-01T09:00:00Z"
+    }
+]
+`,
+	List: []*model.WikiHistory{
+		{
+			PageID:  34,
+			Version: 2,
+			Name:    "Home",
+			Content: "## Updated content",
+			CreatedUser: &model.User{
+				ID:          1,
+				UserID:      "admin",
+				Name:        "admin",
+				RoleType:    1,
+				Lang:        "ja",
+				MailAddress: "eguchi@nulab.example",
+			},
+			Created: mustTime("2014-06-10T09:00:00Z"),
+		},
+		{
+			PageID:  34,
+			Version: 1,
+			Name:    "Home",
+			Content: "## Initial content",
+			CreatedUser: &model.User{
+				ID:          1,
+				UserID:      "admin",
+				Name:        "admin",
+				RoleType:    1,
+				Lang:        "ja",
+				MailAddress: "eguchi@nulab.example",
+			},
+			Created: mustTime("2014-06-01T09:00:00Z"),
+		},
+	},
+}

--- a/issue.go
+++ b/issue.go
@@ -662,9 +662,12 @@ func issueFromModel(m *model.Issue) *Issue {
 	}
 }
 
-func issuesFromModel(ms []*model.Issue) []*Issue {
-	result := make([]*Issue, len(ms))
-	for i, v := range ms {
+func issuesFromModel(m []*model.Issue) []*Issue {
+	if m == nil {
+		return nil
+	}
+	result := make([]*Issue, len(m))
+	for i, v := range m {
 		result[i] = issueFromModel(v)
 	}
 	return result

--- a/models_test.go
+++ b/models_test.go
@@ -28,10 +28,6 @@ func Test_changeLogFromModel(t *testing.T) {
 				OriginalValue: "1",
 			},
 		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
 	}
 
 	for name, tc := range cases {
@@ -89,10 +85,6 @@ func Test_customFieldFromModel(t *testing.T) {
 				Items: []*CustomFieldItem{},
 			},
 		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
 	}
 
 	for name, tc := range cases {
@@ -113,10 +105,6 @@ func Test_customFieldItemFromModel(t *testing.T) {
 		"normal": {
 			input: &model.CustomFieldItem{ID: 1, Name: "Windows 8", DisplayOrder: 0},
 			want:  &CustomFieldItem{ID: 1, Name: "Windows 8", DisplayOrder: 0},
-		},
-		"nil": {
-			input: nil,
-			want:  nil,
 		},
 	}
 
@@ -156,10 +144,6 @@ func Test_diskUsageProjectFromModel(t *testing.T) {
 				Git:        1024,
 				GitLFS:     0,
 			},
-		},
-		"nil": {
-			input: nil,
-			want:  nil,
 		},
 	}
 
@@ -218,10 +202,6 @@ func Test_diskUsageSpaceFromModel(t *testing.T) {
 				Capacity: 512,
 				Details:  []*DiskUsageProject{},
 			},
-		},
-		"nil": {
-			input: nil,
-			want:  nil,
 		},
 	}
 
@@ -366,10 +346,6 @@ func Test_issueFromModel(t *testing.T) {
 				Stars:        []*Star{nil},
 			},
 		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
 	}
 
 	for name, tc := range cases {
@@ -454,10 +430,6 @@ func Test_pullRequestFromModel(t *testing.T) {
 				},
 			},
 		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
 	}
 
 	for name, tc := range cases {
@@ -502,10 +474,6 @@ func Test_spaceFromModel(t *testing.T) {
 				Updated:            updated,
 			},
 		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
 	}
 
 	for name, tc := range cases {
@@ -535,10 +503,6 @@ func Test_spaceNotificationFromModel(t *testing.T) {
 				Updated: updated,
 			},
 		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
 	}
 
 	for name, tc := range cases {
@@ -559,10 +523,6 @@ func Test_statusFromModel(t *testing.T) {
 		"normal": {
 			input: &model.Status{ID: 1, Name: "Open"},
 			want:  &Status{ID: 1, Name: "Open"},
-		},
-		"nil": {
-			input: nil,
-			want:  nil,
 		},
 	}
 
@@ -606,10 +566,6 @@ func Test_versionFromModel(t *testing.T) {
 				DisplayOrder:   0,
 			},
 		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
 	}
 
 	for name, tc := range cases {
@@ -639,10 +595,6 @@ func Test_versionsFromModel(t *testing.T) {
 			input: []*model.Version{},
 			want:  []*Version{},
 		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
 	}
 
 	for name, tc := range cases {
@@ -654,22 +606,35 @@ func Test_versionsFromModel(t *testing.T) {
 }
 
 func Test_fromModel_nil(t *testing.T) {
+	t.Parallel()
 	cases := map[string]struct {
 		call func() any
 	}{
-		"activity":         {call: func() any { return activityFromModel(nil) }},
-		"activity_content": {call: func() any { return activityContentFromModel(nil) }},
-		"attachment":       {call: func() any { return attachmentFromModel(nil) }},
-		"comment":          {call: func() any { return commentFromModel(nil) }},
-		"notification":     {call: func() any { return notificationFromModel(nil) }},
-		"project":          {call: func() any { return projectFromModel(nil) }},
-		"shared_file":      {call: func() any { return sharedFileFromModel(nil) }},
-		"star":             {call: func() any { return starFromModel(nil) }},
-		"stars":            {call: func() any { return starsFromModel(nil) }},
-		"tag":              {call: func() any { return tagFromModel(nil) }},
-		"user":             {call: func() any { return userFromModel(nil) }},
-		"wiki":             {call: func() any { return wikiFromModel(nil) }},
-		"wiki_history":     {call: func() any { return wikiHistoryFromModel(nil) }},
+		"activity":           {call: func() any { return activityFromModel(nil) }},
+		"activity_content":   {call: func() any { return activityContentFromModel(nil) }},
+		"attachment":         {call: func() any { return attachmentFromModel(nil) }},
+		"change_log":         {call: func() any { return changeLogFromModel(nil) }},
+		"comment":            {call: func() any { return commentFromModel(nil) }},
+		"custom_field":       {call: func() any { return customFieldFromModel(nil) }},
+		"custom_field_item":  {call: func() any { return customFieldItemFromModel(nil) }},
+		"disk_usage_project": {call: func() any { return diskUsageProjectFromModel(nil) }},
+		"disk_usage_space":   {call: func() any { return diskUsageSpaceFromModel(nil) }},
+		"issue":              {call: func() any { return issueFromModel(nil) }},
+		"notification":       {call: func() any { return notificationFromModel(nil) }},
+		"project":            {call: func() any { return projectFromModel(nil) }},
+		"pull_request":       {call: func() any { return pullRequestFromModel(nil) }},
+		"shared_file":        {call: func() any { return sharedFileFromModel(nil) }},
+		"space":              {call: func() any { return spaceFromModel(nil) }},
+		"space_notification": {call: func() any { return spaceNotificationFromModel(nil) }},
+		"star":               {call: func() any { return starFromModel(nil) }},
+		"stars":              {call: func() any { return starsFromModel(nil) }},
+		"status":             {call: func() any { return statusFromModel(nil) }},
+		"tag":                {call: func() any { return tagFromModel(nil) }},
+		"user":               {call: func() any { return userFromModel(nil) }},
+		"version":            {call: func() any { return versionFromModel(nil) }},
+		"versions":           {call: func() any { return versionsFromModel(nil) }},
+		"wiki":               {call: func() any { return wikiFromModel(nil) }},
+		"wiki_history":       {call: func() any { return wikiHistoryFromModel(nil) }},
 	}
 
 	for name, tc := range cases {

--- a/models_test.go
+++ b/models_test.go
@@ -9,21 +9,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/model"
 )
 
-func Test_activityContentFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, activityContentFromModel(nil))
-}
-
-func Test_activityFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, activityFromModel(nil))
-}
-
-func Test_attachmentFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, attachmentFromModel(nil))
-}
-
 func Test_changeLogFromModel(t *testing.T) {
 	t.Parallel()
 
@@ -55,11 +40,6 @@ func Test_changeLogFromModel(t *testing.T) {
 			assert.Equal(t, tc.want, changeLogFromModel(tc.input))
 		})
 	}
-}
-
-func Test_commentFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, commentFromModel(nil))
 }
 
 func Test_customFieldFromModel(t *testing.T) {
@@ -400,16 +380,6 @@ func Test_issueFromModel(t *testing.T) {
 	}
 }
 
-func Test_notificationFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, notificationFromModel(nil))
-}
-
-func Test_projectFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, projectFromModel(nil))
-}
-
 func Test_pullRequestFromModel(t *testing.T) {
 	t.Parallel()
 
@@ -498,11 +468,6 @@ func Test_pullRequestFromModel(t *testing.T) {
 	}
 }
 
-func Test_sharedFileFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, sharedFileFromModel(nil))
-}
-
 func Test_spaceFromModel(t *testing.T) {
 	t.Parallel()
 
@@ -584,16 +549,6 @@ func Test_spaceNotificationFromModel(t *testing.T) {
 	}
 }
 
-func Test_starFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, starFromModel(nil))
-}
-
-func Test_starsFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, starsFromModel(nil))
-}
-
 func Test_statusFromModel(t *testing.T) {
 	t.Parallel()
 
@@ -617,16 +572,6 @@ func Test_statusFromModel(t *testing.T) {
 			assert.Equal(t, tc.want, statusFromModel(tc.input))
 		})
 	}
-}
-
-func Test_tagFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, tagFromModel(nil))
-}
-
-func Test_userFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, userFromModel(nil))
 }
 
 func Test_versionFromModel(t *testing.T) {
@@ -676,8 +621,6 @@ func Test_versionFromModel(t *testing.T) {
 }
 
 func Test_versionsFromModel(t *testing.T) {
-	t.Parallel()
-
 	cases := map[string]struct {
 		input []*model.Version
 		want  []*Version
@@ -710,12 +653,29 @@ func Test_versionsFromModel(t *testing.T) {
 	}
 }
 
-func Test_wikiFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, wikiFromModel(nil))
-}
+func Test_fromModel_nil(t *testing.T) {
+	cases := map[string]struct {
+		call func() any
+	}{
+		"activity":         {call: func() any { return activityFromModel(nil) }},
+		"activity_content": {call: func() any { return activityContentFromModel(nil) }},
+		"attachment":       {call: func() any { return attachmentFromModel(nil) }},
+		"comment":          {call: func() any { return commentFromModel(nil) }},
+		"notification":     {call: func() any { return notificationFromModel(nil) }},
+		"project":          {call: func() any { return projectFromModel(nil) }},
+		"shared_file":      {call: func() any { return sharedFileFromModel(nil) }},
+		"star":             {call: func() any { return starFromModel(nil) }},
+		"stars":            {call: func() any { return starsFromModel(nil) }},
+		"tag":              {call: func() any { return tagFromModel(nil) }},
+		"user":             {call: func() any { return userFromModel(nil) }},
+		"wiki":             {call: func() any { return wikiFromModel(nil) }},
+		"wiki_history":     {call: func() any { return wikiHistoryFromModel(nil) }},
+	}
 
-func Test_wikiHistoryFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, wikiHistoryFromModel(nil))
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Nil(t, tc.call())
+		})
+	}
 }

--- a/models_test.go
+++ b/models_test.go
@@ -9,6 +9,21 @@ import (
 	"github.com/nattokin/go-backlog/internal/model"
 )
 
+func Test_activityContentFromModel_nil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, activityContentFromModel(nil))
+}
+
+func Test_activityFromModel_nil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, activityFromModel(nil))
+}
+
+func Test_attachmentFromModel_nil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, attachmentFromModel(nil))
+}
+
 func Test_changeLogFromModel(t *testing.T) {
 	t.Parallel()
 
@@ -42,54 +57,9 @@ func Test_changeLogFromModel(t *testing.T) {
 	}
 }
 
-func Test_statusFromModel(t *testing.T) {
+func Test_commentFromModel_nil(t *testing.T) {
 	t.Parallel()
-
-	cases := map[string]struct {
-		input *model.Status
-		want  *Status
-	}{
-		"normal": {
-			input: &model.Status{ID: 1, Name: "Open"},
-			want:  &Status{ID: 1, Name: "Open"},
-		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, statusFromModel(tc.input))
-		})
-	}
-}
-
-func Test_customFieldItemFromModel(t *testing.T) {
-	t.Parallel()
-
-	cases := map[string]struct {
-		input *model.CustomFieldItem
-		want  *CustomFieldItem
-	}{
-		"normal": {
-			input: &model.CustomFieldItem{ID: 1, Name: "Windows 8", DisplayOrder: 0},
-			want:  &CustomFieldItem{ID: 1, Name: "Windows 8", DisplayOrder: 0},
-		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, customFieldItemFromModel(tc.input))
-		})
-	}
+	assert.Nil(t, commentFromModel(nil))
 }
 
 func Test_customFieldFromModel(t *testing.T) {
@@ -153,37 +123,16 @@ func Test_customFieldFromModel(t *testing.T) {
 	}
 }
 
-func Test_versionFromModel(t *testing.T) {
+func Test_customFieldItemFromModel(t *testing.T) {
 	t.Parallel()
 
-	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	due := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
-
 	cases := map[string]struct {
-		input *model.Version
-		want  *Version
+		input *model.CustomFieldItem
+		want  *CustomFieldItem
 	}{
 		"normal": {
-			input: &model.Version{
-				ID:             30,
-				ProjectID:      1,
-				Name:           "v1.0",
-				Description:    "first release",
-				StartDate:      start,
-				ReleaseDueDate: due,
-				Archived:       false,
-				DisplayOrder:   0,
-			},
-			want: &Version{
-				ID:             30,
-				ProjectID:      1,
-				Name:           "v1.0",
-				Description:    "first release",
-				StartDate:      start,
-				ReleaseDueDate: due,
-				Archived:       false,
-				DisplayOrder:   0,
-			},
+			input: &model.CustomFieldItem{ID: 1, Name: "Windows 8", DisplayOrder: 0},
+			want:  &CustomFieldItem{ID: 1, Name: "Windows 8", DisplayOrder: 0},
 		},
 		"nil": {
 			input: nil,
@@ -194,31 +143,39 @@ func Test_versionFromModel(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, versionFromModel(tc.input))
+			assert.Equal(t, tc.want, customFieldItemFromModel(tc.input))
 		})
 	}
 }
 
-func Test_versionsFromModel(t *testing.T) {
+func Test_diskUsageProjectFromModel(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]struct {
-		input []*model.Version
-		want  []*Version
+		input *model.DiskUsageProject
+		want  *DiskUsageProject
 	}{
-		"with_elements": {
-			input: []*model.Version{
-				{ID: 1, Name: "v1.0"},
-				{ID: 2, Name: "v2.0"},
+		"normal": {
+			input: &model.DiskUsageProject{
+				DiskUsageBase: model.DiskUsageBase{
+					Issue:      11931,
+					Wiki:       0,
+					File:       512,
+					Subversion: 0,
+					Git:        1024,
+					GitLFS:     0,
+				},
+				ProjectID: 1,
 			},
-			want: []*Version{
-				{ID: 1, Name: "v1.0"},
-				{ID: 2, Name: "v2.0"},
+			want: &DiskUsageProject{
+				ProjectID:  1,
+				Issue:      11931,
+				Wiki:       0,
+				File:       512,
+				Subversion: 0,
+				Git:        1024,
+				GitLFS:     0,
 			},
-		},
-		"empty": {
-			input: []*model.Version{},
-			want:  []*Version{},
 		},
 		"nil": {
 			input: nil,
@@ -229,7 +186,69 @@ func Test_versionsFromModel(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, versionsFromModel(tc.input))
+			assert.Equal(t, tc.want, diskUsageProjectFromModel(tc.input))
+		})
+	}
+}
+
+func Test_diskUsageSpaceFromModel(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		input *model.DiskUsageSpace
+		want  *DiskUsageSpace
+	}{
+		"with_details": {
+			input: &model.DiskUsageSpace{
+				DiskUsageBase: model.DiskUsageBase{
+					Issue:      119511,
+					Wiki:       0,
+					File:       0,
+					Subversion: 0,
+					Git:        0,
+					GitLFS:     0,
+				},
+				Capacity: 1073741824,
+				Details: []*model.DiskUsageProject{
+					{
+						DiskUsageBase: model.DiskUsageBase{Issue: 11931},
+						ProjectID:     1,
+					},
+				},
+			},
+			want: &DiskUsageSpace{
+				Capacity:   1073741824,
+				Issue:      119511,
+				Wiki:       0,
+				File:       0,
+				Subversion: 0,
+				Git:        0,
+				GitLFS:     0,
+				Details: []*DiskUsageProject{
+					{ProjectID: 1, Issue: 11931},
+				},
+			},
+		},
+		"empty_details": {
+			input: &model.DiskUsageSpace{
+				Capacity: 512,
+				Details:  []*model.DiskUsageProject{},
+			},
+			want: &DiskUsageSpace{
+				Capacity: 512,
+				Details:  []*DiskUsageProject{},
+			},
+		},
+		"nil": {
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, diskUsageSpaceFromModel(tc.input))
 		})
 	}
 }
@@ -381,6 +400,16 @@ func Test_issueFromModel(t *testing.T) {
 	}
 }
 
+func Test_notificationFromModel_nil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, notificationFromModel(nil))
+}
+
+func Test_projectFromModel_nil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, projectFromModel(nil))
+}
+
 func Test_pullRequestFromModel(t *testing.T) {
 	t.Parallel()
 
@@ -469,6 +498,11 @@ func Test_pullRequestFromModel(t *testing.T) {
 	}
 }
 
+func Test_sharedFileFromModel_nil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, sharedFileFromModel(nil))
+}
+
 func Test_spaceFromModel(t *testing.T) {
 	t.Parallel()
 
@@ -517,111 +551,6 @@ func Test_spaceFromModel(t *testing.T) {
 	}
 }
 
-func Test_diskUsageProjectFromModel(t *testing.T) {
-	t.Parallel()
-
-	cases := map[string]struct {
-		input *model.DiskUsageProject
-		want  *DiskUsageProject
-	}{
-		"normal": {
-			input: &model.DiskUsageProject{
-				DiskUsageBase: model.DiskUsageBase{
-					Issue:      11931,
-					Wiki:       0,
-					File:       512,
-					Subversion: 0,
-					Git:        1024,
-					GitLFS:     0,
-				},
-				ProjectID: 1,
-			},
-			want: &DiskUsageProject{
-				ProjectID:  1,
-				Issue:      11931,
-				Wiki:       0,
-				File:       512,
-				Subversion: 0,
-				Git:        1024,
-				GitLFS:     0,
-			},
-		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, diskUsageProjectFromModel(tc.input))
-		})
-	}
-}
-
-func Test_diskUsageSpaceFromModel(t *testing.T) {
-	t.Parallel()
-
-	cases := map[string]struct {
-		input *model.DiskUsageSpace
-		want  *DiskUsageSpace
-	}{
-		"with_details": {
-			input: &model.DiskUsageSpace{
-				DiskUsageBase: model.DiskUsageBase{
-					Issue:      119511,
-					Wiki:       0,
-					File:       0,
-					Subversion: 0,
-					Git:        0,
-					GitLFS:     0,
-				},
-				Capacity: 1073741824,
-				Details: []*model.DiskUsageProject{
-					{
-						DiskUsageBase: model.DiskUsageBase{Issue: 11931},
-						ProjectID:     1,
-					},
-				},
-			},
-			want: &DiskUsageSpace{
-				Capacity:   1073741824,
-				Issue:      119511,
-				Wiki:       0,
-				File:       0,
-				Subversion: 0,
-				Git:        0,
-				GitLFS:     0,
-				Details: []*DiskUsageProject{
-					{ProjectID: 1, Issue: 11931},
-				},
-			},
-		},
-		"empty_details": {
-			input: &model.DiskUsageSpace{
-				Capacity: 512,
-				Details:  []*model.DiskUsageProject{},
-			},
-			want: &DiskUsageSpace{
-				Capacity: 512,
-				Details:  []*DiskUsageProject{},
-			},
-		},
-		"nil": {
-			input: nil,
-			want:  nil,
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, diskUsageSpaceFromModel(tc.input))
-		})
-	}
-}
-
 func Test_spaceNotificationFromModel(t *testing.T) {
 	t.Parallel()
 
@@ -665,24 +594,29 @@ func Test_starsFromModel_nil(t *testing.T) {
 	assert.Nil(t, starsFromModel(nil))
 }
 
-func Test_attachmentFromModel_nil(t *testing.T) {
+func Test_statusFromModel(t *testing.T) {
 	t.Parallel()
-	assert.Nil(t, attachmentFromModel(nil))
-}
 
-func Test_commentFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, commentFromModel(nil))
-}
+	cases := map[string]struct {
+		input *model.Status
+		want  *Status
+	}{
+		"normal": {
+			input: &model.Status{ID: 1, Name: "Open"},
+			want:  &Status{ID: 1, Name: "Open"},
+		},
+		"nil": {
+			input: nil,
+			want:  nil,
+		},
+	}
 
-func Test_notificationFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, notificationFromModel(nil))
-}
-
-func Test_sharedFileFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, sharedFileFromModel(nil))
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, statusFromModel(tc.input))
+		})
+	}
 }
 
 func Test_tagFromModel_nil(t *testing.T) {
@@ -690,27 +624,98 @@ func Test_tagFromModel_nil(t *testing.T) {
 	assert.Nil(t, tagFromModel(nil))
 }
 
-func Test_activityContentFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, activityContentFromModel(nil))
-}
-
-func Test_activityFromModel_nil(t *testing.T) {
-	t.Parallel()
-	assert.Nil(t, activityFromModel(nil))
-}
-
 func Test_userFromModel_nil(t *testing.T) {
 	t.Parallel()
 	assert.Nil(t, userFromModel(nil))
 }
 
-func Test_projectFromModel_nil(t *testing.T) {
+func Test_versionFromModel(t *testing.T) {
 	t.Parallel()
-	assert.Nil(t, projectFromModel(nil))
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	due := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+
+	cases := map[string]struct {
+		input *model.Version
+		want  *Version
+	}{
+		"normal": {
+			input: &model.Version{
+				ID:             30,
+				ProjectID:      1,
+				Name:           "v1.0",
+				Description:    "first release",
+				StartDate:      start,
+				ReleaseDueDate: due,
+				Archived:       false,
+				DisplayOrder:   0,
+			},
+			want: &Version{
+				ID:             30,
+				ProjectID:      1,
+				Name:           "v1.0",
+				Description:    "first release",
+				StartDate:      start,
+				ReleaseDueDate: due,
+				Archived:       false,
+				DisplayOrder:   0,
+			},
+		},
+		"nil": {
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, versionFromModel(tc.input))
+		})
+	}
+}
+
+func Test_versionsFromModel(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		input []*model.Version
+		want  []*Version
+	}{
+		"with_elements": {
+			input: []*model.Version{
+				{ID: 1, Name: "v1.0"},
+				{ID: 2, Name: "v2.0"},
+			},
+			want: []*Version{
+				{ID: 1, Name: "v1.0"},
+				{ID: 2, Name: "v2.0"},
+			},
+		},
+		"empty": {
+			input: []*model.Version{},
+			want:  []*Version{},
+		},
+		"nil": {
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, versionsFromModel(tc.input))
+		})
+	}
 }
 
 func Test_wikiFromModel_nil(t *testing.T) {
 	t.Parallel()
 	assert.Nil(t, wikiFromModel(nil))
+}
+
+func Test_wikiHistoryFromModel_nil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, wikiHistoryFromModel(nil))
 }

--- a/models_test.go
+++ b/models_test.go
@@ -12,35 +12,12 @@ import (
 func Test_changeLogFromModel(t *testing.T) {
 	t.Parallel()
 
-	cases := map[string]struct {
-		input *model.ChangeLog
-		want  *ChangeLog
-	}{
-		"normal": {
-			input: &model.ChangeLog{
-				Field:         "status",
-				NewValue:      "4",
-				OriginalValue: "1",
-			},
-			want: &ChangeLog{
-				Field:         "status",
-				NewValue:      "4",
-				OriginalValue: "1",
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, changeLogFromModel(tc.input))
-		})
-	}
+	input := &model.ChangeLog{Field: "status", NewValue: "4", OriginalValue: "1"}
+	want := &ChangeLog{Field: "status", NewValue: "4", OriginalValue: "1"}
+	assert.Equal(t, want, changeLogFromModel(input))
 }
 
 func Test_customFieldFromModel(t *testing.T) {
-	t.Parallel()
-
 	cases := map[string]struct {
 		input *model.CustomField
 		want  *CustomField
@@ -90,6 +67,7 @@ func Test_customFieldFromModel(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
 			assert.Equal(t, tc.want, customFieldFromModel(tc.input))
 		})
 	}
@@ -98,66 +76,38 @@ func Test_customFieldFromModel(t *testing.T) {
 func Test_customFieldItemFromModel(t *testing.T) {
 	t.Parallel()
 
-	cases := map[string]struct {
-		input *model.CustomFieldItem
-		want  *CustomFieldItem
-	}{
-		"normal": {
-			input: &model.CustomFieldItem{ID: 1, Name: "Windows 8", DisplayOrder: 0},
-			want:  &CustomFieldItem{ID: 1, Name: "Windows 8", DisplayOrder: 0},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, customFieldItemFromModel(tc.input))
-		})
-	}
+	input := &model.CustomFieldItem{ID: 1, Name: "Windows 8", DisplayOrder: 0}
+	want := &CustomFieldItem{ID: 1, Name: "Windows 8", DisplayOrder: 0}
+	assert.Equal(t, want, customFieldItemFromModel(input))
 }
 
 func Test_diskUsageProjectFromModel(t *testing.T) {
 	t.Parallel()
 
-	cases := map[string]struct {
-		input *model.DiskUsageProject
-		want  *DiskUsageProject
-	}{
-		"normal": {
-			input: &model.DiskUsageProject{
-				DiskUsageBase: model.DiskUsageBase{
-					Issue:      11931,
-					Wiki:       0,
-					File:       512,
-					Subversion: 0,
-					Git:        1024,
-					GitLFS:     0,
-				},
-				ProjectID: 1,
-			},
-			want: &DiskUsageProject{
-				ProjectID:  1,
-				Issue:      11931,
-				Wiki:       0,
-				File:       512,
-				Subversion: 0,
-				Git:        1024,
-				GitLFS:     0,
-			},
+	input := &model.DiskUsageProject{
+		DiskUsageBase: model.DiskUsageBase{
+			Issue:      11931,
+			Wiki:       0,
+			File:       512,
+			Subversion: 0,
+			Git:        1024,
+			GitLFS:     0,
 		},
+		ProjectID: 1,
 	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, diskUsageProjectFromModel(tc.input))
-		})
+	want := &DiskUsageProject{
+		ProjectID:  1,
+		Issue:      11931,
+		Wiki:       0,
+		File:       512,
+		Subversion: 0,
+		Git:        1024,
+		GitLFS:     0,
 	}
+	assert.Equal(t, want, diskUsageProjectFromModel(input))
 }
 
 func Test_diskUsageSpaceFromModel(t *testing.T) {
-	t.Parallel()
-
 	cases := map[string]struct {
 		input *model.DiskUsageSpace
 		want  *DiskUsageSpace
@@ -208,14 +158,13 @@ func Test_diskUsageSpaceFromModel(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
 			assert.Equal(t, tc.want, diskUsageSpaceFromModel(tc.input))
 		})
 	}
 }
 
 func Test_issueFromModel(t *testing.T) {
-	t.Parallel()
-
 	created := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	updated := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
 
@@ -351,6 +300,7 @@ func Test_issueFromModel(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
 			assert.Equal(t, tc.want, issueFromModel(tc.input))
 		})
 	}
@@ -367,77 +317,64 @@ func Test_pullRequestFromModel(t *testing.T) {
 	user := &model.User{ID: 1, UserID: "admin", Name: "admin", RoleType: model.RoleAdministrator, Lang: "ja", MailAddress: "admin@example.com"}
 	wantUser := &User{ID: 1, UserID: "admin", Name: "admin", RoleType: RoleAdministrator, Lang: "ja", MailAddress: "admin@example.com"}
 
-	cases := map[string]struct {
-		input *model.PullRequest
-		want  *PullRequest
-	}{
-		"full": {
-			input: &model.PullRequest{
-				ID:           2,
-				ProjectID:    3,
-				RepositoryID: 5,
-				Number:       1,
-				Summary:      "test PR",
-				Description:  "PR desc",
-				Base:         "main",
-				Branch:       "feature",
-				Status:       &model.Status{ID: 1, Name: "Open"},
-				Assignee:     user,
-				Issue:        &model.Issue{ID: 10, Summary: "related issue"},
-				BaseCommit:   "abc123",
-				BranchCommit: "def456",
-				CloseAt:      closeAt,
-				MergeAt:      mergeAt,
-				CreatedUser:  user,
-				Created:      created,
-				UpdatedUser:  user,
-				Updated:      updated,
-				Attachments: []*model.Attachment{
-					{ID: 10, Name: "file.txt", Size: 100, CreatedUser: user, Created: created},
-				},
-				Stars: []*model.Star{
-					{ID: 75, Comment: "good", URL: "https://example.com", Title: "title", Presenter: user, Created: created},
-				},
-			},
-			want: &PullRequest{
-				ID:           2,
-				ProjectID:    3,
-				RepositoryID: 5,
-				Number:       1,
-				Summary:      "test PR",
-				Description:  "PR desc",
-				Base:         "main",
-				Branch:       "feature",
-				Status:       &Status{ID: 1, Name: "Open"},
-				Assignee:     wantUser,
-				Issue: &Issue{
-					ID:      10,
-					Summary: "related issue",
-				},
-				BaseCommit:   "abc123",
-				BranchCommit: "def456",
-				CloseAt:      closeAt,
-				MergeAt:      mergeAt,
-				CreatedUser:  wantUser,
-				Created:      created,
-				UpdatedUser:  wantUser,
-				Updated:      updated,
-				Attachments: []*Attachment{
-					{ID: 10, Name: "file.txt", Size: 100, CreatedUser: wantUser, Created: created},
-				},
-				Stars: []*Star{
-					{ID: 75, Comment: "good", URL: "https://example.com", Title: "title", Presenter: wantUser, Created: created},
-				},
-			},
+	input := &model.PullRequest{
+		ID:           2,
+		ProjectID:    3,
+		RepositoryID: 5,
+		Number:       1,
+		Summary:      "test PR",
+		Description:  "PR desc",
+		Base:         "main",
+		Branch:       "feature",
+		Status:       &model.Status{ID: 1, Name: "Open"},
+		Assignee:     user,
+		Issue:        &model.Issue{ID: 10, Summary: "related issue"},
+		BaseCommit:   "abc123",
+		BranchCommit: "def456",
+		CloseAt:      closeAt,
+		MergeAt:      mergeAt,
+		CreatedUser:  user,
+		Created:      created,
+		UpdatedUser:  user,
+		Updated:      updated,
+		Attachments: []*model.Attachment{
+			{ID: 10, Name: "file.txt", Size: 100, CreatedUser: user, Created: created},
+		},
+		Stars: []*model.Star{
+			{ID: 75, Comment: "good", URL: "https://example.com", Title: "title", Presenter: user, Created: created},
 		},
 	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, pullRequestFromModel(tc.input))
-		})
+	want := &PullRequest{
+		ID:           2,
+		ProjectID:    3,
+		RepositoryID: 5,
+		Number:       1,
+		Summary:      "test PR",
+		Description:  "PR desc",
+		Base:         "main",
+		Branch:       "feature",
+		Status:       &Status{ID: 1, Name: "Open"},
+		Assignee:     wantUser,
+		Issue: &Issue{
+			ID:      10,
+			Summary: "related issue",
+		},
+		BaseCommit:   "abc123",
+		BranchCommit: "def456",
+		CloseAt:      closeAt,
+		MergeAt:      mergeAt,
+		CreatedUser:  wantUser,
+		Created:      created,
+		UpdatedUser:  wantUser,
+		Updated:      updated,
+		Attachments: []*Attachment{
+			{ID: 10, Name: "file.txt", Size: 100, CreatedUser: wantUser, Created: created},
+		},
+		Stars: []*Star{
+			{ID: 75, Comment: "good", URL: "https://example.com", Title: "title", Presenter: wantUser, Created: created},
+		},
 	}
+	assert.Equal(t, want, pullRequestFromModel(input))
 }
 
 func Test_spaceFromModel(t *testing.T) {
@@ -445,93 +382,52 @@ func Test_spaceFromModel(t *testing.T) {
 
 	created := time.Date(2008, 7, 6, 15, 0, 0, 0, time.UTC)
 	updated := time.Date(2013, 6, 18, 7, 55, 37, 0, time.UTC)
-
-	cases := map[string]struct {
-		input *model.Space
-		want  *Space
-	}{
-		"normal": {
-			input: &model.Space{
-				SpaceKey:           "nulab",
-				Name:               "Nulab Inc.",
-				OwnerID:            1,
-				Lang:               "ja",
-				Timezone:           "Asia/Tokyo",
-				ReportSendTime:     "08:00:00",
-				TextFormattingRule: model.FormatMarkdown,
-				Created:            created,
-				Updated:            updated,
-			},
-			want: &Space{
-				SpaceKey:           "nulab",
-				Name:               "Nulab Inc.",
-				OwnerID:            1,
-				Lang:               "ja",
-				Timezone:           "Asia/Tokyo",
-				ReportSendTime:     "08:00:00",
-				TextFormattingRule: FormatMarkdown,
-				Created:            created,
-				Updated:            updated,
-			},
-		},
+	input := &model.Space{
+		SpaceKey:           "nulab",
+		Name:               "Nulab Inc.",
+		OwnerID:            1,
+		Lang:               "ja",
+		Timezone:           "Asia/Tokyo",
+		ReportSendTime:     "08:00:00",
+		TextFormattingRule: model.FormatMarkdown,
+		Created:            created,
+		Updated:            updated,
 	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, spaceFromModel(tc.input))
-		})
+	want := &Space{
+		SpaceKey:           "nulab",
+		Name:               "Nulab Inc.",
+		OwnerID:            1,
+		Lang:               "ja",
+		Timezone:           "Asia/Tokyo",
+		ReportSendTime:     "08:00:00",
+		TextFormattingRule: FormatMarkdown,
+		Created:            created,
+		Updated:            updated,
 	}
+	assert.Equal(t, want, spaceFromModel(input))
 }
 
 func Test_spaceNotificationFromModel(t *testing.T) {
 	t.Parallel()
 
 	updated := time.Date(2013, 6, 18, 7, 55, 37, 0, time.UTC)
-
-	cases := map[string]struct {
-		input *model.SpaceNotification
-		want  *SpaceNotification
-	}{
-		"normal": {
-			input: &model.SpaceNotification{
-				Content: "Backlog is a project management tool.",
-				Updated: updated,
-			},
-			want: &SpaceNotification{
-				Content: "Backlog is a project management tool.",
-				Updated: updated,
-			},
-		},
+	input := &model.SpaceNotification{
+		Content: "Backlog is a project management tool.",
+		Updated: updated,
 	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, spaceNotificationFromModel(tc.input))
-		})
+	want := &SpaceNotification{
+		Content: "Backlog is a project management tool.",
+		Updated: updated,
 	}
+	assert.Equal(t, want, spaceNotificationFromModel(input))
 }
 
 func Test_statusFromModel(t *testing.T) {
 	t.Parallel()
 
-	cases := map[string]struct {
-		input *model.Status
-		want  *Status
-	}{
-		"normal": {
-			input: &model.Status{ID: 1, Name: "Open"},
-			want:  &Status{ID: 1, Name: "Open"},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, statusFromModel(tc.input))
-		})
-	}
+	input := &model.Status{ID: 1, Name: "Open"}
+	want := &Status{ID: 1, Name: "Open"}
+	assert.Equal(t, want, statusFromModel(input))
 }
 
 func Test_versionFromModel(t *testing.T) {
@@ -539,41 +435,27 @@ func Test_versionFromModel(t *testing.T) {
 
 	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	due := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
-
-	cases := map[string]struct {
-		input *model.Version
-		want  *Version
-	}{
-		"normal": {
-			input: &model.Version{
-				ID:             30,
-				ProjectID:      1,
-				Name:           "v1.0",
-				Description:    "first release",
-				StartDate:      start,
-				ReleaseDueDate: due,
-				Archived:       false,
-				DisplayOrder:   0,
-			},
-			want: &Version{
-				ID:             30,
-				ProjectID:      1,
-				Name:           "v1.0",
-				Description:    "first release",
-				StartDate:      start,
-				ReleaseDueDate: due,
-				Archived:       false,
-				DisplayOrder:   0,
-			},
-		},
+	input := &model.Version{
+		ID:             30,
+		ProjectID:      1,
+		Name:           "v1.0",
+		Description:    "first release",
+		StartDate:      start,
+		ReleaseDueDate: due,
+		Archived:       false,
+		DisplayOrder:   0,
 	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, versionFromModel(tc.input))
-		})
+	want := &Version{
+		ID:             30,
+		ProjectID:      1,
+		Name:           "v1.0",
+		Description:    "first release",
+		StartDate:      start,
+		ReleaseDueDate: due,
+		Archived:       false,
+		DisplayOrder:   0,
 	}
+	assert.Equal(t, want, versionFromModel(input))
 }
 
 func Test_versionsFromModel(t *testing.T) {
@@ -606,7 +488,6 @@ func Test_versionsFromModel(t *testing.T) {
 }
 
 func Test_fromModel_nil(t *testing.T) {
-	t.Parallel()
 	cases := map[string]struct {
 		call func() any
 	}{
@@ -640,6 +521,7 @@ func Test_fromModel_nil(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
 			assert.Nil(t, tc.call())
 		})
 	}

--- a/wiki.go
+++ b/wiki.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/history"
 	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/sharedfile"
 	"github.com/nattokin/go-backlog/internal/star"
@@ -51,6 +52,7 @@ type WikiService struct {
 	base *wiki.Service
 
 	Attachment *WikiAttachmentService
+	History    *WikiHistoryService
 	SharedFile *WikiSharedFileService
 	Star       *WikiStarService
 
@@ -150,6 +152,23 @@ func (s *WikiAttachmentService) List(ctx context.Context, wikiID int) ([]*Attach
 func (s *WikiAttachmentService) Remove(ctx context.Context, wikiID, attachmentID int) (*Attachment, error) {
 	v, err := s.base.Remove(ctx, wikiID, attachmentID)
 	return attachmentFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  WikiHistoryService
+// ──────────────────────────────────────────────────────────────
+
+// WikiHistoryService handles communication with the wiki history-related methods of the Backlog API.
+type WikiHistoryService struct {
+	base *history.WikiService
+}
+
+// List returns the version history of a wiki page.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-history/
+func (s *WikiHistoryService) List(ctx context.Context, wikiID int) ([]*WikiHistory, error) {
+	v, err := s.base.List(ctx, wikiID)
+	return wikiHistoriesFromModel(v), convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -255,6 +274,7 @@ func newWikiService(method *core.Method, option *core.OptionService) *WikiServic
 	return &WikiService{
 		base:       wiki.NewService(method),
 		Attachment: newWikiAttachmentService(method),
+		History:    newWikiHistoryService(method),
 		Option:     newWikiOptionService(option),
 		SharedFile: newWikiSharedFileService(method),
 		Star:       newWikiStarService(method, option),
@@ -264,6 +284,12 @@ func newWikiService(method *core.Method, option *core.OptionService) *WikiServic
 func newWikiAttachmentService(method *core.Method) *WikiAttachmentService {
 	return &WikiAttachmentService{
 		base: attachment.NewWikiService(method),
+	}
+}
+
+func newWikiHistoryService(method *core.Method) *WikiHistoryService {
+	return &WikiHistoryService{
+		base: history.NewWikiService(method),
 	}
 }
 
@@ -330,6 +356,28 @@ func wikisFromModel(ms []*model.Wiki) []*Wiki {
 	result := make([]*Wiki, len(ms))
 	for i, v := range ms {
 		result[i] = wikiFromModel(v)
+	}
+	return result
+}
+
+func wikiHistoryFromModel(m *model.WikiHistory) *WikiHistory {
+	if m == nil {
+		return nil
+	}
+	return &WikiHistory{
+		PageID:      m.PageID,
+		Version:     m.Version,
+		Name:        m.Name,
+		Content:     m.Content,
+		CreatedUser: userFromModel(m.CreatedUser),
+		Created:     m.Created,
+	}
+}
+
+func wikiHistoriesFromModel(ms []*model.WikiHistory) []*WikiHistory {
+	result := make([]*WikiHistory, len(ms))
+	for i, v := range ms {
+		result[i] = wikiHistoryFromModel(v)
 	}
 	return result
 }

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -338,6 +338,59 @@ func TestWikiAttachmentService(t *testing.T) {
 	}
 }
 
+func TestWikiHistoryService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"List": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/wikis/34/history", req.URL.Path)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.WikiHistory.ListJSON))),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Wiki.History.List(ctx, 34)
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, 34, got[0].PageID)
+				assert.Equal(t, 2, got[0].Version)
+				assert.Equal(t, "Home", got[0].Name)
+				assert.Equal(t, 1, got[1].Version)
+			},
+		},
+		"List/error": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
+				}, nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Wiki.History.List(ctx, 34)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}
+
 func TestWikiSharedFileService(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

Implement `Wiki.History.List` as a new sub-service `WikiHistoryService`, exposing the [Get Wiki Page History](https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-history/) endpoint (`GET /wikis/{wikiId}/history`).

## Changes

- `internal/history`: new package with `WikiService` and `List` method
- `internal/testutil/fixture`: add `WikiHistory` fixtures (`testdata_wikihistory.go`)
- `wiki.go`: add `WikiHistoryService` type, wire into `WikiService.History` field, add `wikiHistoryFromModel` / `wikiHistoriesFromModel` helpers
- `wiki_test.go`: add `TestWikiHistoryService` integration tests
- `example_wiki_test.go`: add `ExampleWikiHistoryService_List`

Part of #217