### PR TITLE
refactor: replace inline &mockDoer with doerNoContent in example tests

### DIFF
--- a/example_issue_test.go
+++ b/example_issue_test.go
@@ -3,7 +3,6 @@ package backlog_test
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
@@ -131,9 +130,7 @@ func ExampleIssueStarService_Add() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
-			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
-		}}),
+		backlog.WithDoer(doerNoContent),
 	)
 
 	err := c.Issue.Star.Add(context.Background(), 1)
@@ -150,9 +147,7 @@ func ExampleIssueStarService_Remove() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
-			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
-		}}),
+		backlog.WithDoer(doerNoContent),
 	)
 
 	err := c.Issue.Star.Remove(context.Background(), 42)

--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -3,7 +3,6 @@ package backlog_test
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
@@ -117,9 +116,7 @@ func ExamplePullRequestStarService_Add() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
-			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
-		}}),
+		backlog.WithDoer(doerNoContent),
 	)
 
 	err := c.PullRequest.Star.Add(context.Background(), 2)
@@ -136,9 +133,7 @@ func ExamplePullRequestStarService_Remove() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
-			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
-		}}),
+		backlog.WithDoer(doerNoContent),
 	)
 
 	err := c.PullRequest.Star.Remove(context.Background(), 42)

--- a/example_star_test.go
+++ b/example_star_test.go
@@ -3,7 +3,6 @@ package backlog_test
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	backlog "github.com/nattokin/go-backlog"
 )
@@ -12,9 +11,7 @@ func ExampleStarService_Add() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
-			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
-		}}),
+		backlog.WithDoer(doerNoContent),
 	)
 
 	err := c.Star.Add(context.Background(), c.Star.Option.WithIssueID(1))
@@ -31,9 +28,7 @@ func ExampleStarService_Remove() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
-			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
-		}}),
+		backlog.WithDoer(doerNoContent),
 	)
 
 	err := c.Star.Remove(context.Background(), 42)

--- a/example_wiki_test.go
+++ b/example_wiki_test.go
@@ -3,7 +3,6 @@ package backlog_test
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
@@ -177,9 +176,7 @@ func ExampleWikiStarService_Add() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
-			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
-		}}),
+		backlog.WithDoer(doerNoContent),
 	)
 
 	err := c.Wiki.Star.Add(context.Background(), 34)
@@ -196,9 +193,7 @@ func ExampleWikiStarService_Remove() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(&mockDoer{do: func(_ *http.Request) (*http.Response, error) {
-			return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
-		}}),
+		backlog.WithDoer(doerNoContent),
 	)
 
 	err := c.Wiki.Star.Remove(context.Background(), 42)

--- a/mock_test.go
+++ b/mock_test.go
@@ -25,3 +25,10 @@ func newMockDoer(body string) *mockDoer {
 		},
 	}
 }
+
+// doerNoContent is a mockDoer that always responds with HTTP 204 No Content.
+var doerNoContent = &mockDoer{
+	do: func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+	},
+}


### PR DESCRIPTION
## Summary
Replace inline `&mockDoer{...}` literals in Example tests with a shared `doerNoContent` variable to eliminate repetition and improve consistency.

## Changes
- `mock_test.go`: add `doerNoContent`, a package-level `*mockDoer` that always returns HTTP 204 No Content
- `example_issue_test.go`: use `doerNoContent` in `ExampleIssueStarService_Add` and `ExampleIssueStarService_Remove`
- `example_pullrequest_test.go`: use `doerNoContent` in `ExamplePullRequestStarService_Add` and `ExamplePullRequestStarService_Remove`
- `example_star_test.go`: use `doerNoContent` in `ExampleStarService_Add` and `ExampleStarService_Remove`; remove unused `net/http` import
- `example_wiki_test.go`: use `doerNoContent` in `ExampleWikiStarService_Add` and `ExampleWikiStarService_Remove`; remove unused `net/http` import