### PR TITLE
refactor: extract authErrorResponse helper in test files

### DIFF
--- a/issue_test.go
+++ b/issue_test.go
@@ -205,10 +205,7 @@ func TestIssueService(t *testing.T) {
 		},
 		"Create/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return authErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.Create(ctx, 10, "New issue", 2, 3)
@@ -529,10 +526,7 @@ func TestIssueStarService(t *testing.T) {
 		},
 		"Add/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return authErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Issue.Star.Add(ctx, 1)
@@ -559,10 +553,7 @@ func TestIssueStarService(t *testing.T) {
 		},
 		"Remove/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return authErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Issue.Star.Remove(ctx, 42)

--- a/issue_test.go
+++ b/issue_test.go
@@ -204,9 +204,7 @@ func TestIssueService(t *testing.T) {
 			},
 		},
 		"Create/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.Create(ctx, 10, "New issue", 2, 3)
 				require.Error(t, err)
@@ -525,9 +523,7 @@ func TestIssueStarService(t *testing.T) {
 			},
 		},
 		"Add/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Issue.Star.Add(ctx, 1)
 				require.Error(t, err)
@@ -552,9 +548,7 @@ func TestIssueStarService(t *testing.T) {
 			},
 		},
 		"Remove/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Issue.Star.Remove(ctx, 42)
 				require.Error(t, err)

--- a/issue_test.go
+++ b/issue_test.go
@@ -1,7 +1,6 @@
 package backlog_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -30,10 +29,7 @@ func TestIssueService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.All(ctx)
@@ -49,10 +45,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues", req.URL.Path)
 				assert.Equal(t, "bug", req.URL.Query().Get("keyword"))
 				assert.Equal(t, []string{"10", "20"}, req.URL.Query()["projectId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.All(ctx,
@@ -130,10 +123,7 @@ func TestIssueService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/PRJ-1", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.One(ctx, "PRJ-1")
@@ -168,7 +158,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "3", req.PostForm.Get("priorityId"))
 				return &http.Response{
 					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
+					Body:       io.NopCloser(strings.NewReader(fixture.Issue.SingleJSON)),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
@@ -191,7 +181,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "5", req.PostForm.Get("assigneeId"))
 				return &http.Response{
 					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
+					Body:       io.NopCloser(strings.NewReader(fixture.Issue.SingleJSON)),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
@@ -218,10 +208,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/PRJ-1", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Update(ctx, "PRJ-1", c.Issue.Option.WithSummary("Updated summary"))
@@ -237,10 +224,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
 				assert.Equal(t, "2", req.PostForm.Get("statusId"))
 				assert.Equal(t, "1", req.PostForm.Get("resolutionId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Update(ctx, "PRJ-1",
@@ -270,10 +254,7 @@ func TestIssueService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/issues/PRJ-1", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Delete(ctx, "PRJ-1")
@@ -320,10 +301,7 @@ func TestIssueAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/TEST-1/attachments", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Attachment.List(ctx, "TEST-1")
@@ -351,10 +329,7 @@ func TestIssueAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/issues/TEST-1/attachments/8", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Attachment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Attachment.Remove(ctx, "TEST-1", 8)
@@ -400,10 +375,7 @@ func TestIssueSharedFileService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/TEST-1/sharedFiles", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.SharedFile.List(ctx, "TEST-1")
@@ -433,10 +405,7 @@ func TestIssueSharedFileService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/TEST-1/sharedFiles", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, []string{"454403"}, req.PostForm["fileId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.SingleListJSON))),
-				}, nil
+				return newJSONResponse(fixture.SharedFile.SingleListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.SharedFile.Link(ctx, "TEST-1", []int{454403})
@@ -463,10 +432,7 @@ func TestIssueSharedFileService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/issues/TEST-1/sharedFiles/454403", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.SharedFile.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.SharedFile.Unlink(ctx, "TEST-1", 454403)

--- a/issue_test.go
+++ b/issue_test.go
@@ -205,7 +205,7 @@ func TestIssueService(t *testing.T) {
 		},
 		"Create/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return authErrorResponse(), nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.Create(ctx, 10, "New issue", 2, 3)
@@ -526,7 +526,7 @@ func TestIssueStarService(t *testing.T) {
 		},
 		"Add/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return authErrorResponse(), nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Issue.Star.Add(ctx, 1)
@@ -553,7 +553,7 @@ func TestIssueStarService(t *testing.T) {
 		},
 		"Remove/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return authErrorResponse(), nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Issue.Star.Remove(ctx, 42)

--- a/mock_test.go
+++ b/mock_test.go
@@ -34,9 +34,9 @@ var doerNoContent = &mockDoer{
 	},
 }
 
-// authErrorResponse returns an HTTP 401 Unauthorized response with an
+// newAuthErrorResponse returns an HTTP 401 Unauthorized response with an
 // authentication failure error body, matching the Backlog API error format.
-func authErrorResponse() *http.Response {
+func newAuthErrorResponse() *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusUnauthorized,
 		Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),

--- a/mock_test.go
+++ b/mock_test.go
@@ -34,11 +34,14 @@ var doerNoContent = &mockDoer{
 	},
 }
 
-// newAuthErrorResponse returns an HTTP 401 Unauthorized response with an
-// authentication failure error body, matching the Backlog API error format.
-func newAuthErrorResponse() *http.Response {
-	return &http.Response{
-		StatusCode: http.StatusUnauthorized,
-		Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+// newAuthErrorDoFunc returns a doFunc that always responds with HTTP 401 Unauthorized
+// and a Backlog authentication failure error body.
+// It returns a new response on each call to avoid reuse of the consumed Body reader.
+func newAuthErrorDoFunc() func(req *http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+		}, nil
 	}
 }

--- a/mock_test.go
+++ b/mock_test.go
@@ -45,3 +45,13 @@ func newAuthErrorDoFunc() func(req *http.Request) (*http.Response, error) {
 		}, nil
 	}
 }
+
+// newJSONResponse returns an HTTP 200 OK response with the given JSON string as body.
+// It allocates a fresh reader on each call so the body can only be consumed once,
+// matching the behaviour of a real HTTP response.
+func newJSONResponse(json string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+	}
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 )
 
 type mockDoer struct {
@@ -31,4 +32,13 @@ var doerNoContent = &mockDoer{
 	do: func(_ *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
 	},
+}
+
+// authErrorResponse returns an HTTP 401 Unauthorized response with an
+// authentication failure error body, matching the Backlog API error format.
+func authErrorResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
+	}
 }

--- a/project_test.go
+++ b/project_test.go
@@ -1,7 +1,6 @@
 package backlog_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -30,10 +29,7 @@ func TestProjectService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects", req.URL.Path)
 				assert.Equal(t, "true", req.URL.Query().Get("archived"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Project.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.All(ctx, c.Project.Option.WithArchived(true))
@@ -54,10 +50,7 @@ func TestProjectService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Project.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.One(ctx, "TEST")
@@ -87,10 +80,7 @@ func TestProjectService(t *testing.T) {
 				assert.Equal(t, "TEST", req.PostForm.Get("key"))
 				assert.Equal(t, "test", req.PostForm.Get("name"))
 				assert.Equal(t, "true", req.PostForm.Get("chartEnabled"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Project.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.Create(ctx, "TEST", "test", c.Project.Option.WithChartEnabled(true))
@@ -113,10 +103,7 @@ func TestProjectService(t *testing.T) {
 				assert.Equal(t, "/api/v2/projects/TEST", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "new-name", req.PostForm.Get("name"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Project.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.Update(ctx, "TEST", c.Project.Option.WithName("new-name"))
@@ -142,10 +129,7 @@ func TestProjectService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Project.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.Delete(ctx, "TEST")
@@ -192,10 +176,7 @@ func TestProjectActivityService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/activities", req.URL.Path)
 				assert.Equal(t, "10", req.URL.Query().Get("count"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Activity.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.Activity.List(ctx, "TEST", c.Project.Activity.Option.WithCount(10))

--- a/project_test.go
+++ b/project_test.go
@@ -43,10 +43,7 @@ func TestProjectService(t *testing.T) {
 		},
 		"All/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.All(ctx)
@@ -105,10 +102,7 @@ func TestProjectService(t *testing.T) {
 		},
 		"Create/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.Create(ctx, "TEST", "test")

--- a/project_test.go
+++ b/project_test.go
@@ -42,9 +42,7 @@ func TestProjectService(t *testing.T) {
 			},
 		},
 		"All/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.All(ctx)
 				require.Error(t, err)
@@ -101,9 +99,7 @@ func TestProjectService(t *testing.T) {
 			},
 		},
 		"Create/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.Create(ctx, "TEST", "test")
 				require.Error(t, err)

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -1,7 +1,6 @@
 package backlog_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -29,10 +28,7 @@ func TestPullRequestService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.PullRequest.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.All(ctx, "TEST", "repo")
@@ -48,10 +44,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests", req.URL.Path)
 				assert.Equal(t, []string{"1", "2"}, req.URL.Query()["statusId[]"])
 				assert.Equal(t, "10", req.URL.Query().Get("count"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.PullRequest.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.All(ctx, "TEST", "repo",
@@ -127,10 +120,7 @@ func TestPullRequestService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.One(ctx, "TEST", "repo", 1)
@@ -164,7 +154,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, "feature/foo", req.PostForm.Get("branch"))
 				return &http.Response{
 					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+					Body:       io.NopCloser(strings.NewReader(fixture.PullRequest.SingleJSON)),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
@@ -184,7 +174,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, []string{"10", "20"}, req.PostForm["notifiedUserId[]"])
 				return &http.Response{
 					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
+					Body:       io.NopCloser(strings.NewReader(fixture.PullRequest.SingleJSON)),
 				}, nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
@@ -211,10 +201,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Update(ctx, "TEST", "repo", 1, c.PullRequest.Option.WithSummary("Updated summary"))
@@ -229,10 +216,7 @@ func TestPullRequestService(t *testing.T) {
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
 				assert.Equal(t, "a note", req.PostForm.Get("comment"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Update(ctx, "TEST", "repo", 1,
@@ -281,10 +265,7 @@ func TestPullRequestAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1/attachments", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Attachment.List(ctx, "TEST", "repo", 1)
@@ -312,10 +293,7 @@ func TestPullRequestAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1/attachments/8", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Attachment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Attachment.Remove(ctx, "TEST", "repo", 1, 8)

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -197,9 +197,7 @@ func TestPullRequestService(t *testing.T) {
 			},
 		},
 		"Create/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.Create(ctx, "TEST", "repo", "new PR", "", "main", "feature/foo")
 				require.Error(t, err)
@@ -373,9 +371,7 @@ func TestPullRequestStarService(t *testing.T) {
 			},
 		},
 		"Add/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.PullRequest.Star.Add(ctx, 2)
 				require.Error(t, err)
@@ -400,9 +396,7 @@ func TestPullRequestStarService(t *testing.T) {
 			},
 		},
 		"Remove/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.PullRequest.Star.Remove(ctx, 42)
 				require.Error(t, err)

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -198,10 +198,7 @@ func TestPullRequestService(t *testing.T) {
 		},
 		"Create/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.Create(ctx, "TEST", "repo", "new PR", "", "main", "feature/foo")
@@ -377,10 +374,7 @@ func TestPullRequestStarService(t *testing.T) {
 		},
 		"Add/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.PullRequest.Star.Add(ctx, 2)
@@ -407,10 +401,7 @@ func TestPullRequestStarService(t *testing.T) {
 		},
 		"Remove/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.PullRequest.Star.Remove(ctx, 42)

--- a/space_test.go
+++ b/space_test.go
@@ -36,10 +36,7 @@ func TestSpaceService_One(t *testing.T) {
 		},
 		"error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			wantErr: true,
 		},
@@ -89,10 +86,7 @@ func TestSpaceService_DiskUsage(t *testing.T) {
 		},
 		"error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			wantErr: true,
 		},
@@ -144,10 +138,7 @@ func TestSpaceService_Notification(t *testing.T) {
 		},
 		"error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			wantErr: true,
 		},
@@ -204,10 +195,7 @@ func TestSpaceService_UpdateNotification(t *testing.T) {
 		"error-api": {
 			content: "content",
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			wantErr: true,
 		},
@@ -263,10 +251,7 @@ func TestSpaceActivityService(t *testing.T) {
 		},
 		"List/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Space.Activity.List(ctx)
@@ -300,10 +285,7 @@ func TestSpaceActivityService(t *testing.T) {
 		},
 		"Get/error-api": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Space.Activity.Get(ctx, 1)
@@ -362,10 +344,7 @@ func TestSpaceAttachmentService(t *testing.T) {
 
 	t.Run("Upload/error", func(t *testing.T) {
 		doFunc := func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusUnauthorized,
-				Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-			}, nil
+			return newAuthErrorResponse(), nil
 		}
 
 		c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: doFunc}))

--- a/space_test.go
+++ b/space_test.go
@@ -1,10 +1,8 @@
 package backlog_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -28,10 +26,7 @@ func TestSpaceService_One(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/space", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.SpaceJSON))),
-				}, nil
+				return newJSONResponse(fixture.Space.SpaceJSON), nil
 			},
 		},
 		"error": {
@@ -76,10 +71,7 @@ func TestSpaceService_DiskUsage(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/space/diskUsage", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.DiskUsageJSON))),
-				}, nil
+				return newJSONResponse(fixture.Space.DiskUsageJSON), nil
 			},
 		},
 		"error": {
@@ -126,10 +118,7 @@ func TestSpaceService_Notification(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/space/notification", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.NotificationJSON))),
-				}, nil
+				return newJSONResponse(fixture.Space.NotificationJSON), nil
 			},
 		},
 		"error": {
@@ -176,10 +165,7 @@ func TestSpaceService_UpdateNotification(t *testing.T) {
 				assert.Equal(t, "/api/v2/space/notification", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "Backlog is a project management tool.", req.FormValue("content"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.NotificationJSON))),
-				}, nil
+				return newJSONResponse(fixture.Space.NotificationJSON), nil
 			},
 		},
 		"error-validation-empty-content": {
@@ -230,10 +216,7 @@ func TestSpaceActivityService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/space/activities", req.URL.Path)
 				assert.Equal(t, "20", req.URL.Query().Get("count"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Activity.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Space.Activity.List(ctx, c.Space.Activity.Option.WithCount(20))
@@ -254,10 +237,7 @@ func TestSpaceActivityService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/activities/3153", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Activity.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Space.Activity.Get(ctx, 3153)
@@ -310,10 +290,7 @@ func TestSpaceAttachmentService(t *testing.T) {
 			assert.Equal(t, http.MethodPost, req.Method)
 			assert.Equal(t, "/api/v2/space/attachment", req.URL.Path)
 			assert.True(t, strings.HasPrefix(req.Header.Get("Content-Type"), "multipart/form-data"))
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.UploadJSON))),
-			}, nil
+			return newJSONResponse(fixture.Attachment.UploadJSON), nil
 		}
 
 		c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: doFunc}))

--- a/space_test.go
+++ b/space_test.go
@@ -35,9 +35,7 @@ func TestSpaceService_One(t *testing.T) {
 			},
 		},
 		"error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc:  newAuthErrorDoFunc(),
 			wantErr: true,
 		},
 	}
@@ -85,9 +83,7 @@ func TestSpaceService_DiskUsage(t *testing.T) {
 			},
 		},
 		"error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc:  newAuthErrorDoFunc(),
 			wantErr: true,
 		},
 	}
@@ -137,9 +133,7 @@ func TestSpaceService_Notification(t *testing.T) {
 			},
 		},
 		"error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc:  newAuthErrorDoFunc(),
 			wantErr: true,
 		},
 	}
@@ -194,9 +188,7 @@ func TestSpaceService_UpdateNotification(t *testing.T) {
 		},
 		"error-api": {
 			content: "content",
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc:  newAuthErrorDoFunc(),
 			wantErr: true,
 		},
 	}
@@ -250,9 +242,7 @@ func TestSpaceActivityService(t *testing.T) {
 			},
 		},
 		"List/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Space.Activity.List(ctx)
 				require.Error(t, err)
@@ -284,9 +274,7 @@ func TestSpaceActivityService(t *testing.T) {
 			},
 		},
 		"Get/error-api": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Space.Activity.Get(ctx, 1)
 				require.Error(t, err)
@@ -343,9 +331,7 @@ func TestSpaceAttachmentService(t *testing.T) {
 	})
 
 	t.Run("Upload/error", func(t *testing.T) {
-		doFunc := func(req *http.Request) (*http.Response, error) {
-			return newAuthErrorResponse(), nil
-		}
+		doFunc := newAuthErrorDoFunc()
 
 		c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: doFunc}))
 		require.NoError(t, err)

--- a/star_test.go
+++ b/star_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,10 +84,7 @@ func TestStarService_Add(t *testing.T) {
 		},
 		"error-api": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return authErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Star.Add(ctx, c.Star.Option.WithIssueID(1))
@@ -147,10 +143,7 @@ func TestStarService_Remove(t *testing.T) {
 		"error-api": {
 			starID: 1,
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return authErrorResponse(), nil
 			},
 			wantErr: true,
 		},

--- a/star_test.go
+++ b/star_test.go
@@ -84,7 +84,7 @@ func TestStarService_Add(t *testing.T) {
 		},
 		"error-api": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return authErrorResponse(), nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Star.Add(ctx, c.Star.Option.WithIssueID(1))
@@ -143,7 +143,7 @@ func TestStarService_Remove(t *testing.T) {
 		"error-api": {
 			starID: 1,
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return authErrorResponse(), nil
+				return newAuthErrorResponse(), nil
 			},
 			wantErr: true,
 		},

--- a/star_test.go
+++ b/star_test.go
@@ -83,9 +83,7 @@ func TestStarService_Add(t *testing.T) {
 			},
 		},
 		"error-api": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Star.Add(ctx, c.Star.Option.WithIssueID(1))
 				require.Error(t, err)
@@ -142,9 +140,7 @@ func TestStarService_Remove(t *testing.T) {
 		},
 		"error-api": {
 			starID: 1,
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			wantErr: true,
 		},
 	}

--- a/star_test.go
+++ b/star_test.go
@@ -139,8 +139,8 @@ func TestStarService_Remove(t *testing.T) {
 			wantErr: true,
 		},
 		"error-api": {
-			starID: 1,
-			doFunc: newAuthErrorDoFunc(),
+			starID:  1,
+			doFunc:  newAuthErrorDoFunc(),
 			wantErr: true,
 		},
 	}

--- a/user_recentlyviewed_test.go
+++ b/user_recentlyviewed_test.go
@@ -66,10 +66,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 		},
 		"ListIssues/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.RecentlyViewed.ListIssues(ctx)
@@ -125,10 +122,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 		},
 		"ListProjects/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.RecentlyViewed.ListProjects(ctx)
@@ -155,10 +149,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 		},
 		"ListWikis/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.RecentlyViewed.ListWikis(ctx)

--- a/user_recentlyviewed_test.go
+++ b/user_recentlyviewed_test.go
@@ -65,9 +65,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 			},
 		},
 		"ListIssues/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.RecentlyViewed.ListIssues(ctx)
 				require.Error(t, err)
@@ -121,9 +119,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 			},
 		},
 		"ListProjects/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.RecentlyViewed.ListProjects(ctx)
 				require.Error(t, err)
@@ -148,9 +144,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 			},
 		},
 		"ListWikis/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.RecentlyViewed.ListWikis(ctx)
 				require.Error(t, err)

--- a/user_test.go
+++ b/user_test.go
@@ -1,7 +1,6 @@
 package backlog_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -30,10 +29,7 @@ func TestProjectUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/users", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.All(ctx, "TEST", false)
@@ -61,10 +57,7 @@ func TestProjectUserService(t *testing.T) {
 				assert.Equal(t, "/api/v2/projects/TEST/users", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "1", req.PostForm.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.Add(ctx, "TEST", 1)
@@ -95,10 +88,7 @@ func TestProjectUserService(t *testing.T) {
 				form, err := url.ParseQuery(string(body))
 				require.NoError(t, err)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.Delete(ctx, "TEST", 1)
@@ -126,10 +116,7 @@ func TestProjectUserService(t *testing.T) {
 				assert.Equal(t, "/api/v2/projects/TEST/administrators", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "1", req.PostForm.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.AddAdmin(ctx, "TEST", 1)
@@ -155,10 +142,7 @@ func TestProjectUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/administrators", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.AdminAll(ctx, "TEST")
@@ -189,10 +173,7 @@ func TestProjectUserService(t *testing.T) {
 				form, err := url.ParseQuery(string(body))
 				require.NoError(t, err)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.DeleteAdmin(ctx, "TEST", 1)
@@ -238,10 +219,7 @@ func TestUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.All(ctx)
@@ -262,10 +240,7 @@ func TestUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/1", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.One(ctx, 1)
@@ -291,10 +266,7 @@ func TestUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/myself", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Own(ctx)
@@ -320,10 +292,7 @@ func TestUserService(t *testing.T) {
 				assert.Equal(t, "password", req.PostForm.Get("password"))
 				assert.Equal(t, "New User", req.PostForm.Get("name"))
 				assert.Equal(t, "new@example.com", req.PostForm.Get("mailAddress"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Add(ctx, "newuser", "password", "New User", "new@example.com", backlog.RoleAdministrator)
@@ -346,10 +315,7 @@ func TestUserService(t *testing.T) {
 				assert.Equal(t, "/api/v2/users/1", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "updated-user", req.PostForm.Get("name"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Update(ctx, 1, c.User.Option.WithName("updated-user"))
@@ -380,10 +346,7 @@ func TestUserService(t *testing.T) {
 				form, err := url.ParseQuery(string(body))
 				require.NoError(t, err)
 				assert.Empty(t, form)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Delete(ctx, 1)
@@ -430,10 +393,7 @@ func TestUserActivityService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/1/activities", req.URL.Path)
 				assert.Equal(t, "5", req.URL.Query().Get("minId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Activity.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Activity.List(ctx, 1, c.User.Activity.Option.WithMinID(5))

--- a/user_test.go
+++ b/user_test.go
@@ -250,9 +250,7 @@ func TestUserService(t *testing.T) {
 			},
 		},
 		"All/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.All(ctx)
 				require.Error(t, err)
@@ -305,9 +303,7 @@ func TestUserService(t *testing.T) {
 			},
 		},
 		"Own/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.Own(ctx)
 				require.Error(t, err)
@@ -336,9 +332,7 @@ func TestUserService(t *testing.T) {
 			},
 		},
 		"Add/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.Add(ctx, "newuser", "password", "New User", "new@example.com", backlog.RoleGuestReporter)
 				require.Error(t, err)

--- a/user_test.go
+++ b/user_test.go
@@ -251,10 +251,7 @@ func TestUserService(t *testing.T) {
 		},
 		"All/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.All(ctx)
@@ -309,10 +306,7 @@ func TestUserService(t *testing.T) {
 		},
 		"Own/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.Own(ctx)
@@ -343,10 +337,7 @@ func TestUserService(t *testing.T) {
 		},
 		"Add/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.Add(ctx, "newuser", "password", "New User", "new@example.com", backlog.RoleGuestReporter)

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -135,7 +135,7 @@ func TestWikiService(t *testing.T) {
 		},
 		"Create/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return authErrorResponse(), nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.Create(ctx, 56, "Test Wiki", "content")
@@ -558,7 +558,7 @@ func TestWikiStarService(t *testing.T) {
 		},
 		"Add/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return authErrorResponse(), nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Wiki.Star.Add(ctx, 34)
@@ -585,7 +585,7 @@ func TestWikiStarService(t *testing.T) {
 		},
 		"Remove/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return authErrorResponse(), nil
+				return newAuthErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Wiki.Star.Remove(ctx, 42)

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -134,9 +134,7 @@ func TestWikiService(t *testing.T) {
 			},
 		},
 		"Create/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.Create(ctx, 56, "Test Wiki", "content")
 				require.Error(t, err)
@@ -557,9 +555,7 @@ func TestWikiStarService(t *testing.T) {
 			},
 		},
 		"Add/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Wiki.Star.Add(ctx, 34)
 				require.Error(t, err)
@@ -584,9 +580,7 @@ func TestWikiStarService(t *testing.T) {
 			},
 		},
 		"Remove/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return newAuthErrorResponse(), nil
-			},
+			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Wiki.Star.Remove(ctx, 42)
 				require.Error(t, err)

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -1,7 +1,6 @@
 package backlog_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -30,10 +29,7 @@ func TestWikiService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis", req.URL.Path)
 				assert.Equal(t, "backlog", req.URL.Query().Get("keyword"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Wiki.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.All(ctx, "TEST", c.Wiki.Option.WithKeyword("backlog"))
@@ -59,10 +55,7 @@ func TestWikiService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/count", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count": 34}`))),
-				}, nil
+				return newJSONResponse(`{"count": 34}`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Count(ctx, "TEST")
@@ -88,10 +81,7 @@ func TestWikiService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),
-				}, nil
+				return newJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.One(ctx, 34)
@@ -122,10 +112,7 @@ func TestWikiService(t *testing.T) {
 				assert.Equal(t, "Test Wiki", req.PostForm.Get("name"))
 				assert.Equal(t, "content", req.PostForm.Get("content"))
 				assert.Equal(t, "true", req.PostForm.Get("mailNotify"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MinimumJSON))),
-				}, nil
+				return newJSONResponse(fixture.Wiki.MinimumJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Create(ctx, 56, "Test Wiki", "content", c.Wiki.Option.WithMailNotify(true))
@@ -148,10 +135,7 @@ func TestWikiService(t *testing.T) {
 				assert.Equal(t, "/api/v2/wikis/34", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "New Name", req.PostForm.Get("name"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),
-				}, nil
+				return newJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Update(ctx, 34, c.Wiki.Option.WithName("New Name"))
@@ -182,10 +166,7 @@ func TestWikiService(t *testing.T) {
 				form, err := url.ParseQuery(string(body))
 				require.NoError(t, err)
 				assert.Equal(t, "true", form.Get("mailNotify"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),
-				}, nil
+				return newJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Delete(ctx, 34, c.Wiki.Option.WithMailNotify(true))
@@ -233,10 +214,7 @@ func TestWikiAttachmentService(t *testing.T) {
 				assert.Equal(t, "/api/v2/wikis/34/attachments", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, []string{"2", "5"}, req.PostForm["attachmentId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Attachment.Attach(ctx, 34, []int{2, 5})
@@ -264,10 +242,7 @@ func TestWikiAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/attachments", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Attachment.List(ctx, 34)
@@ -295,10 +270,7 @@ func TestWikiAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/attachments/8", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.Attachment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Attachment.Remove(ctx, 34, 8)
@@ -344,10 +316,7 @@ func TestWikiHistoryService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/history", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.WikiHistory.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.WikiHistory.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.History.List(ctx, 34)
@@ -397,10 +366,7 @@ func TestWikiSharedFileService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/sharedFiles", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.SharedFile.List(ctx, 34)
@@ -432,10 +398,7 @@ func TestWikiSharedFileService(t *testing.T) {
 				assert.Equal(t, "/api/v2/wikis/34/sharedFiles", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, []string{"454403", "454404"}, req.PostForm["fileId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.SharedFile.Link(ctx, 34, []int{454403, 454404})
@@ -463,10 +426,7 @@ func TestWikiSharedFileService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/sharedFiles/454403", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.SharedFile.SingleJSON))),
-				}, nil
+				return newJSONResponse(fixture.SharedFile.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.SharedFile.Unlink(ctx, 34, 454403)
@@ -514,10 +474,7 @@ func TestWikiStarService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/stars", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Star.ListJSON))),
-				}, nil
+				return newJSONResponse(fixture.Star.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Star.List(ctx, 34)

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -135,10 +135,7 @@ func TestWikiService(t *testing.T) {
 		},
 		"Create/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return authErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.Create(ctx, 56, "Test Wiki", "content")
@@ -561,10 +558,7 @@ func TestWikiStarService(t *testing.T) {
 		},
 		"Add/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return authErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Wiki.Star.Add(ctx, 34)
@@ -591,10 +585,7 @@ func TestWikiStarService(t *testing.T) {
 		},
 		"Remove/error": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Authentication failure.","code":11,"moreInfo":""}]}`)),
-				}, nil
+				return authErrorResponse(), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				err := c.Wiki.Star.Remove(ctx, 42)


### PR DESCRIPTION
## Summary
Introduce two shared test helpers in `mock_test.go` to eliminate repeated response literals across test files.

- `newAuthErrorDoFunc()` — returns a `doFunc` that always responds with HTTP 401 Unauthorized and a Backlog authentication failure error body. Returns a new response on each call to avoid reuse of the consumed Body reader.
- `newJSONResponse(json string)` — returns an HTTP 200 OK `*http.Response` with the given JSON string as body. Allocates a fresh reader on each call.

## Changes
- `mock_test.go`: add `newAuthErrorDoFunc()` and `newJSONResponse()`
- `issue_test.go`: use `newAuthErrorDoFunc()` for error cases; use `newJSONResponse()` for success cases returning fixture JSON
- `wiki_test.go`: same as above
- `star_test.go`: use `newAuthErrorDoFunc()` for error cases; remove unused `strings` import
- `project_test.go`: use `newAuthErrorDoFunc()` and `newJSONResponse()`
- `pullrequest_test.go`: use `newAuthErrorDoFunc()` and `newJSONResponse()`
- `space_test.go`: use `newAuthErrorDoFunc()` and `newJSONResponse()`
- `user_test.go`: use `newAuthErrorDoFunc()` and `newJSONResponse()`