### PR TITLE
refactor: add mock response helpers and eliminate inline response literals

### DIFF
--- a/internal/star/service_test.go
+++ b/internal/star/service_test.go
@@ -3,8 +3,10 @@ package star_test
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +16,13 @@ import (
 	"github.com/nattokin/go-backlog/internal/star"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
+
+func newJSONResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
 
 func newNoContentResponse() *http.Response {
 	return &http.Response{

--- a/internal/star/service_user_test.go
+++ b/internal/star/service_user_test.go
@@ -3,10 +3,8 @@ package star_test
 import (
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,13 +15,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
-
-func newJSONResponse(body string) *http.Response {
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(body)),
-	}
-}
 
 func TestUserStarService_List(t *testing.T) {
 	o := &core.OptionService{}

--- a/issue_test.go
+++ b/issue_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -57,12 +56,7 @@ func TestIssueService(t *testing.T) {
 			},
 		},
 		"All/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusInternalServerError,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Internal Server Error","code":1,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.All(ctx)
 				require.Error(t, err)
@@ -74,10 +68,7 @@ func TestIssueService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/count", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"count":5}`)),
-				}, nil
+				return newJSONResponse(`{"count":5}`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Count(ctx)
@@ -91,10 +82,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/count", req.URL.Path)
 				assert.Equal(t, "bug", req.URL.Query().Get("keyword"))
 				assert.Equal(t, []string{"10", "20"}, req.URL.Query()["projectId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"count":2}`)),
-				}, nil
+				return newJSONResponse(`{"count":2}`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Count(ctx,
@@ -106,12 +94,7 @@ func TestIssueService(t *testing.T) {
 			},
 		},
 		"Count/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusInternalServerError,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Internal Server Error","code":1,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.Count(ctx)
 				require.Error(t, err)
@@ -134,12 +117,7 @@ func TestIssueService(t *testing.T) {
 			},
 		},
 		"One/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.One(ctx, "PRJ-1")
 				require.Error(t, err)
@@ -156,10 +134,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "New issue", req.PostForm.Get("summary"))
 				assert.Equal(t, "2", req.PostForm.Get("issueTypeId"))
 				assert.Equal(t, "3", req.PostForm.Get("priorityId"))
-				return &http.Response{
-					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(strings.NewReader(fixture.Issue.SingleJSON)),
-				}, nil
+				return newCreatedJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Create(ctx, 10, "New issue", 2, 3)
@@ -179,10 +154,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "3", req.PostForm.Get("priorityId"))
 				assert.Equal(t, "details here", req.PostForm.Get("description"))
 				assert.Equal(t, "5", req.PostForm.Get("assigneeId"))
-				return &http.Response{
-					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(strings.NewReader(fixture.Issue.SingleJSON)),
-				}, nil
+				return newCreatedJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Create(ctx, 10, "New issue", 2, 3,
@@ -237,12 +209,7 @@ func TestIssueService(t *testing.T) {
 			},
 		},
 		"Update/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.Update(ctx, "PRJ-1", c.Issue.Option.WithSummary("Updated summary"))
 				require.Error(t, err)
@@ -264,12 +231,7 @@ func TestIssueService(t *testing.T) {
 			},
 		},
 		"Delete/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.Delete(ctx, "PRJ-1")
 				require.Error(t, err)
@@ -312,12 +274,7 @@ func TestIssueAttachmentService(t *testing.T) {
 			},
 		},
 		"List/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.Attachment.List(ctx, "TEST-1")
 				require.Error(t, err)
@@ -338,12 +295,7 @@ func TestIssueAttachmentService(t *testing.T) {
 			},
 		},
 		"Remove/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such attachment.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.Attachment.Remove(ctx, "TEST-1", 8)
 				require.Error(t, err)
@@ -386,12 +338,7 @@ func TestIssueSharedFileService(t *testing.T) {
 			},
 		},
 		"List/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.SharedFile.List(ctx, "TEST-1")
 				require.Error(t, err)
@@ -415,12 +362,7 @@ func TestIssueSharedFileService(t *testing.T) {
 			},
 		},
 		"Link/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.SharedFile.Link(ctx, "TEST-1", []int{454403})
 				require.Error(t, err)
@@ -442,12 +384,7 @@ func TestIssueSharedFileService(t *testing.T) {
 			},
 		},
 		"Unlink/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.SharedFile.Unlink(ctx, "TEST-1", 454403)
 				require.Error(t, err)

--- a/mock_test.go
+++ b/mock_test.go
@@ -76,7 +76,7 @@ func newInternalServerErrorDoFunc() func(req *http.Request) (*http.Response, err
 func newJSONResponse(json string) *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		Body:       io.NopCloser(strings.NewReader(json)),
 	}
 }
 
@@ -86,6 +86,6 @@ func newJSONResponse(json string) *http.Response {
 func newCreatedJSONResponse(json string) *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusCreated,
-		Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		Body:       io.NopCloser(strings.NewReader(json)),
 	}
 }

--- a/mock_test.go
+++ b/mock_test.go
@@ -46,12 +46,46 @@ func newAuthErrorDoFunc() func(req *http.Request) (*http.Response, error) {
 	}
 }
 
+// newNotFoundDoFunc returns a doFunc that always responds with HTTP 404 Not Found
+// and a generic Backlog not-found error body.
+// It returns a new response on each call to avoid reuse of the consumed Body reader.
+func newNotFoundDoFunc() func(req *http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such resource.","code":6,"moreInfo":""}]}`)),
+		}, nil
+	}
+}
+
+// newInternalServerErrorDoFunc returns a doFunc that always responds with HTTP 500
+// and a generic Backlog internal server error body.
+// It returns a new response on each call to avoid reuse of the consumed Body reader.
+func newInternalServerErrorDoFunc() func(req *http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Internal Server Error","code":1,"moreInfo":""}]}`)),
+		}, nil
+	}
+}
+
 // newJSONResponse returns an HTTP 200 OK response with the given JSON string as body.
 // It allocates a fresh reader on each call so the body can only be consumed once,
 // matching the behaviour of a real HTTP response.
 func newJSONResponse(json string) *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+	}
+}
+
+// newCreatedJSONResponse returns an HTTP 201 Created response with the given JSON string as body.
+// It allocates a fresh reader on each call so the body can only be consumed once,
+// matching the behaviour of a real HTTP response.
+func newCreatedJSONResponse(json string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusCreated,
 		Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 	}
 }

--- a/project_test.go
+++ b/project_test.go
@@ -3,9 +3,7 @@ package backlog_test
 import (
 	"context"
 	"errors"
-	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,12 +57,7 @@ func TestProjectService(t *testing.T) {
 			},
 		},
 		"One/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.One(ctx, "TEST")
 				require.Error(t, err)
@@ -112,12 +105,7 @@ func TestProjectService(t *testing.T) {
 			},
 		},
 		"Update/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.Update(ctx, "TEST")
 				require.Error(t, err)
@@ -138,12 +126,7 @@ func TestProjectService(t *testing.T) {
 			},
 		},
 		"Delete/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.Delete(ctx, "TEST")
 				require.Error(t, err)
@@ -185,12 +168,7 @@ func TestProjectActivityService(t *testing.T) {
 			},
 		},
 		"List/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.Activity.List(ctx, "TEST")
 				require.Error(t, err)

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,12 +55,7 @@ func TestPullRequestService(t *testing.T) {
 			},
 		},
 		"All/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusInternalServerError,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Internal Server Error","code":1,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.All(ctx, "TEST", "repo")
 				require.Error(t, err)
@@ -73,10 +67,7 @@ func TestPullRequestService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/count", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"count":5}`)),
-				}, nil
+				return newJSONResponse(`{"count":5}`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Count(ctx, "TEST", "repo")
@@ -89,10 +80,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/count", req.URL.Path)
 				assert.Equal(t, []string{"1"}, req.URL.Query()["statusId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"count":3}`)),
-				}, nil
+				return newJSONResponse(`{"count":3}`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Count(ctx, "TEST", "repo",
@@ -103,12 +91,7 @@ func TestPullRequestService(t *testing.T) {
 			},
 		},
 		"Count/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusInternalServerError,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Internal Server Error","code":1,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.Count(ctx, "TEST", "repo")
 				require.Error(t, err)
@@ -130,12 +113,7 @@ func TestPullRequestService(t *testing.T) {
 			},
 		},
 		"One/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such pull request.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.One(ctx, "TEST", "repo", 1)
 				require.Error(t, err)
@@ -152,10 +130,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, "details", req.PostForm.Get("description"))
 				assert.Equal(t, "main", req.PostForm.Get("base"))
 				assert.Equal(t, "feature/foo", req.PostForm.Get("branch"))
-				return &http.Response{
-					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(strings.NewReader(fixture.PullRequest.SingleJSON)),
-				}, nil
+				return newCreatedJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Create(ctx, "TEST", "repo", "new PR", "details", "main", "feature/foo")
@@ -172,10 +147,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, "new PR", req.PostForm.Get("summary"))
 				assert.Equal(t, "5", req.PostForm.Get("assigneeId"))
 				assert.Equal(t, []string{"10", "20"}, req.PostForm["notifiedUserId[]"])
-				return &http.Response{
-					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(strings.NewReader(fixture.PullRequest.SingleJSON)),
-				}, nil
+				return newCreatedJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Create(ctx, "TEST", "repo", "new PR", "", "main", "feature/foo",
@@ -228,12 +200,7 @@ func TestPullRequestService(t *testing.T) {
 			},
 		},
 		"Update/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such pull request.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.Update(ctx, "TEST", "repo", 1, c.PullRequest.Option.WithSummary("Updated summary"))
 				require.Error(t, err)
@@ -276,12 +243,7 @@ func TestPullRequestAttachmentService(t *testing.T) {
 			},
 		},
 		"List/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such repository.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.Attachment.List(ctx, "TEST", "repo", 1)
 				require.Error(t, err)
@@ -302,12 +264,7 @@ func TestPullRequestAttachmentService(t *testing.T) {
 			},
 		},
 		"Remove/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such attachment.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.Attachment.Remove(ctx, "TEST", "repo", 1, 8)
 				require.Error(t, err)

--- a/user_recentlyviewed_test.go
+++ b/user_recentlyviewed_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,12 +88,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 			},
 		},
 		"AddIssue/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such issue.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.RecentlyViewed.AddIssue(ctx, 1)
 				require.Error(t, err)
@@ -168,12 +162,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 			},
 		},
 		"AddWiki/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.RecentlyViewed.AddWiki(ctx, 10)
 				require.Error(t, err)

--- a/user_star_test.go
+++ b/user_star_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,12 +68,7 @@ func TestUserStarService(t *testing.T) {
 			},
 		},
 		"List/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such user.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.Star.List(ctx, 1)
 				require.Error(t, err)
@@ -98,12 +92,7 @@ func TestUserStarService(t *testing.T) {
 			},
 		},
 		"Count/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such user.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.Star.Count(ctx, 1)
 				require.Error(t, err)

--- a/user_test.go
+++ b/user_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,12 +37,7 @@ func TestProjectUserService(t *testing.T) {
 			},
 		},
 		"All/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.User.All(ctx, "TEST", false)
 				require.Error(t, err)
@@ -66,12 +60,7 @@ func TestProjectUserService(t *testing.T) {
 			},
 		},
 		"Add/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.User.Add(ctx, "TEST", 1)
 				require.Error(t, err)
@@ -97,12 +86,7 @@ func TestProjectUserService(t *testing.T) {
 			},
 		},
 		"Delete/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.User.Delete(ctx, "TEST", 1)
 				require.Error(t, err)
@@ -125,12 +109,7 @@ func TestProjectUserService(t *testing.T) {
 			},
 		},
 		"AddAdmin/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.User.AddAdmin(ctx, "TEST", 1)
 				require.Error(t, err)
@@ -151,12 +130,7 @@ func TestProjectUserService(t *testing.T) {
 			},
 		},
 		"AdminAll/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.User.AdminAll(ctx, "TEST")
 				require.Error(t, err)
@@ -182,12 +156,7 @@ func TestProjectUserService(t *testing.T) {
 			},
 		},
 		"DeleteAdmin/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such project.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.User.DeleteAdmin(ctx, "TEST", 1)
 				require.Error(t, err)
@@ -249,12 +218,7 @@ func TestUserService(t *testing.T) {
 			},
 		},
 		"One/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such user.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.One(ctx, 1)
 				require.Error(t, err)
@@ -324,12 +288,7 @@ func TestUserService(t *testing.T) {
 			},
 		},
 		"Update/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such user.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.Update(ctx, 1)
 				require.Error(t, err)
@@ -355,12 +314,7 @@ func TestUserService(t *testing.T) {
 			},
 		},
 		"Delete/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such user.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.Delete(ctx, 1)
 				require.Error(t, err)
@@ -402,12 +356,7 @@ func TestUserActivityService(t *testing.T) {
 			},
 		},
 		"List/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such user.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.Activity.List(ctx, 1)
 				require.Error(t, err)

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,12 +37,7 @@ func TestWikiService(t *testing.T) {
 			},
 		},
 		"All/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.All(ctx, "TEST")
 				require.Error(t, err)
@@ -64,12 +58,7 @@ func TestWikiService(t *testing.T) {
 			},
 		},
 		"Count/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No project.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.Count(ctx, "TEST")
 				require.Error(t, err)
@@ -90,12 +79,7 @@ func TestWikiService(t *testing.T) {
 			},
 		},
 		"One/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.One(ctx, 34)
 				require.Error(t, err)
@@ -144,12 +128,7 @@ func TestWikiService(t *testing.T) {
 			},
 		},
 		"Update/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.Update(ctx, 34, c.Wiki.Option.WithName("New Name"))
 				require.Error(t, err)
@@ -175,12 +154,7 @@ func TestWikiService(t *testing.T) {
 			},
 		},
 		"Delete/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.Delete(ctx, 34)
 				require.Error(t, err)
@@ -225,12 +199,7 @@ func TestWikiAttachmentService(t *testing.T) {
 			},
 		},
 		"Attach/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.Attachment.Attach(ctx, 34, []int{2, 5})
 				require.Error(t, err)
@@ -253,12 +222,7 @@ func TestWikiAttachmentService(t *testing.T) {
 			},
 		},
 		"List/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.Attachment.List(ctx, 34)
 				require.Error(t, err)
@@ -279,12 +243,7 @@ func TestWikiAttachmentService(t *testing.T) {
 			},
 		},
 		"Remove/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such attachment.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.Attachment.Remove(ctx, 34, 8)
 				require.Error(t, err)
@@ -329,12 +288,7 @@ func TestWikiHistoryService(t *testing.T) {
 			},
 		},
 		"List/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.History.List(ctx, 34)
 				require.Error(t, err)
@@ -379,12 +333,7 @@ func TestWikiSharedFileService(t *testing.T) {
 			},
 		},
 		"List/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.SharedFile.List(ctx, 34)
 				require.Error(t, err)
@@ -409,12 +358,7 @@ func TestWikiSharedFileService(t *testing.T) {
 			},
 		},
 		"Link/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.SharedFile.Link(ctx, 34, []int{454403})
 				require.Error(t, err)
@@ -437,12 +381,7 @@ func TestWikiSharedFileService(t *testing.T) {
 			},
 		},
 		"Unlink/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such shared file.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.SharedFile.Unlink(ctx, 34, 454403)
 				require.Error(t, err)
@@ -485,12 +424,7 @@ func TestWikiStarService(t *testing.T) {
 			},
 		},
 		"List/error": {
-			doFunc: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"No such wiki.","code":6,"moreInfo":""}]}`)),
-				}, nil
-			},
+			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.Star.List(ctx, 34)
 				require.Error(t, err)


### PR DESCRIPTION
## Summary
Add three new helper functions to `mock_test.go` to eliminate the remaining `io.NopCloser(strings.NewReader(...))` inline response literals in test files.

- `newNotFoundDoFunc()` — returns a doFunc that responds with HTTP 404 Not Found and a generic Backlog not-found error body
- `newInternalServerErrorDoFunc()` — returns a doFunc that responds with HTTP 500 Internal Server Error and a generic Backlog error body
- `newCreatedJSONResponse(json string)` — returns an HTTP 201 Created `*http.Response` with the given JSON body

All three allocate a fresh reader on each call to avoid reuse of the consumed Body reader.

## Changes
- `mock_test.go`: add `newNotFoundDoFunc()`, `newInternalServerErrorDoFunc()`, `newCreatedJSONResponse()`
- `issue_test.go`: replace inline 404/500 literals with the new doFuncs; replace `StatusCreated` literals with `newCreatedJSONResponse()`; remove unused `io`, `strings` imports
- `wiki_test.go`: replace inline 404 literals with `newNotFoundDoFunc()`; remove unused `io`, `strings` imports
- `pullrequest_test.go`: replace inline 404/500 literals and `StatusCreated` literals; remove unused `io`, `strings` imports
- `project_test.go`: replace inline 404 literals with `newNotFoundDoFunc()`; remove unused `io`, `strings` imports
- `space_test.go`: no remaining inline literals (already clean)
- `user_test.go`: replace inline 404 literals with `newNotFoundDoFunc()`; remove unused `strings` import