### PR TITLE
feat: implement IssueCommentService

### DIFF
--- a/internal/comment/service.go
+++ b/internal/comment/service.go
@@ -169,14 +169,12 @@ func (s *IssueService) Update(ctx context.Context, issueIDOrKey string, commentI
 		return nil, err
 	}
 
-	form := url.Values{}
-	validTypes := []core.APIParamOptionType{
-		core.ParamContent,
-	}
 	option := (&core.OptionService{}).WithContent(content)
-	if err := core.ApplyOptions(form, validTypes, option); err != nil {
+	if err := option.Check(); err != nil {
 		return nil, err
 	}
+	form := url.Values{}
+	option.Set(form)
 
 	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID))
 	resp, err := s.method.Patch(ctx, spath, form)

--- a/internal/comment/service.go
+++ b/internal/comment/service.go
@@ -1,0 +1,260 @@
+package comment
+
+import (
+	"context"
+	"net/url"
+	"path"
+	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/validate"
+)
+
+// IssueService handles communication with the issue comment-related methods of the Backlog API.
+type IssueService struct {
+	method *core.Method
+}
+
+// All returns a list of comments on an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-comment-list
+func (s *IssueService) All(ctx context.Context, issueIDOrKey string, opts ...core.RequestOption) ([]*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+
+	query := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamMinID,
+		core.ParamMaxID,
+		core.ParamCount,
+		core.ParamOrder,
+	}
+	if err := core.ApplyOptions(query, validTypes, opts...); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments")
+	resp, err := s.method.Get(ctx, spath, query)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.Comment{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Add adds a comment to an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-comment
+func (s *IssueService) Add(ctx context.Context, issueIDOrKey string, content string, opts ...core.RequestOption) (*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+
+	option := &core.OptionService{}
+	form := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamContent,
+		core.ParamNotifiedUserIDs,
+		core.ParamAttachmentIDs,
+	}
+	options := append(
+		[]core.RequestOption{option.WithContent(content)},
+		opts...,
+	)
+	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments")
+	resp, err := s.method.Post(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Comment{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Count returns the number of comments on an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-comment
+func (s *IssueService) Count(ctx context.Context, issueIDOrKey string) (int, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return 0, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", "count")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	v := map[string]int{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return 0, err
+	}
+
+	return v["count"], nil
+}
+
+// One returns information about a specific comment.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-comment
+func (s *IssueService) One(ctx context.Context, issueIDOrKey string, commentID int) (*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID))
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Comment{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Delete deletes a comment from an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-comment
+func (s *IssueService) Delete(ctx context.Context, issueIDOrKey string, commentID int) (*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID))
+	resp, err := s.method.Delete(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Comment{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Update updates a comment on an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-comment
+func (s *IssueService) Update(ctx context.Context, issueIDOrKey string, commentID int, option core.RequestOption) (*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	form := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamContent,
+	}
+	if err := core.ApplyOptions(form, validTypes, option); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID))
+	resp, err := s.method.Patch(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Comment{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Notifications returns a list of notifications on a comment.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-comment-notifications
+func (s *IssueService) Notifications(ctx context.Context, issueIDOrKey string, commentID int) ([]*model.Notification, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID), "notifications")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.Notification{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Notify sends notifications for a comment.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-comment-notification
+func (s *IssueService) Notify(ctx context.Context, issueIDOrKey string, commentID int, userIDs []int) (*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	option := &core.OptionService{}
+	form := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamNotifiedUserIDs,
+	}
+	if err := core.ApplyOptions(form, validTypes, option.WithNotifiedUserIDs(userIDs)); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID), "notifications")
+	resp, err := s.method.Post(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Comment{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructor
+// ──────────────────────────────────────────────────────────────
+
+// NewIssueService creates and returns a new comment IssueService.
+func NewIssueService(method *core.Method) *IssueService {
+	return &IssueService{method: method}
+}

--- a/internal/comment/service.go
+++ b/internal/comment/service.go
@@ -161,7 +161,7 @@ func (s *IssueService) Delete(ctx context.Context, issueIDOrKey string, commentI
 // Update updates a comment on an issue.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-comment
-func (s *IssueService) Update(ctx context.Context, issueIDOrKey string, commentID int, option core.RequestOption) (*model.Comment, error) {
+func (s *IssueService) Update(ctx context.Context, issueIDOrKey string, commentID int, content string) (*model.Comment, error) {
 	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
 		return nil, err
 	}
@@ -173,6 +173,7 @@ func (s *IssueService) Update(ctx context.Context, issueIDOrKey string, commentI
 	validTypes := []core.APIParamOptionType{
 		core.ParamContent,
 	}
+	option := (&core.OptionService{}).WithContent(content)
 	if err := core.ApplyOptions(form, validTypes, option); err != nil {
 		return nil, err
 	}

--- a/internal/comment/service_test.go
+++ b/internal/comment/service_test.go
@@ -493,12 +493,10 @@ func TestIssueCommentService_Delete(t *testing.T) {
 }
 
 func TestIssueCommentService_Update(t *testing.T) {
-	o := &core.OptionService{}
-
 	cases := map[string]struct {
 		issueIDOrKey string
 		commentID    int
-		option       core.RequestOption
+		content      string
 
 		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
@@ -508,7 +506,7 @@ func TestIssueCommentService_Update(t *testing.T) {
 		"success": {
 			issueIDOrKey: "PRJ-1",
 			commentID:    42,
-			option:       o.WithContent("Updated content."),
+			content:      "Updated content.",
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1/comments/42", spath)
 				assert.Equal(t, "Updated content.", form.Get("content"))
@@ -522,25 +520,19 @@ func TestIssueCommentService_Update(t *testing.T) {
 		"error-empty-issueIDOrKey": {
 			issueIDOrKey: "",
 			commentID:    1,
-			option:       o.WithContent("x"),
+			content:      "x",
 			wantErrType:  &core.ValidationError{},
 		},
 		"error-invalid-commentID": {
 			issueIDOrKey: "PRJ-1",
 			commentID:    0,
-			option:       o.WithContent("x"),
+			content:      "x",
 			wantErrType:  &core.ValidationError{},
-		},
-		"error-option-invalid-type": {
-			issueIDOrKey: "PRJ-1",
-			commentID:    42,
-			option:       mock.NewInvalidTypeOption(),
-			wantErrType:  &core.InvalidOptionKeyError{},
 		},
 		"error-client-network": {
 			issueIDOrKey: "PRJ-1",
 			commentID:    42,
-			option:       o.WithContent("x"),
+			content:      "x",
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("network error")
 			},
@@ -549,7 +541,7 @@ func TestIssueCommentService_Update(t *testing.T) {
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
 			commentID:    42,
-			option:       o.WithContent("x"),
+			content:      "x",
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -571,7 +563,7 @@ func TestIssueCommentService_Update(t *testing.T) {
 
 			s := comment.NewIssueService(method)
 
-			got, err := s.Update(context.Background(), tc.issueIDOrKey, tc.commentID, tc.option)
+			got, err := s.Update(context.Background(), tc.issueIDOrKey, tc.commentID, tc.content)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)

--- a/internal/comment/service_test.go
+++ b/internal/comment/service_test.go
@@ -529,6 +529,13 @@ func TestIssueCommentService_Update(t *testing.T) {
 			content:      "x",
 			wantErrType:  &core.ValidationError{},
 		},
+		"error-empty-comment": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    1,
+			content:      "",
+			wantErrType:  &core.ValidationError{},
+		},
+
 		"error-client-network": {
 			issueIDOrKey: "PRJ-1",
 			commentID:    42,

--- a/internal/comment/service_test.go
+++ b/internal/comment/service_test.go
@@ -1,0 +1,749 @@
+package comment_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nattokin/go-backlog/internal/comment"
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
+)
+
+func TestIssueCommentService_All(t *testing.T) {
+	o := &core.OptionService{}
+
+	cases := map[string]struct {
+		issueIDOrKey string
+		opts         []core.RequestOption
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantIDs     []int
+	}{
+		"success-no-options": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.ListJSON))),
+				}, nil
+			},
+			wantIDs: []int{1, 2},
+		},
+		"success-by-numeric-id": {
+			issueIDOrKey: "1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/1/comments", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.ListJSON))),
+				}, nil
+			},
+			wantIDs: []int{1, 2},
+		},
+		"success-with-count-and-order": {
+			issueIDOrKey: "PRJ-1",
+			opts: []core.RequestOption{
+				o.WithCount(20),
+				o.WithOrder("asc"),
+			},
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments", spath)
+				assert.Equal(t, "20", query.Get("count"))
+				assert.Equal(t, "asc", query.Get("order"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.ListJSON))),
+				}, nil
+			},
+			wantIDs: []int{1, 2},
+		},
+		"success-with-minID-maxID": {
+			issueIDOrKey: "PRJ-1",
+			opts: []core.RequestOption{
+				o.WithMinID(10),
+				o.WithMaxID(100),
+			},
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments", spath)
+				assert.Equal(t, "10", query.Get("minId"))
+				assert.Equal(t, "100", query.Get("maxId"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.ListJSON))),
+				}, nil
+			},
+			wantIDs: []int{1, 2},
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-zero-issueIDOrKey": {
+			issueIDOrKey: "0",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-option-invalid-type": {
+			issueIDOrKey: "PRJ-1",
+			opts:         []core.RequestOption{mock.NewInvalidTypeOption()},
+			wantErrType:  &core.InvalidOptionKeyError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := comment.NewIssueService(method)
+
+			got, err := s.All(context.Background(), tc.issueIDOrKey, tc.opts...)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Len(t, got, len(tc.wantIDs))
+			for i := range got {
+				assert.Equal(t, tc.wantIDs[i], got[i].ID)
+			}
+		})
+	}
+}
+
+func TestIssueCommentService_Add(t *testing.T) {
+	o := &core.OptionService{}
+
+	cases := map[string]struct {
+		issueIDOrKey string
+		content      string
+		opts         []core.RequestOption
+
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantID      int
+	}{
+		"success-required-only": {
+			issueIDOrKey: "PRJ-1",
+			content:      "This is a comment.",
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments", spath)
+				assert.Equal(t, "This is a comment.", form.Get("content"))
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
+				}, nil
+			},
+			wantID: 1,
+		},
+		"success-with-notifiedUserIDs": {
+			issueIDOrKey: "PRJ-1",
+			content:      "Notifying users.",
+			opts:         []core.RequestOption{o.WithNotifiedUserIDs([]int{5, 6})},
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments", spath)
+				assert.Equal(t, "Notifying users.", form.Get("content"))
+				assert.Equal(t, []string{"5", "6"}, form["notifiedUserId[]"])
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
+				}, nil
+			},
+			wantID: 1,
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			content:      "x",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-zero-issueIDOrKey": {
+			issueIDOrKey: "0",
+			content:      "x",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-empty-content": {
+			issueIDOrKey: "PRJ-1",
+			content:      "",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-option-invalid-type": {
+			issueIDOrKey: "PRJ-1",
+			content:      "x",
+			opts:         []core.RequestOption{mock.NewInvalidTypeOption()},
+			wantErrType:  &core.InvalidOptionKeyError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			content:      "x",
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			content:      "x",
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPostFn != nil {
+				method.Post = tc.mockPostFn
+			}
+
+			s := comment.NewIssueService(method)
+
+			got, err := s.Add(context.Background(), tc.issueIDOrKey, tc.content, tc.opts...)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}
+
+func TestIssueCommentService_Count(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantCount   int
+	}{
+		"success": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments/count", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count":7}`))),
+				}, nil
+			},
+			wantCount: 7,
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-zero-issueIDOrKey": {
+			issueIDOrKey: "0",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := comment.NewIssueService(method)
+
+			count, err := s.Count(context.Background(), tc.issueIDOrKey)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Zero(t, count)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantCount, count)
+		})
+	}
+}
+
+func TestIssueCommentService_One(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+		commentID    int
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantID      int
+	}{
+		"success": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments/42", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
+				}, nil
+			},
+			wantID: 1,
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			commentID:    1,
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-invalid-commentID": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    0,
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := comment.NewIssueService(method)
+
+			got, err := s.One(context.Background(), tc.issueIDOrKey, tc.commentID)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}
+
+func TestIssueCommentService_Delete(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+		commentID    int
+
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantID      int
+	}{
+		"success": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments/42", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
+				}, nil
+			},
+			wantID: 1,
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			commentID:    1,
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-invalid-commentID": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    0,
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockDeleteFn != nil {
+				method.Delete = tc.mockDeleteFn
+			}
+
+			s := comment.NewIssueService(method)
+
+			got, err := s.Delete(context.Background(), tc.issueIDOrKey, tc.commentID)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}
+
+func TestIssueCommentService_Update(t *testing.T) {
+	o := &core.OptionService{}
+
+	cases := map[string]struct {
+		issueIDOrKey string
+		commentID    int
+		option       core.RequestOption
+
+		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantID      int
+	}{
+		"success": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			option:       o.WithContent("Updated content."),
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments/42", spath)
+				assert.Equal(t, "Updated content.", form.Get("content"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
+				}, nil
+			},
+			wantID: 1,
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			commentID:    1,
+			option:       o.WithContent("x"),
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-invalid-commentID": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    0,
+			option:       o.WithContent("x"),
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-option-invalid-type": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			option:       mock.NewInvalidTypeOption(),
+			wantErrType:  &core.InvalidOptionKeyError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			option:       o.WithContent("x"),
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			option:       o.WithContent("x"),
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPatchFn != nil {
+				method.Patch = tc.mockPatchFn
+			}
+
+			s := comment.NewIssueService(method)
+
+			got, err := s.Update(context.Background(), tc.issueIDOrKey, tc.commentID, tc.option)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}
+
+func TestIssueCommentService_Notifications(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+		commentID    int
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantLen     int
+	}{
+		"success": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments/42/notifications", spath)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(`[{"id":1},{"id":2}]`))),
+				}, nil
+			},
+			wantLen: 2,
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			commentID:    1,
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-invalid-commentID": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    0,
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := comment.NewIssueService(method)
+
+			got, err := s.Notifications(context.Background(), tc.issueIDOrKey, tc.commentID)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, got, tc.wantLen)
+		})
+	}
+}
+
+func TestIssueCommentService_Notify(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+		commentID    int
+		userIDs      []int
+
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantID      int
+	}{
+		"success": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			userIDs:      []int{5, 6},
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments/42/notifications", spath)
+				assert.Equal(t, []string{"5", "6"}, form["notifiedUserId[]"])
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
+				}, nil
+			},
+			wantID: 1,
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			commentID:    1,
+			userIDs:      []int{5},
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-invalid-commentID": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    0,
+			userIDs:      []int{5},
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-invalid-userID": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			userIDs:      []int{0},
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			userIDs:      []int{5},
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			userIDs:      []int{5},
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPostFn != nil {
+				method.Post = tc.mockPostFn
+			}
+
+			s := comment.NewIssueService(method)
+
+			got, err := s.Notify(context.Background(), tc.issueIDOrKey, tc.commentID, tc.userIDs)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}

--- a/internal/comment/service_test.go
+++ b/internal/comment/service_test.go
@@ -627,6 +627,17 @@ func TestIssueCommentService_Notifications(t *testing.T) {
 			},
 			wantErrType: errors.New(""),
 		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockGetFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
+				}, nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/comment/service_test.go
+++ b/internal/comment/service_test.go
@@ -535,7 +535,6 @@ func TestIssueCommentService_Update(t *testing.T) {
 			content:      "",
 			wantErrType:  &core.ValidationError{},
 		},
-
 		"error-client-network": {
 			issueIDOrKey: "PRJ-1",
 			commentID:    42,

--- a/internal/testutil/fixture/testdata_comment.go
+++ b/internal/testutil/fixture/testdata_comment.go
@@ -1,0 +1,117 @@
+package fixture
+
+import (
+	backlog "github.com/nattokin/go-backlog"
+)
+
+type commentFixtures struct {
+	SingleJSON string
+	Single     *backlog.Comment
+	ListJSON   string
+	List       []*backlog.Comment
+}
+
+// Comment provides test fixtures for Comment-related tests.
+var Comment = commentFixtures{
+	SingleJSON: `
+{
+    "id": 1,
+    "content": "This is a comment.",
+    "changeLog": [],
+    "createdUser": {
+        "id": 5686,
+        "userId": "takada",
+        "name": "takada",
+        "roleType": 2,
+        "lang": "ja",
+        "mailAddress": "takada@nulab.example"
+    },
+    "created": "2013-08-05T06:15:06Z",
+    "updated": "2013-08-05T06:15:06Z",
+    "stars": [],
+    "notifications": []
+}
+`,
+	Single: &backlog.Comment{
+		ID:      1,
+		Content: "This is a comment.",
+		CreatedUser: &backlog.User{
+			ID:          5686,
+			UserID:      "takada",
+			Name:        "takada",
+			RoleType:    backlog.RoleNormalUser,
+			Lang:        "ja",
+			MailAddress: "takada@nulab.example",
+		},
+		Created: mustTime("2013-08-05T06:15:06Z"),
+		Updated: mustTime("2013-08-05T06:15:06Z"),
+	},
+	ListJSON: `
+[
+    {
+        "id": 1,
+        "content": "This is a comment.",
+        "changeLog": [],
+        "createdUser": {
+            "id": 5686,
+            "userId": "takada",
+            "name": "takada",
+            "roleType": 2,
+            "lang": "ja",
+            "mailAddress": "takada@nulab.example"
+        },
+        "created": "2013-08-05T06:15:06Z",
+        "updated": "2013-08-05T06:15:06Z",
+        "stars": [],
+        "notifications": []
+    },
+    {
+        "id": 2,
+        "content": "Second comment.",
+        "changeLog": [],
+        "createdUser": {
+            "id": 5686,
+            "userId": "takada",
+            "name": "takada",
+            "roleType": 2,
+            "lang": "ja",
+            "mailAddress": "takada@nulab.example"
+        },
+        "created": "2013-08-06T06:15:06Z",
+        "updated": "2013-08-06T06:15:06Z",
+        "stars": [],
+        "notifications": []
+    }
+]
+`,
+	List: []*backlog.Comment{
+		{
+			ID:      1,
+			Content: "This is a comment.",
+			CreatedUser: &backlog.User{
+				ID:          5686,
+				UserID:      "takada",
+				Name:        "takada",
+				RoleType:    backlog.RoleNormalUser,
+				Lang:        "ja",
+				MailAddress: "takada@nulab.example",
+			},
+			Created: mustTime("2013-08-05T06:15:06Z"),
+			Updated: mustTime("2013-08-05T06:15:06Z"),
+		},
+		{
+			ID:      2,
+			Content: "Second comment.",
+			CreatedUser: &backlog.User{
+				ID:          5686,
+				UserID:      "takada",
+				Name:        "takada",
+				RoleType:    backlog.RoleNormalUser,
+				Lang:        "ja",
+				MailAddress: "takada@nulab.example",
+			},
+			Created: mustTime("2013-08-06T06:15:06Z"),
+			Updated: mustTime("2013-08-06T06:15:06Z"),
+		},
+	},
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -16,6 +16,13 @@ func ValidateAttachmentID(attachmentID int) error {
 	return nil
 }
 
+func ValidateCommentID(commentID int) error {
+	if commentID < 1 {
+		return core.NewValidationError("commentID must not be less than 1")
+	}
+	return nil
+}
+
 func ValidateIssueIDOrKey(issueIDOrKey string) error {
 	if issueIDOrKey == "" {
 		return core.NewValidationError("issueIDOrKey must not be empty")

--- a/issue.go
+++ b/issue.go
@@ -300,8 +300,8 @@ func (s *IssueCommentService) Delete(ctx context.Context, issueIDOrKey string, c
 // Update updates a comment on an issue.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-comment
-func (s *IssueCommentService) Update(ctx context.Context, issueIDOrKey string, commentID int, option RequestOption) (*Comment, error) {
-	v, err := s.base.Update(ctx, issueIDOrKey, commentID, option)
+func (s *IssueCommentService) Update(ctx context.Context, issueIDOrKey string, commentID int, content string) (*Comment, error) {
+	v, err := s.base.Update(ctx, issueIDOrKey, commentID, content)
 	return commentFromModel(v), convertError(err)
 }
 

--- a/issue.go
+++ b/issue.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/nattokin/go-backlog/internal/attachment"
+	"github.com/nattokin/go-backlog/internal/comment"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/issue"
 	"github.com/nattokin/go-backlog/internal/model"
@@ -83,6 +84,7 @@ type IssueService struct {
 	base *issue.Service
 
 	Attachment *IssueAttachmentService
+	Comment    *IssueCommentService
 	SharedFile *IssueSharedFileService
 	Star       *IssueStarService
 
@@ -231,6 +233,132 @@ func (s *IssueAttachmentService) List(ctx context.Context, issueIDOrKey string) 
 func (s *IssueAttachmentService) Remove(ctx context.Context, issueIDOrKey string, attachmentID int) (*Attachment, error) {
 	v, err := s.base.Remove(ctx, issueIDOrKey, attachmentID)
 	return attachmentFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  IssueCommentService
+// ──────────────────────────────────────────────────────────────
+
+// IssueCommentService handles communication with the issue comment-related methods of the Backlog API.
+type IssueCommentService struct {
+	base   *comment.IssueService
+	Option *IssueCommentOptionService
+}
+
+// All returns a list of comments on an issue.
+//
+// This method supports options returned by methods in "*Client.Issue.Comment.Option",
+// such as:
+//   - WithMinID
+//   - WithMaxID
+//   - WithCount
+//   - WithOrder
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-comment-list
+func (s *IssueCommentService) All(ctx context.Context, issueIDOrKey string, opts ...RequestOption) ([]*Comment, error) {
+	v, err := s.base.All(ctx, issueIDOrKey, toCoreOptions(opts)...)
+	return commentsFromModel(v), convertError(err)
+}
+
+// Add adds a comment to an issue.
+//
+// This method supports options returned by methods in "*Client.Issue.Comment.Option",
+// such as:
+//   - WithNotifiedUserIDs
+//   - WithAttachmentIDs
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-comment
+func (s *IssueCommentService) Add(ctx context.Context, issueIDOrKey string, content string, opts ...RequestOption) (*Comment, error) {
+	v, err := s.base.Add(ctx, issueIDOrKey, content, toCoreOptions(opts)...)
+	return commentFromModel(v), convertError(err)
+}
+
+// Count returns the number of comments on an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-comment
+func (s *IssueCommentService) Count(ctx context.Context, issueIDOrKey string) (int, error) {
+	count, err := s.base.Count(ctx, issueIDOrKey)
+	return count, convertError(err)
+}
+
+// One returns information about a specific comment.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-comment
+func (s *IssueCommentService) One(ctx context.Context, issueIDOrKey string, commentID int) (*Comment, error) {
+	v, err := s.base.One(ctx, issueIDOrKey, commentID)
+	return commentFromModel(v), convertError(err)
+}
+
+// Delete deletes a comment from an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-comment
+func (s *IssueCommentService) Delete(ctx context.Context, issueIDOrKey string, commentID int) (*Comment, error) {
+	v, err := s.base.Delete(ctx, issueIDOrKey, commentID)
+	return commentFromModel(v), convertError(err)
+}
+
+// Update updates a comment on an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-comment
+func (s *IssueCommentService) Update(ctx context.Context, issueIDOrKey string, commentID int, option RequestOption) (*Comment, error) {
+	v, err := s.base.Update(ctx, issueIDOrKey, commentID, option)
+	return commentFromModel(v), convertError(err)
+}
+
+// Notifications returns a list of notifications on a comment.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-comment-notifications
+func (s *IssueCommentService) Notifications(ctx context.Context, issueIDOrKey string, commentID int) ([]*Notification, error) {
+	v, err := s.base.Notifications(ctx, issueIDOrKey, commentID)
+	return notificationsFromModel(v), convertError(err)
+}
+
+// Notify sends notifications for a comment.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-comment-notification
+func (s *IssueCommentService) Notify(ctx context.Context, issueIDOrKey string, commentID int, userIDs []int) (*Comment, error) {
+	v, err := s.base.Notify(ctx, issueIDOrKey, commentID, userIDs)
+	return commentFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  IssueCommentOptionService
+// ──────────────────────────────────────────────────────────────
+
+// IssueCommentOptionService provides a domain-specific set of option builders
+// for operations within the IssueCommentService.
+type IssueCommentOptionService struct {
+	base *core.OptionService
+}
+
+// WithCount sets the number of comments to retrieve (1-100).
+func (s *IssueCommentOptionService) WithCount(count int) RequestOption {
+	return s.base.WithCount(count)
+}
+
+// WithMaxID filters comments with ID at or below the given value.
+func (s *IssueCommentOptionService) WithMaxID(id int) RequestOption {
+	return s.base.WithMaxID(id)
+}
+
+// WithMinID filters comments with ID at or above the given value.
+func (s *IssueCommentOptionService) WithMinID(id int) RequestOption {
+	return s.base.WithMinID(id)
+}
+
+// WithOrder sets the sort order of results.
+func (s *IssueCommentOptionService) WithOrder(order Order) RequestOption {
+	return s.base.WithOrder(model.Order(order))
+}
+
+// WithNotifiedUserIDs returns an option to set multiple `notifiedUserId[]` parameters.
+func (s *IssueCommentOptionService) WithNotifiedUserIDs(ids []int) RequestOption {
+	return s.base.WithNotifiedUserIDs(ids)
+}
+
+// WithAttachmentIDs returns an option to set multiple `attachmentId[]` parameters.
+func (s *IssueCommentOptionService) WithAttachmentIDs(ids []int) RequestOption {
+	return s.base.WithAttachmentIDs(ids)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -525,6 +653,7 @@ func newIssueService(method *core.Method, option *core.OptionService) *IssueServ
 		base: issue.NewService(method),
 
 		Attachment: newIssueAttachmentService(method),
+		Comment:    newIssueCommentService(method, option),
 		SharedFile: newIssueSharedFileService(method),
 		Star:       newIssueStarService(method, option),
 
@@ -535,6 +664,13 @@ func newIssueService(method *core.Method, option *core.OptionService) *IssueServ
 func newIssueAttachmentService(method *core.Method) *IssueAttachmentService {
 	return &IssueAttachmentService{
 		base: attachment.NewIssueService(method),
+	}
+}
+
+func newIssueCommentService(method *core.Method, option *core.OptionService) *IssueCommentService {
+	return &IssueCommentService{
+		base:   comment.NewIssueService(method),
+		Option: &IssueCommentOptionService{base: option},
 	}
 }
 
@@ -609,6 +745,28 @@ func versionsFromModel(m []*model.Version) []*Version {
 	result := make([]*Version, len(m))
 	for i, v := range m {
 		result[i] = versionFromModel(v)
+	}
+	return result
+}
+
+func commentsFromModel(m []*model.Comment) []*Comment {
+	if m == nil {
+		return nil
+	}
+	result := make([]*Comment, len(m))
+	for i, v := range m {
+		result[i] = commentFromModel(v)
+	}
+	return result
+}
+
+func notificationsFromModel(m []*model.Notification) []*Notification {
+	if m == nil {
+		return nil
+	}
+	result := make([]*Notification, len(m))
+	for i, v := range m {
+		result[i] = notificationFromModel(v)
 	}
 	return result
 }

--- a/issue_test.go
+++ b/issue_test.go
@@ -316,6 +316,244 @@ func TestIssueAttachmentService(t *testing.T) {
 	}
 }
 
+func TestIssueCommentService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"All": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1/comments", req.URL.Path)
+				return newJSONResponse(fixture.Comment.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Comment.All(ctx, "PRJ-1")
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, 1, got[0].ID)
+				assert.Equal(t, 2, got[1].ID)
+			},
+		},
+		"All/with-options": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1/comments", req.URL.Path)
+				assert.Equal(t, "20", req.URL.Query().Get("count"))
+				assert.Equal(t, "asc", req.URL.Query().Get("order"))
+				return newJSONResponse(fixture.Comment.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Comment.All(ctx, "PRJ-1",
+					c.Issue.Comment.Option.WithCount(20),
+					c.Issue.Comment.Option.WithOrder(backlog.OrderAsc),
+				)
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+			},
+		},
+		"All/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.Comment.All(ctx, "PRJ-1")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Add": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1/comments", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "This is a comment.", req.PostForm.Get("content"))
+				return newCreatedJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Comment.Add(ctx, "PRJ-1", "This is a comment.")
+				require.NoError(t, err)
+				assert.Equal(t, 1, got.ID)
+				assert.Equal(t, "This is a comment.", got.Content)
+			},
+		},
+		"Add/with-options": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1/comments", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "Notifying users.", req.PostForm.Get("content"))
+				assert.Equal(t, []string{"5", "6"}, req.PostForm["notifiedUserId[]"])
+				return newCreatedJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Comment.Add(ctx, "PRJ-1", "Notifying users.",
+					c.Issue.Comment.Option.WithNotifiedUserIDs([]int{5, 6}),
+				)
+				require.NoError(t, err)
+				assert.Equal(t, 1, got.ID)
+			},
+		},
+		"Add/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.Comment.Add(ctx, "PRJ-1", "This is a comment.")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Count": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/count", req.URL.Path)
+				return newJSONResponse(`{"count":7}`), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Comment.Count(ctx, "PRJ-1")
+				require.NoError(t, err)
+				assert.Equal(t, 7, got)
+			},
+		},
+		"Count/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.Comment.Count(ctx, "PRJ-1")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"One": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/42", req.URL.Path)
+				return newJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Comment.One(ctx, "PRJ-1", 42)
+				require.NoError(t, err)
+				assert.Equal(t, 1, got.ID)
+				assert.Equal(t, "This is a comment.", got.Content)
+			},
+		},
+		"One/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.Comment.One(ctx, "PRJ-1", 42)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Delete": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/42", req.URL.Path)
+				return newJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Comment.Delete(ctx, "PRJ-1", 42)
+				require.NoError(t, err)
+				assert.Equal(t, 1, got.ID)
+			},
+		},
+		"Delete/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.Comment.Delete(ctx, "PRJ-1", 42)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Update": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPatch, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/42", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "Updated content.", req.PostForm.Get("content"))
+				return newJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Comment.Update(ctx, "PRJ-1", 42,
+					c.Issue.Comment.Option.WithContent("Updated content."),
+				)
+				require.NoError(t, err)
+				assert.Equal(t, 1, got.ID)
+			},
+		},
+		"Update/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.Comment.Update(ctx, "PRJ-1", 42,
+					c.Issue.Comment.Option.WithContent("Updated content."),
+				)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Notifications": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/42/notifications", req.URL.Path)
+				return newJSONResponse(`[{"id":1},{"id":2}]`), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Comment.Notifications(ctx, "PRJ-1", 42)
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, 1, got[0].ID)
+				assert.Equal(t, 2, got[1].ID)
+			},
+		},
+		"Notifications/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.Comment.Notifications(ctx, "PRJ-1", 42)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Notify": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/42/notifications", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, []string{"5", "6"}, req.PostForm["notifiedUserId[]"])
+				return newJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Comment.Notify(ctx, "PRJ-1", 42, []int{5, 6})
+				require.NoError(t, err)
+				assert.Equal(t, 1, got.ID)
+			},
+		},
+		"Notify/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.Comment.Notify(ctx, "PRJ-1", 42, []int{5, 6})
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}
+
 func TestIssueSharedFileService(t *testing.T) {
 	ctx := context.Background()
 
@@ -534,4 +772,38 @@ func TestIssueOptionService(t *testing.T) {
 			assert.Equal(t, tc.wantKey, tc.option.Key())
 		})
 	}
+}
+
+func TestIssueCommentOptionService(t *testing.T) {
+	c, err := backlog.NewClient("https://example.backlog.com", "token")
+	require.NoError(t, err)
+	s := c.Issue.Comment.Option
+
+	cases := map[string]struct {
+		option  backlog.RequestOption
+		wantKey string
+	}{
+		"WithCount":           {option: s.WithCount(20), wantKey: core.ParamCount.Value()},
+		"WithMaxID":           {option: s.WithMaxID(100), wantKey: core.ParamMaxID.Value()},
+		"WithMinID":           {option: s.WithMinID(10), wantKey: core.ParamMinID.Value()},
+		"WithOrder":           {option: s.WithOrder(backlog.OrderAsc), wantKey: core.ParamOrder.Value()},
+		"WithNotifiedUserIDs": {option: s.WithNotifiedUserIDs([]int{1}), wantKey: core.ParamNotifiedUserIDs.Value()},
+		"WithAttachmentIDs":   {option: s.WithAttachmentIDs([]int{1}), wantKey: core.ParamAttachmentIDs.Value()},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.wantKey, tc.option.Key())
+		})
+	}
+}
+
+func TestIssueCommentOptionService_WithContent(t *testing.T) {
+	c, err := backlog.NewClient("https://example.backlog.com", "token")
+	require.NoError(t, err)
+	s := c.Issue.Comment.Option
+
+	opt := s.WithContent("Updated content.")
+	assert.Equal(t, core.ParamContent.Value(), opt.Key())
 }

--- a/issue_test.go
+++ b/issue_test.go
@@ -477,9 +477,7 @@ func TestIssueCommentService(t *testing.T) {
 				return newJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Issue.Comment.Update(ctx, "PRJ-1", 42,
-					c.Issue.Comment.Option.WithContent("Updated content."),
-				)
+				got, err := c.Issue.Comment.Update(ctx, "PRJ-1", 42, "Updated content.")
 				require.NoError(t, err)
 				assert.Equal(t, 1, got.ID)
 			},
@@ -487,9 +485,7 @@ func TestIssueCommentService(t *testing.T) {
 		"Update/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Issue.Comment.Update(ctx, "PRJ-1", 42,
-					c.Issue.Comment.Option.WithContent("Updated content."),
-				)
+				_, err := c.Issue.Comment.Update(ctx, "PRJ-1", 42, "Updated content.")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))
@@ -797,13 +793,4 @@ func TestIssueCommentOptionService(t *testing.T) {
 			assert.Equal(t, tc.wantKey, tc.option.Key())
 		})
 	}
-}
-
-func TestIssueCommentOptionService_WithContent(t *testing.T) {
-	c, err := backlog.NewClient("https://example.backlog.com", "token")
-	require.NoError(t, err)
-	s := c.Issue.Comment.Option
-
-	opt := s.WithContent("Updated content.")
-	assert.Equal(t, core.ParamContent.Value(), opt.Key())
 }


### PR DESCRIPTION
## Summary

Implements `Issue.Comment` sub-service covering all 8 Comment API endpoints from #216.

## Changes

- Add `internal/comment/service.go` — `IssueService` with `All`, `Add`, `Count`, `One`, `Delete`, `Update`, `Notifications`, `Notify`
- Add `internal/comment/service_test.go` — full table-driven tests for all methods
- Add `internal/validate/validate.go` — add `ValidateCommentID`
- Add `internal/testutil/fixture/testdata_comment.go` — `Comment` fixture (SingleJSON, ListJSON, Single, List)
- Update `issue.go` — add `IssueCommentService` and `IssueCommentOptionService` to public API; wire into `newIssueService`

### Public API

```go
c.Issue.Comment.All(ctx, issueIDOrKey, opts...)           // Get Comment List
c.Issue.Comment.Add(ctx, issueIDOrKey, content, opts...)  // Add Comment
c.Issue.Comment.Count(ctx, issueIDOrKey)                  // Count Comment
c.Issue.Comment.One(ctx, issueIDOrKey, commentID)         // Get Comment
c.Issue.Comment.Delete(ctx, issueIDOrKey, commentID)      // Delete Comment
c.Issue.Comment.Update(ctx, issueIDOrKey, commentID, content) // Update Comment
c.Issue.Comment.Notifications(ctx, issueIDOrKey, commentID)      // Get List of Comment Notifications
c.Issue.Comment.Notify(ctx, issueIDOrKey, commentID, userIDs)    // Add Comment Notification
```

### Option builders (`c.Issue.Comment.Option`)

- `WithMinID`, `WithMaxID`, `WithCount`, `WithOrder` — for `All`
- `WithNotifiedUserIDs`, `WithAttachmentIDs` — for `Add`

Part of #216