### PR TITLE
refactor: add NewJSONResponse and NewCreatedJSONResponse to mock package

### DIFF
--- a/internal/activity/service_test.go
+++ b/internal/activity/service_test.go
@@ -1,10 +1,8 @@
 package activity_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -58,11 +56,7 @@ func TestProjectActivityService_List_invalidJson(t *testing.T) {
 
 	method := mock.NewMethod(t)
 	method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-		resp := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-		}
-		return resp, nil
+		return mock.NewJSONResponse(fixture.InvalidJSON), nil
 	}
 	s := activity.NewProjectService(method)
 
@@ -129,11 +123,7 @@ func TestSpaceActivityService_Get_invalidJson(t *testing.T) {
 
 	method := mock.NewMethod(t)
 	method.Get = func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-		resp := &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-		}
-		return resp, nil
+		return mock.NewJSONResponse(fixture.InvalidJSON), nil
 	}
 	s := activity.NewSpaceService(method)
 
@@ -313,12 +303,7 @@ func TestBaseActivityService_GetList(t *testing.T) {
 				assert.Equal(t, tc.want.maxID, query.Get("maxId"))
 				assert.Equal(t, tc.want.count, query.Get("count"))
 				assert.Equal(t, tc.want.order, query.Get("order"))
-
-				resp := &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Activity.ListJSON))),
-				}
-				return resp, nil
+				return mock.NewJSONResponse(fixture.Activity.ListJSON), nil
 			}
 			s := activity.NewSpaceService(method)
 

--- a/internal/attachment/service_issue_test.go
+++ b/internal/attachment/service_issue_test.go
@@ -1,10 +1,8 @@
 package attachment_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -32,13 +30,7 @@ func TestIssueAttachmentService_List(t *testing.T) {
 			want:         newTestAttachmentList(),
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/1234/attachments", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.Attachment.ListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 		},
 
@@ -60,12 +52,7 @@ func TestIssueAttachmentService_List(t *testing.T) {
 			issueIDOrKey: "1234",
 			expectError:  true,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}
@@ -117,13 +104,7 @@ func TestIssueAttachmentService_Remove(t *testing.T) {
 			want:         newTestAttachment(),
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/1234/attachments/8", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.Attachment.SingleJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.Attachment.SingleJSON), nil
 			},
 		},
 
@@ -155,12 +136,7 @@ func TestIssueAttachmentService_Remove(t *testing.T) {
 			attachmentID: 8,
 			expectError:  true,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}

--- a/internal/attachment/service_pullrequest_test.go
+++ b/internal/attachment/service_pullrequest_test.go
@@ -1,10 +1,8 @@
 package attachment_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -40,13 +38,7 @@ func TestPullRequestAttachmentService_List(t *testing.T) {
 					"projects/TEST/git/repositories/test/pullRequests/1234/attachments",
 					spath,
 				)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.Attachment.ListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 		},
 
@@ -90,12 +82,7 @@ func TestPullRequestAttachmentService_List(t *testing.T) {
 			prNumber:           10,
 			expectError:        true,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}
@@ -159,13 +146,7 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 					"projects/TEST/git/repositories/test/pullRequests/1234/attachments/8",
 					spath,
 				)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.Attachment.SingleJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.Attachment.SingleJSON), nil
 			},
 		},
 
@@ -223,12 +204,7 @@ func TestPullRequestAttachmentService_Remove(t *testing.T) {
 			attachmentID:       8,
 			expectError:        true,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}

--- a/internal/attachment/service_test.go
+++ b/internal/attachment/service_test.go
@@ -107,11 +107,7 @@ func TestSpaceAttachmentService_Upload(t *testing.T) {
 			mockUploadFn: func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
 				assert.Equal(t, "space/attachment", spath)
 				assert.Equal(t, "fpath", fileName)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Attachment.UploadJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Attachment.UploadJSON), nil
 			},
 		},
 
@@ -127,10 +123,7 @@ func TestSpaceAttachmentService_Upload(t *testing.T) {
 			fpath:       "fpath",
 			expectError: true,
 			mockUploadFn: func(ctx context.Context, spath, fileName string, r io.Reader) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}

--- a/internal/attachment/service_wiki_test.go
+++ b/internal/attachment/service_wiki_test.go
@@ -1,10 +1,8 @@
 package attachment_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -34,16 +32,9 @@ func TestWikiAttachmentService_Attach(t *testing.T) {
 			want:          newTestAttachmentSingleList(),
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/attachments", spath)
-
 				v := form
 				assert.Equal(t, []string{"2"}, v["attachmentId[]"])
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.Attachment.SingleListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.Attachment.SingleListJSON), nil
 			},
 		},
 
@@ -52,12 +43,7 @@ func TestWikiAttachmentService_Attach(t *testing.T) {
 			attachmentIDs: []int{2, 5},
 			want:          newTestAttachmentList(),
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.Attachment.ListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 		},
 
@@ -96,12 +82,7 @@ func TestWikiAttachmentService_Attach(t *testing.T) {
 			attachmentIDs: []int{2},
 			expectError:   true,
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}
@@ -151,13 +132,7 @@ func TestWikiAttachmentService_List(t *testing.T) {
 			want:   newTestAttachmentList(),
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/attachments", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.Attachment.ListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 		},
 
@@ -185,12 +160,7 @@ func TestWikiAttachmentService_List(t *testing.T) {
 			wikiID:      1234,
 			expectError: true,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}
@@ -242,13 +212,7 @@ func TestWikiAttachmentService_Remove(t *testing.T) {
 			want:         newTestAttachment(),
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/attachments/8", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.Attachment.SingleJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.Attachment.SingleJSON), nil
 			},
 		},
 
@@ -294,12 +258,7 @@ func TestWikiAttachmentService_Remove(t *testing.T) {
 			attachmentID: 8,
 			expectError:  true,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}

--- a/internal/comment/service_test.go
+++ b/internal/comment/service_test.go
@@ -1,11 +1,9 @@
 package comment_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -35,10 +33,7 @@ func TestIssueCommentService_All(t *testing.T) {
 			issueIDOrKey: "PRJ-1",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1/comments", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
 			},
 			wantIDs: []int{1, 2},
 		},
@@ -46,10 +41,7 @@ func TestIssueCommentService_All(t *testing.T) {
 			issueIDOrKey: "1",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/1/comments", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
 			},
 			wantIDs: []int{1, 2},
 		},
@@ -63,10 +55,7 @@ func TestIssueCommentService_All(t *testing.T) {
 				assert.Equal(t, "issues/PRJ-1/comments", spath)
 				assert.Equal(t, "20", query.Get("count"))
 				assert.Equal(t, "asc", query.Get("order"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
 			},
 			wantIDs: []int{1, 2},
 		},
@@ -80,10 +69,7 @@ func TestIssueCommentService_All(t *testing.T) {
 				assert.Equal(t, "issues/PRJ-1/comments", spath)
 				assert.Equal(t, "10", query.Get("minId"))
 				assert.Equal(t, "100", query.Get("maxId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
 			},
 			wantIDs: []int{1, 2},
 		},
@@ -110,10 +96,7 @@ func TestIssueCommentService_All(t *testing.T) {
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -168,10 +151,7 @@ func TestIssueCommentService_Add(t *testing.T) {
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1/comments", spath)
 				assert.Equal(t, "This is a comment.", form.Get("content"))
-				return &http.Response{
-					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
-				}, nil
+				return mock.NewCreatedJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -183,10 +163,7 @@ func TestIssueCommentService_Add(t *testing.T) {
 				assert.Equal(t, "issues/PRJ-1/comments", spath)
 				assert.Equal(t, "Notifying users.", form.Get("content"))
 				assert.Equal(t, []string{"5", "6"}, form["notifiedUserId[]"])
-				return &http.Response{
-					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
-				}, nil
+				return mock.NewCreatedJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -223,10 +200,7 @@ func TestIssueCommentService_Add(t *testing.T) {
 			issueIDOrKey: "PRJ-1",
 			content:      "x",
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -272,10 +246,7 @@ func TestIssueCommentService_Count(t *testing.T) {
 			issueIDOrKey: "PRJ-1",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1/comments/count", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count":7}`))),
-				}, nil
+				return mock.NewJSONResponse(`{"count":7}`), nil
 			},
 			wantCount: 7,
 		},
@@ -297,10 +268,7 @@ func TestIssueCommentService_Count(t *testing.T) {
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -347,10 +315,7 @@ func TestIssueCommentService_One(t *testing.T) {
 			commentID:    42,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1/comments/42", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -376,10 +341,7 @@ func TestIssueCommentService_One(t *testing.T) {
 			issueIDOrKey: "PRJ-1",
 			commentID:    42,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -427,10 +389,7 @@ func TestIssueCommentService_Delete(t *testing.T) {
 			commentID:    42,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1/comments/42", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -456,10 +415,7 @@ func TestIssueCommentService_Delete(t *testing.T) {
 			issueIDOrKey: "PRJ-1",
 			commentID:    42,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -510,10 +466,7 @@ func TestIssueCommentService_Update(t *testing.T) {
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1/comments/42", spath)
 				assert.Equal(t, "Updated content.", form.Get("content"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -549,10 +502,7 @@ func TestIssueCommentService_Update(t *testing.T) {
 			commentID:    42,
 			content:      "x",
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -600,10 +550,7 @@ func TestIssueCommentService_Notifications(t *testing.T) {
 			commentID:    42,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1/comments/42/notifications", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`[{"id":1},{"id":2}]`))),
-				}, nil
+				return mock.NewJSONResponse(`[{"id":1},{"id":2}]`), nil
 			},
 			wantLen: 2,
 		},
@@ -629,10 +576,7 @@ func TestIssueCommentService_Notifications(t *testing.T) {
 			issueIDOrKey: "PRJ-1",
 			commentID:    42,
 			mockGetFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -682,10 +626,7 @@ func TestIssueCommentService_Notify(t *testing.T) {
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1/comments/42/notifications", spath)
 				assert.Equal(t, []string{"5", "6"}, form["notifiedUserId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Comment.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -721,10 +662,7 @@ func TestIssueCommentService_Notify(t *testing.T) {
 			commentID:    42,
 			userIDs:      []int{5},
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},

--- a/internal/core/client_test.go
+++ b/internal/core/client_test.go
@@ -768,10 +768,7 @@ func makeClient(t *testing.T) (*core.Client, *httpCapture) {
 			captured.Header = req.Header
 			captured.Body = bodyBytes
 
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(`{}`)),
-			}, nil
+			return mock.NewJSONResponse(`{}`), nil
 		},
 	})
 

--- a/internal/history/service_test.go
+++ b/internal/history/service_test.go
@@ -1,10 +1,8 @@
 package history_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -30,12 +28,7 @@ func TestWikiHistoryService_List(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/history", spath)
 
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.WikiHistory.ListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.WikiHistory.ListJSON), nil
 			},
 		},
 
@@ -63,12 +56,7 @@ func TestWikiHistoryService_List(t *testing.T) {
 			wikiID:      1234,
 			expectError: true,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}

--- a/internal/issue/service_test.go
+++ b/internal/issue/service_test.go
@@ -1,11 +1,9 @@
 package issue_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -35,10 +33,7 @@ func TestIssueService_All(t *testing.T) {
 		"success-no-options": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			wantIDs: []int{1, 2},
 		},
@@ -47,10 +42,7 @@ func TestIssueService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues", spath)
 				assert.Equal(t, []string{"10", "20"}, query["projectId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			wantIDs: []int{1, 2},
 		},
@@ -59,10 +51,7 @@ func TestIssueService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues", spath)
 				assert.Equal(t, "bug", query.Get("keyword"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			wantIDs: []int{1, 2},
 		},
@@ -75,10 +64,7 @@ func TestIssueService_All(t *testing.T) {
 				assert.Equal(t, "issues", spath)
 				assert.Equal(t, "created", query.Get("sort"))
 				assert.Equal(t, "asc", query.Get("order"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			wantIDs: []int{1, 2},
 		},
@@ -91,10 +77,7 @@ func TestIssueService_All(t *testing.T) {
 				assert.Equal(t, "issues", spath)
 				assert.Equal(t, "50", query.Get("count"))
 				assert.Equal(t, "100", query.Get("offset"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			wantIDs: []int{1, 2},
 		},
@@ -107,10 +90,7 @@ func TestIssueService_All(t *testing.T) {
 				assert.Equal(t, "issues", spath)
 				assert.Equal(t, "2024-01-01", query.Get("createdSince"))
 				assert.Equal(t, "2024-12-31", query.Get("createdUntil"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			wantIDs: []int{1, 2},
 		},
@@ -119,10 +99,7 @@ func TestIssueService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues", spath)
 				assert.Equal(t, "1", query.Get("parentChild"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			wantIDs: []int{1, 2},
 		},
@@ -162,10 +139,7 @@ func TestIssueService_All(t *testing.T) {
 		},
 		"error-response-invalid-json": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -215,10 +189,7 @@ func TestIssueService_Count(t *testing.T) {
 		"success-no-options": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/count", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count":42}`))),
-				}, nil
+				return mock.NewJSONResponse(`{"count":42}`), nil
 			},
 			wantCount: 42,
 		},
@@ -227,10 +198,7 @@ func TestIssueService_Count(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/count", spath)
 				assert.Equal(t, []string{"10", "20"}, query["projectId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count":5}`))),
-				}, nil
+				return mock.NewJSONResponse(`{"count":5}`), nil
 			},
 			wantCount: 5,
 		},
@@ -239,10 +207,7 @@ func TestIssueService_Count(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/count", spath)
 				assert.Equal(t, "bug", query.Get("keyword"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count":3}`))),
-				}, nil
+				return mock.NewJSONResponse(`{"count":3}`), nil
 			},
 			wantCount: 3,
 		},
@@ -262,10 +227,7 @@ func TestIssueService_Count(t *testing.T) {
 		},
 		"error-response-invalid-json": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -310,10 +272,7 @@ func TestIssueService_One(t *testing.T) {
 			issueIDOrKey: "PRJ-1",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -321,10 +280,7 @@ func TestIssueService_One(t *testing.T) {
 			issueIDOrKey: "1",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/1", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -346,10 +302,7 @@ func TestIssueService_One(t *testing.T) {
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -408,10 +361,7 @@ func TestIssueService_Create(t *testing.T) {
 				assert.Equal(t, "New issue", form.Get("summary"))
 				assert.Equal(t, "2", form.Get("issueTypeId"))
 				assert.Equal(t, "3", form.Get("priorityId"))
-				return &http.Response{
-					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return mock.NewCreatedJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -436,10 +386,7 @@ func TestIssueService_Create(t *testing.T) {
 				assert.Equal(t, "5", form.Get("assigneeId"))
 				assert.Equal(t, "2024-06-01", form.Get("startDate"))
 				assert.Equal(t, "2024-06-30", form.Get("dueDate"))
-				return &http.Response{
-					StatusCode: http.StatusCreated,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return mock.NewCreatedJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -495,10 +442,7 @@ func TestIssueService_Create(t *testing.T) {
 			issueTypeID: 2,
 			priorityID:  3,
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -550,10 +494,7 @@ func TestIssueService_Update(t *testing.T) {
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1", spath)
 				assert.Equal(t, "Updated summary", form.Get("summary"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -571,10 +512,7 @@ func TestIssueService_Update(t *testing.T) {
 				assert.Equal(t, "2", form.Get("statusId"))
 				assert.Equal(t, "1", form.Get("resolutionId"))
 				assert.Equal(t, "5", form.Get("assigneeId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -584,10 +522,7 @@ func TestIssueService_Update(t *testing.T) {
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/1", spath)
 				assert.Equal(t, "updated desc", form.Get("description"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -623,10 +558,7 @@ func TestIssueService_Update(t *testing.T) {
 			issueIDOrKey: "PRJ-1",
 			option:       o.WithSummary("x"),
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -672,10 +604,7 @@ func TestIssueService_Delete(t *testing.T) {
 			issueIDOrKey: "PRJ-1",
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/PRJ-1", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -683,10 +612,7 @@ func TestIssueService_Delete(t *testing.T) {
 			issueIDOrKey: "1",
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/1", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Issue.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			wantID: 1,
 		},
@@ -708,10 +634,7 @@ func TestIssueService_Delete(t *testing.T) {
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -1,11 +1,9 @@
 package project_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -40,10 +38,7 @@ func TestProjectService_All(t *testing.T) {
 				assert.Equal(t, "projects", spath)
 				require.NotNil(t, query)
 				assert.Empty(t, query)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.ListJSON), nil
 			},
 
 			wantIDs:     []int{1, 2, 3},
@@ -60,10 +55,7 @@ func TestProjectService_All(t *testing.T) {
 				assert.Equal(t, "projects", spath)
 				assert.Equal(t, "false", query.Get("all"))
 				assert.Equal(t, "true", query.Get("archived"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.ListJSON), nil
 			},
 
 			wantIDs:     []int{1, 2, 3},
@@ -93,10 +85,7 @@ func TestProjectService_All(t *testing.T) {
 			opts: []core.RequestOption{},
 
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -148,10 +137,7 @@ func TestProjectService_One(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST", spath)
 				assert.Nil(t, query)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -162,10 +148,7 @@ func TestProjectService_One(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/6", spath)
 				assert.Nil(t, query)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -188,10 +171,7 @@ func TestProjectService_One(t *testing.T) {
 			projectIDOrKey: "TEST",
 
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -248,11 +228,7 @@ func TestProjectService_Create(t *testing.T) {
 				assert.NotNil(t, form)
 				assert.Equal(t, "TEST", form.Get("key"))
 				assert.Equal(t, "test", form.Get("name"))
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -268,11 +244,7 @@ func TestProjectService_Create(t *testing.T) {
 				assert.Equal(t, "", form.Get("subtaskingEnabled"))
 				assert.Equal(t, "", form.Get("projectLeaderCanEditProjectLeader"))
 				assert.Equal(t, "", form.Get("textFormattingRule"))
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -294,11 +266,7 @@ func TestProjectService_Create(t *testing.T) {
 				assert.Equal(t, "true", form.Get("subtaskingEnabled"))
 				assert.Equal(t, "true", form.Get("projectLeaderCanEditProjectLeader"))
 				assert.Equal(t, "backlog", form.Get("textFormattingRule"))
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -354,10 +322,7 @@ func TestProjectService_Create(t *testing.T) {
 			name: "test",
 
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -409,11 +374,7 @@ func TestProjectService_Update(t *testing.T) {
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST", spath)
 				assert.NotNil(t, form)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -424,11 +385,7 @@ func TestProjectService_Update(t *testing.T) {
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/1234", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -467,11 +424,7 @@ func TestProjectService_Update(t *testing.T) {
 				assert.Equal(t, "true", form.Get("projectLeaderCanEditProjectLeader"))
 				assert.Equal(t, "backlog", form.Get("textFormattingRule"))
 				assert.Equal(t, "true", form.Get("archived"))
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -509,10 +462,7 @@ func TestProjectService_Update(t *testing.T) {
 			projectIDOrKey: "TEST",
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -558,11 +508,7 @@ func TestProjectService_Delete(t *testing.T) {
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST", spath)
 				assert.NotNil(t, form)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -572,11 +518,7 @@ func TestProjectService_Delete(t *testing.T) {
 
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/1234", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Project.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -604,10 +546,7 @@ func TestProjectService_Delete(t *testing.T) {
 			projectIDOrKey: "TEST",
 
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -1,11 +1,9 @@
 package pullrequest_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -42,10 +40,7 @@ func TestPullRequestService_All(t *testing.T) {
 			repoIDOrName:   testRepo,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/PRJ/git/repositories/repo1/pullRequests", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.PullRequest.ListJSON), nil
 			},
 			wantNumbers: []int{1, 2},
 		},
@@ -55,10 +50,7 @@ func TestPullRequestService_All(t *testing.T) {
 			opts:           []core.RequestOption{o.WithStatusIDs([]int{1, 2})},
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, []string{"1", "2"}, query["statusId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.PullRequest.ListJSON), nil
 			},
 			wantNumbers: []int{1, 2},
 		},
@@ -72,10 +64,7 @@ func TestPullRequestService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "50", query.Get("count"))
 				assert.Equal(t, "10", query.Get("offset"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.PullRequest.ListJSON), nil
 			},
 			wantNumbers: []int{1, 2},
 		},
@@ -135,10 +124,7 @@ func TestPullRequestService_All(t *testing.T) {
 			projectIDOrKey: testProject,
 			repoIDOrName:   testRepo,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -191,10 +177,7 @@ func TestPullRequestService_Count(t *testing.T) {
 			repoIDOrName:   testRepo,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/PRJ/git/repositories/repo1/pullRequests/count", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count":5}`))),
-				}, nil
+				return mock.NewJSONResponse(`{"count":5}`), nil
 			},
 			wantCount: 5,
 		},
@@ -204,10 +187,7 @@ func TestPullRequestService_Count(t *testing.T) {
 			opts:           []core.RequestOption{o.WithAssigneeIDs([]int{10, 20})},
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, []string{"10", "20"}, query["assigneeId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count":2}`))),
-				}, nil
+				return mock.NewJSONResponse(`{"count":2}`), nil
 			},
 			wantCount: 2,
 		},
@@ -239,10 +219,7 @@ func TestPullRequestService_Count(t *testing.T) {
 			projectIDOrKey: testProject,
 			repoIDOrName:   testRepo,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -290,10 +267,7 @@ func TestPullRequestService_One(t *testing.T) {
 			prNumber:       1,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/PRJ/git/repositories/repo1/pullRequests/1", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			wantNumber: 1,
 		},
@@ -329,10 +303,7 @@ func TestPullRequestService_One(t *testing.T) {
 			repoIDOrName:   testRepo,
 			prNumber:       1,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -394,10 +365,7 @@ func TestPullRequestService_Create(t *testing.T) {
 				assert.Equal(t, "test description", form.Get("description"))
 				assert.Equal(t, "main", form.Get("base"))
 				assert.Equal(t, "feature/foo", form.Get("branch"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			wantNumber: 1,
 		},
@@ -417,10 +385,7 @@ func TestPullRequestService_Create(t *testing.T) {
 				assert.Equal(t, "5", form.Get("assigneeId"))
 				assert.Equal(t, "10", form.Get("issueId"))
 				assert.Equal(t, []string{"1", "2"}, form["notifiedUserId[]"])
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			wantNumber: 1,
 		},
@@ -509,10 +474,7 @@ func TestPullRequestService_Create(t *testing.T) {
 			base:           "main",
 			branch:         "feature/foo",
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -567,10 +529,7 @@ func TestPullRequestService_Update(t *testing.T) {
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/PRJ/git/repositories/repo1/pullRequests/1", spath)
 				assert.Equal(t, "Updated PR", form.Get("summary"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			wantNumber: 1,
 		},
@@ -583,10 +542,7 @@ func TestPullRequestService_Update(t *testing.T) {
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "Updated PR", form.Get("summary"))
 				assert.Equal(t, "looks good", form.Get("comment"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			wantNumber: 1,
 		},
@@ -597,10 +553,7 @@ func TestPullRequestService_Update(t *testing.T) {
 			option:         o.WithIssueID(42),
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "42", form.Get("issueId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.PullRequest.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			wantNumber: 1,
 		},
@@ -655,10 +608,7 @@ func TestPullRequestService_Update(t *testing.T) {
 			prNumber:       1,
 			option:         o.WithSummary("x"),
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},

--- a/internal/recentlyviewed/service_test.go
+++ b/internal/recentlyviewed/service_test.go
@@ -3,10 +3,8 @@ package recentlyviewed_test
 import (
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,13 +15,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
-
-func newJSONResponse(body string) *http.Response {
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(body)),
-	}
-}
 
 func TestService_ListIssues(t *testing.T) {
 	o := &core.OptionService{}
@@ -37,7 +28,7 @@ func TestService_ListIssues(t *testing.T) {
 		"success-no-options": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/myself/recentlyViewedIssues", spath)
-				return newJSONResponse(`[{"id":1},{"id":2}]`), nil
+				return mock.NewJSONResponse(`[{"id":1},{"id":2}]`), nil
 			},
 			wantLen: 2,
 		},
@@ -46,7 +37,7 @@ func TestService_ListIssues(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/myself/recentlyViewedIssues", spath)
 				assert.Equal(t, "5", query.Get("count"))
-				return newJSONResponse(`[{"id":1}]`), nil
+				return mock.NewJSONResponse(`[{"id":1}]`), nil
 			},
 			wantLen: 1,
 		},
@@ -54,7 +45,7 @@ func TestService_ListIssues(t *testing.T) {
 			opts: []core.RequestOption{o.WithOffset(10)},
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "10", query.Get("offset"))
-				return newJSONResponse(`[]`), nil
+				return mock.NewJSONResponse(`[]`), nil
 			},
 			wantLen: 0,
 		},
@@ -70,7 +61,7 @@ func TestService_ListIssues(t *testing.T) {
 		},
 		"error-json-decode": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return newJSONResponse(fixture.InvalidJSON), nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErr: true,
 		},
@@ -110,7 +101,7 @@ func TestService_AddIssue(t *testing.T) {
 			issueID: 1,
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/1/recentlyViewedIssues", spath)
-				return newJSONResponse(`{"id":1,"summary":"test issue"}`), nil
+				return mock.NewJSONResponse(`{"id":1,"summary":"test issue"}`), nil
 			},
 			wantID: 1,
 		},
@@ -128,7 +119,7 @@ func TestService_AddIssue(t *testing.T) {
 		"error-json-decode": {
 			issueID: 1,
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return newJSONResponse(fixture.InvalidJSON), nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErr: true,
 		},
@@ -169,7 +160,7 @@ func TestService_ListProjects(t *testing.T) {
 		"success-no-options": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/myself/recentlyViewedProjects", spath)
-				return newJSONResponse(`[{"id":1},{"id":2}]`), nil
+				return mock.NewJSONResponse(`[{"id":1},{"id":2}]`), nil
 			},
 			wantLen: 2,
 		},
@@ -177,7 +168,7 @@ func TestService_ListProjects(t *testing.T) {
 			opts: []core.RequestOption{o.WithCount(3)},
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "3", query.Get("count"))
-				return newJSONResponse(`[{"id":1}]`), nil
+				return mock.NewJSONResponse(`[{"id":1}]`), nil
 			},
 			wantLen: 1,
 		},
@@ -193,7 +184,7 @@ func TestService_ListProjects(t *testing.T) {
 		},
 		"error-json-decode": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return newJSONResponse(fixture.InvalidJSON), nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErr: true,
 		},
@@ -234,7 +225,7 @@ func TestService_ListWikis(t *testing.T) {
 		"success-no-options": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/myself/recentlyViewedWikis", spath)
-				return newJSONResponse(`[{"id":1},{"id":2}]`), nil
+				return mock.NewJSONResponse(`[{"id":1},{"id":2}]`), nil
 			},
 			wantLen: 2,
 		},
@@ -242,7 +233,7 @@ func TestService_ListWikis(t *testing.T) {
 			opts: []core.RequestOption{o.WithOrder("asc")},
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "asc", query.Get("order"))
-				return newJSONResponse(`[{"id":1}]`), nil
+				return mock.NewJSONResponse(`[{"id":1}]`), nil
 			},
 			wantLen: 1,
 		},
@@ -258,7 +249,7 @@ func TestService_ListWikis(t *testing.T) {
 		},
 		"error-json-decode": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return newJSONResponse(fixture.InvalidJSON), nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErr: true,
 		},
@@ -298,7 +289,7 @@ func TestService_AddWiki(t *testing.T) {
 			wikiID: 10,
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/10/recentlyViewedWikis", spath)
-				return newJSONResponse(`{"id":10,"name":"TestWiki"}`), nil
+				return mock.NewJSONResponse(`{"id":10,"name":"TestWiki"}`), nil
 			},
 			wantID: 10,
 		},
@@ -316,7 +307,7 @@ func TestService_AddWiki(t *testing.T) {
 		"error-json-decode": {
 			wikiID: 10,
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return newJSONResponse(fixture.InvalidJSON), nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErr: true,
 		},

--- a/internal/sharedfile/service_issue_test.go
+++ b/internal/sharedfile/service_issue_test.go
@@ -1,10 +1,8 @@
 package sharedfile_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -29,13 +27,7 @@ func TestIssueSharedFileService_List(t *testing.T) {
 			issueIDOrKey: "TEST-1",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/TEST-1/sharedFiles", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.SharedFile.ListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 		},
 
@@ -43,13 +35,7 @@ func TestIssueSharedFileService_List(t *testing.T) {
 			issueIDOrKey: "1234",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/1234/sharedFiles", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.SharedFile.ListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 		},
 
@@ -77,12 +63,7 @@ func TestIssueSharedFileService_List(t *testing.T) {
 			issueIDOrKey: "TEST-1",
 			expectError:  true,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}
@@ -133,13 +114,7 @@ func TestIssueSharedFileService_Link(t *testing.T) {
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/TEST-1/sharedFiles", spath)
 				assert.Equal(t, []string{"454403"}, form["fileId[]"])
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.SharedFile.SingleListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.SharedFile.SingleListJSON), nil
 			},
 		},
 
@@ -147,12 +122,7 @@ func TestIssueSharedFileService_Link(t *testing.T) {
 			issueIDOrKey: "TEST-1",
 			fileIDs:      []int{454403, 454404},
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.SharedFile.ListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 		},
 
@@ -191,12 +161,7 @@ func TestIssueSharedFileService_Link(t *testing.T) {
 			fileIDs:      []int{454403},
 			expectError:  true,
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}
@@ -243,13 +208,7 @@ func TestIssueSharedFileService_Unlink(t *testing.T) {
 			fileID:       454403,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues/TEST-1/sharedFiles/454403", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.SharedFile.SingleJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.SharedFile.SingleJSON), nil
 			},
 		},
 
@@ -295,12 +254,7 @@ func TestIssueSharedFileService_Unlink(t *testing.T) {
 			fileID:       454403,
 			expectError:  true,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}

--- a/internal/sharedfile/service_wiki_test.go
+++ b/internal/sharedfile/service_wiki_test.go
@@ -1,10 +1,8 @@
 package sharedfile_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -29,13 +27,7 @@ func TestWikiSharedFileService_List(t *testing.T) {
 			wikiID: 1234,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/sharedFiles", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.SharedFile.ListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 		},
 
@@ -63,12 +55,7 @@ func TestWikiSharedFileService_List(t *testing.T) {
 			wikiID:      1234,
 			expectError: true,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}
@@ -119,13 +106,7 @@ func TestWikiSharedFileService_Link(t *testing.T) {
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/sharedFiles", spath)
 				assert.Equal(t, []string{"454403"}, form["fileId[]"])
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.SharedFile.SingleListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.SharedFile.SingleListJSON), nil
 			},
 		},
 
@@ -133,12 +114,7 @@ func TestWikiSharedFileService_Link(t *testing.T) {
 			wikiID:  1,
 			fileIDs: []int{454403, 454404},
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.SharedFile.ListJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 		},
 
@@ -177,12 +153,7 @@ func TestWikiSharedFileService_Link(t *testing.T) {
 			fileIDs:     []int{454403},
 			expectError: true,
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}
@@ -229,13 +200,7 @@ func TestWikiSharedFileService_Unlink(t *testing.T) {
 			fileID: 454403,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/sharedFiles/454403", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.SharedFile.SingleJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.SharedFile.SingleJSON), nil
 			},
 		},
 
@@ -281,12 +246,7 @@ func TestWikiSharedFileService_Unlink(t *testing.T) {
 			fileID:      454403,
 			expectError: true,
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(fixture.InvalidJSON)),
-					),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 		},
 	}

--- a/internal/space/service_test.go
+++ b/internal/space/service_test.go
@@ -1,11 +1,9 @@
 package space_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -31,10 +29,7 @@ func TestSpaceService_One(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "space", spath)
 				assert.Nil(t, query)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.SpaceJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Space.SpaceJSON), nil
 			},
 			wantSpaceKey: "nulab",
 			wantName:     "Nulab Inc.",
@@ -49,10 +44,7 @@ func TestSpaceService_One(t *testing.T) {
 		"error-response-invalid-json": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "space", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -99,10 +91,7 @@ func TestSpaceService_DiskUsage(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "space/diskUsage", spath)
 				assert.Nil(t, query)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.DiskUsageJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Space.DiskUsageJSON), nil
 			},
 			wantCapacity:  1073741824,
 			wantIssue:     119511,
@@ -118,10 +107,7 @@ func TestSpaceService_DiskUsage(t *testing.T) {
 		"error-response-invalid-json": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "space/diskUsage", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -167,10 +153,7 @@ func TestSpaceService_Notification(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "space/notification", spath)
 				assert.Nil(t, query)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.NotificationJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Space.NotificationJSON), nil
 			},
 			wantContent: "Backlog is a project management tool.",
 		},
@@ -184,10 +167,7 @@ func TestSpaceService_Notification(t *testing.T) {
 		"error-response-invalid-json": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "space/notification", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},
@@ -234,10 +214,7 @@ func TestSpaceService_UpdateNotification(t *testing.T) {
 			mockPutFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "space/notification", spath)
 				assert.Equal(t, "Backlog is a project management tool.", form.Get("content"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Space.NotificationJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Space.NotificationJSON), nil
 			},
 			wantContent: "Backlog is a project management tool.",
 		},
@@ -258,10 +235,7 @@ func TestSpaceService_UpdateNotification(t *testing.T) {
 			content: "some content",
 			mockPutFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "space/notification", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErrType: &json.SyntaxError{},
 		},

--- a/internal/star/service_test.go
+++ b/internal/star/service_test.go
@@ -3,10 +3,8 @@ package star_test
 import (
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,13 +14,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/star"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
-
-func newJSONResponse(body string) *http.Response {
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(body)),
-	}
-}
 
 func newNoContentResponse() *http.Response {
 	return &http.Response{

--- a/internal/star/service_user_test.go
+++ b/internal/star/service_user_test.go
@@ -30,7 +30,7 @@ func TestUserStarService_List(t *testing.T) {
 			userID: 1,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1/stars", spath)
-				return newJSONResponse(`[{"id":10},{"id":20}]`), nil
+				return mock.NewJSONResponse(`[{"id":10},{"id":20}]`), nil
 			},
 			wantLen: 2,
 		},
@@ -40,7 +40,7 @@ func TestUserStarService_List(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/2/stars", spath)
 				assert.Equal(t, "5", query.Get("count"))
-				return newJSONResponse(`[{"id":1}]`), nil
+				return mock.NewJSONResponse(`[{"id":1}]`), nil
 			},
 			wantLen: 1,
 		},
@@ -63,7 +63,7 @@ func TestUserStarService_List(t *testing.T) {
 		"error-json-decode": {
 			userID: 1,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return newJSONResponse(fixture.InvalidJSON), nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErr: true,
 		},
@@ -104,7 +104,7 @@ func TestUserStarService_Count(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1/stars/count", spath)
 				assert.Nil(t, query)
-				return newJSONResponse(`{"count":42}`), nil
+				return mock.NewJSONResponse(`{"count":42}`), nil
 			},
 			wantCount: 42,
 		},
@@ -122,7 +122,7 @@ func TestUserStarService_Count(t *testing.T) {
 		"error-json-decode": {
 			userID: 1,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return newJSONResponse(fixture.InvalidJSON), nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErr: true,
 		},

--- a/internal/star/service_wiki_test.go
+++ b/internal/star/service_wiki_test.go
@@ -3,10 +3,8 @@ package star_test
 import (
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +27,7 @@ func TestWikiStarService_List(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34/stars", spath)
 				assert.Nil(t, query)
-				return newJSONResponse(fixture.Star.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Star.ListJSON), nil
 			},
 			wantLen: 2,
 		},
@@ -47,10 +45,7 @@ func TestWikiStarService_List(t *testing.T) {
 		"error-json-decode": {
 			wikiID: 34,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(fixture.InvalidJSON)),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 			wantErr: true,
 		},

--- a/internal/testutil/mock/mock.go
+++ b/internal/testutil/mock/mock.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -90,6 +91,30 @@ func NewInvalidTypeOption() *core.APIParamOption {
 		Type:      "invalid",
 		CheckFunc: func() error { return nil },
 		SetFunc:   func(_ url.Values) error { return nil },
+	}
+}
+
+// ──────────────────────────────────────────────────────────────
+//  HTTP response helpers
+// ──────────────────────────────────────────────────────────────
+
+// NewJSONResponse returns an HTTP 200 OK response with the given JSON string as body.
+// It allocates a fresh reader on each call so the body can only be consumed once,
+// matching the behaviour of a real HTTP response.
+func NewJSONResponse(json string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(json)),
+	}
+}
+
+// NewCreatedJSONResponse returns an HTTP 201 Created response with the given JSON string as body.
+// It allocates a fresh reader on each call so the body can only be consumed once,
+// matching the behaviour of a real HTTP response.
+func NewCreatedJSONResponse(json string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusCreated,
+		Body:       io.NopCloser(strings.NewReader(json)),
 	}
 }
 

--- a/internal/user/service_project_test.go
+++ b/internal/user/service_project_test.go
@@ -1,11 +1,9 @@
 package user_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -37,10 +35,7 @@ func TestProjectUserService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/users", spath)
 				assert.Equal(t, "false", query.Get("excludeGroupMembers"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 
 			wantUsers: []*model.User{
@@ -59,10 +54,7 @@ func TestProjectUserService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST2/users", spath)
 				assert.Equal(t, "true", query.Get("excludeGroupMembers"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 
 			wantUsers: []*model.User{
@@ -81,10 +73,7 @@ func TestProjectUserService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST3/users", spath)
 				assert.Equal(t, "false", query.Get("excludeGroupMembers"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 
 			wantUsers: []*model.User{
@@ -107,10 +96,7 @@ func TestProjectUserService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/users", spath)
 				assert.Equal(t, "false", query.Get("excludeGroupMembers"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -164,10 +150,7 @@ func TestProjectUserService_Add(t *testing.T) {
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantUser: &model.User{
@@ -195,10 +178,7 @@ func TestProjectUserService_Add(t *testing.T) {
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST2/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantUser: &model.User{
@@ -215,10 +195,7 @@ func TestProjectUserService_Add(t *testing.T) {
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST3/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -271,10 +248,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantUser: &model.User{
@@ -291,10 +265,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/1234/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantUser: &model.User{
@@ -323,10 +294,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST2/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantUser: &model.User{
@@ -343,10 +311,7 @@ func TestProjectUserService_Delete(t *testing.T) {
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST3/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -399,10 +364,7 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/administrators", spath)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantUser: &model.User{
@@ -430,10 +392,7 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST2/administrators", spath)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantUser: &model.User{
@@ -450,10 +409,7 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST3/administrators", spath)
 				assert.Equal(t, "1", form.Get("userId"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -1,11 +1,9 @@
 package user_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -35,10 +33,7 @@ func TestUserService_One(t *testing.T) {
 
 			mockGetFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantUser: &model.User{
@@ -53,10 +48,7 @@ func TestUserService_One(t *testing.T) {
 
 			mockGetFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/100", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
-				}, nil
+				return mock.NewJSONResponse(`{}`), nil
 			},
 
 			wantUser: &model.User{},
@@ -125,11 +117,7 @@ func TestUserService_Add(t *testing.T) {
 				assert.Equal(t, "admin", form.Get("name"))
 				assert.Equal(t, "eguchi@nulab.example", form.Get("mailAddress"))
 				assert.Equal(t, strconv.Itoa(int(model.RoleAdministrator)), form.Get("roleType"))
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantUser: &model.User{
@@ -206,10 +194,7 @@ func TestUserService_Add(t *testing.T) {
 			roleType:    1,
 
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -258,11 +243,7 @@ func TestUserService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users", spath)
 				assert.Nil(t, query)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 
 			wantLen: 4,
@@ -286,11 +267,7 @@ func TestUserService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users", spath)
 				assert.Nil(t, query)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -355,11 +332,7 @@ func TestUserService_Update(t *testing.T) {
 				assert.Equal(t, "admin", form.Get("name"))
 				assert.Equal(t, "eguchi@nulab.example", form.Get("mailAddress"))
 				assert.Equal(t, strconv.Itoa(int(model.RoleAdministrator)), form.Get("roleType"))
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantUser: &model.User{
@@ -379,11 +352,7 @@ func TestUserService_Update(t *testing.T) {
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1234", spath)
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -526,10 +495,7 @@ func TestUserService_Own(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/myself", spath)
 				assert.Nil(t, query)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantUser: &model.User{
@@ -552,10 +518,7 @@ func TestUserService_Own(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/myself", spath)
 				assert.Nil(t, query)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -605,10 +568,7 @@ func TestUserService_Delete(t *testing.T) {
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
 				assert.Nil(t, form)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -619,10 +579,7 @@ func TestUserService_Delete(t *testing.T) {
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/100", spath)
 				assert.Nil(t, form)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.User.SingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 
 			wantErrType: nil,
@@ -638,10 +595,7 @@ func TestUserService_Delete(t *testing.T) {
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1234", spath)
 				assert.Nil(t, form)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},

--- a/internal/wiki/service_test.go
+++ b/internal/wiki/service_test.go
@@ -1,11 +1,9 @@
 package wiki_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -44,11 +42,7 @@ func TestWikiService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis", spath)
 				assert.Equal(t, "103", query.Get("projectIdOrKey"))
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Wiki.ListJSON), nil
 			},
 
 			wantIDs:   []int{testWiki1ID, testWiki2ID},
@@ -65,11 +59,7 @@ func TestWikiService_All(t *testing.T) {
 				assert.Equal(t, "wikis", spath)
 				assert.Equal(t, "PRJ_KEY", query.Get("projectIdOrKey"))
 				assert.Equal(t, "test", query.Get("keyword"))
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Wiki.ListJSON), nil
 			},
 
 			wantIDs:   []int{testWiki1ID, testWiki2ID},
@@ -111,11 +101,7 @@ func TestWikiService_All(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis", spath)
 				assert.Equal(t, "1", query.Get("projectIdOrKey"))
-
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -169,10 +155,7 @@ func TestWikiService_Count(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/count", spath)
 				assert.Equal(t, "103", query.Get("projectIdOrKey"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count": 34}`))),
-				}, nil
+				return mock.NewJSONResponse(`{"count": 34}`), nil
 			},
 
 			wantCount: 34,
@@ -183,10 +166,7 @@ func TestWikiService_Count(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/count", spath)
 				assert.Equal(t, "PRJ_KEY", query.Get("projectIdOrKey"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(`{"count": 10}`))),
-				}, nil
+				return mock.NewJSONResponse(`{"count": 10}`), nil
 			},
 
 			wantCount: 10,
@@ -212,10 +192,7 @@ func TestWikiService_Count(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/count", spath)
 				assert.Equal(t, "1", query.Get("projectIdOrKey"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -264,10 +241,7 @@ func TestWikiService_One(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Nil(t, query)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 
 			wantWikiID:   34,
@@ -298,10 +272,7 @@ func TestWikiService_One(t *testing.T) {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1", spath)
 				assert.Nil(t, query)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -360,12 +331,7 @@ func TestWikiService_Create(t *testing.T) {
 				assert.Equal(t, "56", form.Get("projectId"))
 				assert.Equal(t, "Minimum Wiki Page", form.Get("name"))
 				assert.Equal(t, "This is a minimal wiki page.", form.Get("content"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(bytes.NewReader(
-						[]byte(fixture.Wiki.MinimumJSON),
-					)),
-				}, nil
+				return mock.NewJSONResponse(fixture.Wiki.MinimumJSON), nil
 			},
 
 			wantWiki: &model.Wiki{
@@ -386,12 +352,7 @@ func TestWikiService_Create(t *testing.T) {
 				assert.Equal(t, "Minimum Wiki Page", form.Get("name"))
 				assert.Equal(t, "This is a minimal wiki page.", form.Get("content"))
 				assert.Equal(t, "true", form.Get("mailNotify"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(bytes.NewReader(
-						[]byte(fixture.Wiki.MinimumJSON),
-					)),
-				}, nil
+				return mock.NewJSONResponse(fixture.Wiki.MinimumJSON), nil
 			},
 
 			wantWiki: &model.Wiki{
@@ -457,12 +418,7 @@ func TestWikiService_Create(t *testing.T) {
 				assert.Equal(t, "1", form.Get("projectId"))
 				assert.Equal(t, "Test", form.Get("name"))
 				assert.Equal(t, "content", form.Get("content"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(bytes.NewReader(
-						[]byte(fixture.InvalidJSON),
-					)),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -519,10 +475,7 @@ func TestWikiService_Update(t *testing.T) {
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Equal(t, "New Page Name", form.Get("name"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 
 			wantWiki: &model.Wiki{
@@ -538,10 +491,7 @@ func TestWikiService_Update(t *testing.T) {
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Equal(t, "Full Options Content", form.Get("content"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 
 			wantWiki: &model.Wiki{
@@ -561,10 +511,7 @@ func TestWikiService_Update(t *testing.T) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Equal(t, "Full Options Name", form.Get("name"))
 				assert.Equal(t, "true", form.Get("mailNotify"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 
 			wantWiki: &model.Wiki{
@@ -586,10 +533,7 @@ func TestWikiService_Update(t *testing.T) {
 				assert.Equal(t, "Full Options Name", form.Get("name"))
 				assert.Equal(t, "Full Options Content", form.Get("content"))
 				assert.Equal(t, "true", form.Get("mailNotify"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 
 			wantWiki: &model.Wiki{
@@ -640,10 +584,7 @@ func TestWikiService_Update(t *testing.T) {
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/14", spath)
 				assert.Equal(t, "New Name", form.Get("name"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},
@@ -699,10 +640,7 @@ func TestWikiService_Delete(t *testing.T) {
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Equal(t, "true", form.Get("mailNotify"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 
 			wantWikiID: 34,
@@ -712,10 +650,7 @@ func TestWikiService_Delete(t *testing.T) {
 
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Wiki.MaximumJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 
 			wantWikiID: 34,
@@ -753,10 +688,7 @@ func TestWikiService_Delete(t *testing.T) {
 
 			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/34", spath)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.InvalidJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
 			wantErrType: &json.SyntaxError{},


### PR DESCRIPTION
## Summary

Move HTTP response factory helpers from the root-level `mock_test.go` into
`internal/testutil/mock` so that internal packages can use them in their own
test files.

## Changes

- Add `NewJSONResponse` (HTTP 200) to `internal/testutil/mock/mock.go`
- Add `NewCreatedJSONResponse` (HTTP 201) to `internal/testutil/mock/mock.go`
- Add `strings` import to the mock package (required by the new helpers)

The helpers are placed in the existing `mock` package because they are HTTP
response factories that pair naturally with `MockDoer` and the other
HTTP-level test helpers already living there.