### PR TITLE
refactor: centralize mock HTTP response helpers

### DIFF
--- a/issue_test.go
+++ b/issue_test.go
@@ -15,6 +15,7 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
 func TestIssueService(t *testing.T) {
@@ -28,7 +29,7 @@ func TestIssueService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues", req.URL.Path)
-				return newJSONResponse(fixture.Issue.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.All(ctx)
@@ -44,7 +45,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues", req.URL.Path)
 				assert.Equal(t, "bug", req.URL.Query().Get("keyword"))
 				assert.Equal(t, []string{"10", "20"}, req.URL.Query()["projectId[]"])
-				return newJSONResponse(fixture.Issue.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.All(ctx,
@@ -68,7 +69,7 @@ func TestIssueService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/count", req.URL.Path)
-				return newJSONResponse(`{"count":5}`), nil
+				return mock.NewJSONResponse(`{"count":5}`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Count(ctx)
@@ -82,7 +83,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/count", req.URL.Path)
 				assert.Equal(t, "bug", req.URL.Query().Get("keyword"))
 				assert.Equal(t, []string{"10", "20"}, req.URL.Query()["projectId[]"])
-				return newJSONResponse(`{"count":2}`), nil
+				return mock.NewJSONResponse(`{"count":2}`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Count(ctx,
@@ -106,7 +107,7 @@ func TestIssueService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/PRJ-1", req.URL.Path)
-				return newJSONResponse(fixture.Issue.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.One(ctx, "PRJ-1")
@@ -134,7 +135,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "New issue", req.PostForm.Get("summary"))
 				assert.Equal(t, "2", req.PostForm.Get("issueTypeId"))
 				assert.Equal(t, "3", req.PostForm.Get("priorityId"))
-				return newCreatedJSONResponse(fixture.Issue.SingleJSON), nil
+				return mock.NewCreatedJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Create(ctx, 10, "New issue", 2, 3)
@@ -154,7 +155,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "3", req.PostForm.Get("priorityId"))
 				assert.Equal(t, "details here", req.PostForm.Get("description"))
 				assert.Equal(t, "5", req.PostForm.Get("assigneeId"))
-				return newCreatedJSONResponse(fixture.Issue.SingleJSON), nil
+				return mock.NewCreatedJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Create(ctx, 10, "New issue", 2, 3,
@@ -180,7 +181,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/PRJ-1", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
-				return newJSONResponse(fixture.Issue.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Update(ctx, "PRJ-1", c.Issue.Option.WithSummary("Updated summary"))
@@ -196,7 +197,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
 				assert.Equal(t, "2", req.PostForm.Get("statusId"))
 				assert.Equal(t, "1", req.PostForm.Get("resolutionId"))
-				return newJSONResponse(fixture.Issue.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Update(ctx, "PRJ-1",
@@ -221,7 +222,7 @@ func TestIssueService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/issues/PRJ-1", req.URL.Path)
-				return newJSONResponse(fixture.Issue.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Issue.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Delete(ctx, "PRJ-1")
@@ -263,7 +264,7 @@ func TestIssueAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/TEST-1/attachments", req.URL.Path)
-				return newJSONResponse(fixture.Attachment.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Attachment.List(ctx, "TEST-1")
@@ -286,7 +287,7 @@ func TestIssueAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/issues/TEST-1/attachments/8", req.URL.Path)
-				return newJSONResponse(fixture.Attachment.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Attachment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Attachment.Remove(ctx, "TEST-1", 8)
@@ -327,7 +328,7 @@ func TestIssueCommentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/PRJ-1/comments", req.URL.Path)
-				return newJSONResponse(fixture.Comment.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Comment.All(ctx, "PRJ-1")
@@ -343,7 +344,7 @@ func TestIssueCommentService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/PRJ-1/comments", req.URL.Path)
 				assert.Equal(t, "20", req.URL.Query().Get("count"))
 				assert.Equal(t, "asc", req.URL.Query().Get("order"))
-				return newJSONResponse(fixture.Comment.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Comment.All(ctx, "PRJ-1",
@@ -369,7 +370,7 @@ func TestIssueCommentService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/PRJ-1/comments", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "This is a comment.", req.PostForm.Get("content"))
-				return newCreatedJSONResponse(fixture.Comment.SingleJSON), nil
+				return mock.NewCreatedJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Comment.Add(ctx, "PRJ-1", "This is a comment.")
@@ -385,7 +386,7 @@ func TestIssueCommentService(t *testing.T) {
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "Notifying users.", req.PostForm.Get("content"))
 				assert.Equal(t, []string{"5", "6"}, req.PostForm["notifiedUserId[]"])
-				return newCreatedJSONResponse(fixture.Comment.SingleJSON), nil
+				return mock.NewCreatedJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Comment.Add(ctx, "PRJ-1", "Notifying users.",
@@ -408,7 +409,7 @@ func TestIssueCommentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/count", req.URL.Path)
-				return newJSONResponse(`{"count":7}`), nil
+				return mock.NewJSONResponse(`{"count":7}`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Comment.Count(ctx, "PRJ-1")
@@ -429,7 +430,7 @@ func TestIssueCommentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/42", req.URL.Path)
-				return newJSONResponse(fixture.Comment.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Comment.One(ctx, "PRJ-1", 42)
@@ -451,7 +452,7 @@ func TestIssueCommentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/42", req.URL.Path)
-				return newJSONResponse(fixture.Comment.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Comment.Delete(ctx, "PRJ-1", 42)
@@ -474,7 +475,7 @@ func TestIssueCommentService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/42", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "Updated content.", req.PostForm.Get("content"))
-				return newJSONResponse(fixture.Comment.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Comment.Update(ctx, "PRJ-1", 42, "Updated content.")
@@ -495,7 +496,7 @@ func TestIssueCommentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/42/notifications", req.URL.Path)
-				return newJSONResponse(`[{"id":1},{"id":2}]`), nil
+				return mock.NewJSONResponse(`[{"id":1},{"id":2}]`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Comment.Notifications(ctx, "PRJ-1", 42)
@@ -520,7 +521,7 @@ func TestIssueCommentService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/PRJ-1/comments/42/notifications", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, []string{"5", "6"}, req.PostForm["notifiedUserId[]"])
-				return newJSONResponse(fixture.Comment.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.Comment.Notify(ctx, "PRJ-1", 42, []int{5, 6})
@@ -561,7 +562,7 @@ func TestIssueSharedFileService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/TEST-1/sharedFiles", req.URL.Path)
-				return newJSONResponse(fixture.SharedFile.ListJSON), nil
+				return mock.NewJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.SharedFile.List(ctx, "TEST-1")
@@ -586,7 +587,7 @@ func TestIssueSharedFileService(t *testing.T) {
 				assert.Equal(t, "/api/v2/issues/TEST-1/sharedFiles", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, []string{"454403"}, req.PostForm["fileId[]"])
-				return newJSONResponse(fixture.SharedFile.SingleListJSON), nil
+				return mock.NewJSONResponse(fixture.SharedFile.SingleListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.SharedFile.Link(ctx, "TEST-1", []int{454403})
@@ -608,7 +609,7 @@ func TestIssueSharedFileService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/issues/TEST-1/sharedFiles/454403", req.URL.Path)
-				return newJSONResponse(fixture.SharedFile.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.SharedFile.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Issue.SharedFile.Unlink(ctx, "TEST-1", 454403)

--- a/mock_test.go
+++ b/mock_test.go
@@ -69,23 +69,3 @@ func newInternalServerErrorDoFunc() func(req *http.Request) (*http.Response, err
 		}, nil
 	}
 }
-
-// newJSONResponse returns an HTTP 200 OK response with the given JSON string as body.
-// It allocates a fresh reader on each call so the body can only be consumed once,
-// matching the behaviour of a real HTTP response.
-func newJSONResponse(json string) *http.Response {
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(json)),
-	}
-}
-
-// newCreatedJSONResponse returns an HTTP 201 Created response with the given JSON string as body.
-// It allocates a fresh reader on each call so the body can only be consumed once,
-// matching the behaviour of a real HTTP response.
-func newCreatedJSONResponse(json string) *http.Response {
-	return &http.Response{
-		StatusCode: http.StatusCreated,
-		Body:       io.NopCloser(strings.NewReader(json)),
-	}
-}

--- a/project_test.go
+++ b/project_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
 func TestProjectService(t *testing.T) {
@@ -27,7 +28,7 @@ func TestProjectService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects", req.URL.Path)
 				assert.Equal(t, "true", req.URL.Query().Get("archived"))
-				return newJSONResponse(fixture.Project.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Project.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.All(ctx, c.Project.Option.WithArchived(true))
@@ -48,7 +49,7 @@ func TestProjectService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST", req.URL.Path)
-				return newJSONResponse(fixture.Project.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.One(ctx, "TEST")
@@ -73,7 +74,7 @@ func TestProjectService(t *testing.T) {
 				assert.Equal(t, "TEST", req.PostForm.Get("key"))
 				assert.Equal(t, "test", req.PostForm.Get("name"))
 				assert.Equal(t, "true", req.PostForm.Get("chartEnabled"))
-				return newJSONResponse(fixture.Project.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.Create(ctx, "TEST", "test", c.Project.Option.WithChartEnabled(true))
@@ -96,7 +97,7 @@ func TestProjectService(t *testing.T) {
 				assert.Equal(t, "/api/v2/projects/TEST", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "new-name", req.PostForm.Get("name"))
-				return newJSONResponse(fixture.Project.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.Update(ctx, "TEST", c.Project.Option.WithName("new-name"))
@@ -117,7 +118,7 @@ func TestProjectService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST", req.URL.Path)
-				return newJSONResponse(fixture.Project.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Project.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.Delete(ctx, "TEST")
@@ -159,7 +160,7 @@ func TestProjectActivityService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/activities", req.URL.Path)
 				assert.Equal(t, "10", req.URL.Query().Get("count"))
-				return newJSONResponse(fixture.Activity.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Activity.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.Activity.List(ctx, "TEST", c.Project.Activity.Option.WithCount(10))

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -14,6 +14,7 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
 func TestPullRequestService(t *testing.T) {
@@ -27,7 +28,7 @@ func TestPullRequestService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests", req.URL.Path)
-				return newJSONResponse(fixture.PullRequest.ListJSON), nil
+				return mock.NewJSONResponse(fixture.PullRequest.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.All(ctx, "TEST", "repo")
@@ -43,7 +44,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests", req.URL.Path)
 				assert.Equal(t, []string{"1", "2"}, req.URL.Query()["statusId[]"])
 				assert.Equal(t, "10", req.URL.Query().Get("count"))
-				return newJSONResponse(fixture.PullRequest.ListJSON), nil
+				return mock.NewJSONResponse(fixture.PullRequest.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.All(ctx, "TEST", "repo",
@@ -67,7 +68,7 @@ func TestPullRequestService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/count", req.URL.Path)
-				return newJSONResponse(`{"count":5}`), nil
+				return mock.NewJSONResponse(`{"count":5}`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Count(ctx, "TEST", "repo")
@@ -80,7 +81,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/count", req.URL.Path)
 				assert.Equal(t, []string{"1"}, req.URL.Query()["statusId[]"])
-				return newJSONResponse(`{"count":3}`), nil
+				return mock.NewJSONResponse(`{"count":3}`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Count(ctx, "TEST", "repo",
@@ -103,7 +104,7 @@ func TestPullRequestService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1", req.URL.Path)
-				return newJSONResponse(fixture.PullRequest.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.One(ctx, "TEST", "repo", 1)
@@ -130,7 +131,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, "details", req.PostForm.Get("description"))
 				assert.Equal(t, "main", req.PostForm.Get("base"))
 				assert.Equal(t, "feature/foo", req.PostForm.Get("branch"))
-				return newCreatedJSONResponse(fixture.PullRequest.SingleJSON), nil
+				return mock.NewCreatedJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Create(ctx, "TEST", "repo", "new PR", "details", "main", "feature/foo")
@@ -147,7 +148,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, "new PR", req.PostForm.Get("summary"))
 				assert.Equal(t, "5", req.PostForm.Get("assigneeId"))
 				assert.Equal(t, []string{"10", "20"}, req.PostForm["notifiedUserId[]"])
-				return newCreatedJSONResponse(fixture.PullRequest.SingleJSON), nil
+				return mock.NewCreatedJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Create(ctx, "TEST", "repo", "new PR", "", "main", "feature/foo",
@@ -173,7 +174,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
-				return newJSONResponse(fixture.PullRequest.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Update(ctx, "TEST", "repo", 1, c.PullRequest.Option.WithSummary("Updated summary"))
@@ -188,7 +189,7 @@ func TestPullRequestService(t *testing.T) {
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "Updated summary", req.PostForm.Get("summary"))
 				assert.Equal(t, "a note", req.PostForm.Get("comment"))
-				return newJSONResponse(fixture.PullRequest.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.PullRequest.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Update(ctx, "TEST", "repo", 1,
@@ -232,7 +233,7 @@ func TestPullRequestAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1/attachments", req.URL.Path)
-				return newJSONResponse(fixture.Attachment.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Attachment.List(ctx, "TEST", "repo", 1)
@@ -255,7 +256,7 @@ func TestPullRequestAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1/attachments/8", req.URL.Path)
-				return newJSONResponse(fixture.Attachment.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Attachment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Attachment.Remove(ctx, "TEST", "repo", 1, 8)

--- a/space_test.go
+++ b/space_test.go
@@ -13,6 +13,7 @@ import (
 
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
 func TestSpaceService_One(t *testing.T) {
@@ -26,7 +27,7 @@ func TestSpaceService_One(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/space", req.URL.Path)
-				return newJSONResponse(fixture.Space.SpaceJSON), nil
+				return mock.NewJSONResponse(fixture.Space.SpaceJSON), nil
 			},
 		},
 		"error": {
@@ -71,7 +72,7 @@ func TestSpaceService_DiskUsage(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/space/diskUsage", req.URL.Path)
-				return newJSONResponse(fixture.Space.DiskUsageJSON), nil
+				return mock.NewJSONResponse(fixture.Space.DiskUsageJSON), nil
 			},
 		},
 		"error": {
@@ -118,7 +119,7 @@ func TestSpaceService_Notification(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/space/notification", req.URL.Path)
-				return newJSONResponse(fixture.Space.NotificationJSON), nil
+				return mock.NewJSONResponse(fixture.Space.NotificationJSON), nil
 			},
 		},
 		"error": {
@@ -165,7 +166,7 @@ func TestSpaceService_UpdateNotification(t *testing.T) {
 				assert.Equal(t, "/api/v2/space/notification", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "Backlog is a project management tool.", req.FormValue("content"))
-				return newJSONResponse(fixture.Space.NotificationJSON), nil
+				return mock.NewJSONResponse(fixture.Space.NotificationJSON), nil
 			},
 		},
 		"error-validation-empty-content": {
@@ -216,7 +217,7 @@ func TestSpaceActivityService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/space/activities", req.URL.Path)
 				assert.Equal(t, "20", req.URL.Query().Get("count"))
-				return newJSONResponse(fixture.Activity.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Activity.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Space.Activity.List(ctx, c.Space.Activity.Option.WithCount(20))
@@ -237,7 +238,7 @@ func TestSpaceActivityService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/activities/3153", req.URL.Path)
-				return newJSONResponse(fixture.Activity.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Activity.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Space.Activity.Get(ctx, 3153)
@@ -290,7 +291,7 @@ func TestSpaceAttachmentService(t *testing.T) {
 			assert.Equal(t, http.MethodPost, req.Method)
 			assert.Equal(t, "/api/v2/space/attachment", req.URL.Path)
 			assert.True(t, strings.HasPrefix(req.Header.Get("Content-Type"), "multipart/form-data"))
-			return newJSONResponse(fixture.Attachment.UploadJSON), nil
+			return mock.NewJSONResponse(fixture.Attachment.UploadJSON), nil
 		}
 
 		c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: doFunc}))

--- a/user_recentlyviewed_test.go
+++ b/user_recentlyviewed_test.go
@@ -1,10 +1,8 @@
 package backlog_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -16,6 +14,7 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
 func TestUserRecentlyViewedService(t *testing.T) {
@@ -29,10 +28,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/myself/recentlyViewedIssues", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.RecentlyViewed.IssueListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.RecentlyViewed.IssueListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.RecentlyViewed.ListIssues(ctx)
@@ -47,10 +43,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 				assert.Equal(t, "5", q.Get("count"))
 				assert.Equal(t, "10", q.Get("offset"))
 				assert.Equal(t, "asc", q.Get("order"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.RecentlyViewed.IssueListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.RecentlyViewed.IssueListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				o := c.User.RecentlyViewed.Option
@@ -76,10 +69,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodPost, req.Method)
 				assert.Equal(t, "/api/v2/issues/1/recentlyViewedIssues", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.RecentlyViewed.IssueSingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.RecentlyViewed.IssueSingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.RecentlyViewed.AddIssue(ctx, 1)
@@ -100,10 +90,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/myself/recentlyViewedProjects", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.RecentlyViewed.ProjectListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.RecentlyViewed.ProjectListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.RecentlyViewed.ListProjects(ctx)
@@ -125,10 +112,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/myself/recentlyViewedWikis", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.RecentlyViewed.WikiListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.RecentlyViewed.WikiListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.RecentlyViewed.ListWikis(ctx)
@@ -150,10 +134,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodPost, req.Method)
 				assert.Equal(t, "/api/v2/wikis/10/recentlyViewedWikis", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.RecentlyViewed.WikiSingleJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.RecentlyViewed.WikiSingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.RecentlyViewed.AddWiki(ctx, 10)

--- a/user_star_test.go
+++ b/user_star_test.go
@@ -1,10 +1,8 @@
 package backlog_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -16,6 +14,7 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
 func TestUserStarService(t *testing.T) {
@@ -29,10 +28,7 @@ func TestUserStarService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/1/stars", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Star.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Star.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Star.List(ctx, 1)
@@ -50,10 +46,7 @@ func TestUserStarService(t *testing.T) {
 				assert.Equal(t, "100", q.Get("minId"))
 				assert.Equal(t, "200", q.Get("maxId"))
 				assert.Equal(t, "asc", q.Get("order"))
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Star.ListJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Star.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				o := c.User.Star.Option
@@ -80,10 +73,7 @@ func TestUserStarService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/1/stars/count", req.URL.Path)
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(fixture.Star.CountJSON))),
-				}, nil
+				return mock.NewJSONResponse(fixture.Star.CountJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Star.Count(ctx, 1)

--- a/user_test.go
+++ b/user_test.go
@@ -15,6 +15,7 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
 func TestProjectUserService(t *testing.T) {
@@ -28,7 +29,7 @@ func TestProjectUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/users", req.URL.Path)
-				return newJSONResponse(fixture.User.ListJSON), nil
+				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.All(ctx, "TEST", false)
@@ -51,7 +52,7 @@ func TestProjectUserService(t *testing.T) {
 				assert.Equal(t, "/api/v2/projects/TEST/users", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "1", req.PostForm.Get("userId"))
-				return newJSONResponse(fixture.User.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.Add(ctx, "TEST", 1)
@@ -77,7 +78,7 @@ func TestProjectUserService(t *testing.T) {
 				form, err := url.ParseQuery(string(body))
 				require.NoError(t, err)
 				assert.Equal(t, "1", form.Get("userId"))
-				return newJSONResponse(fixture.User.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.Delete(ctx, "TEST", 1)
@@ -100,7 +101,7 @@ func TestProjectUserService(t *testing.T) {
 				assert.Equal(t, "/api/v2/projects/TEST/administrators", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "1", req.PostForm.Get("userId"))
-				return newJSONResponse(fixture.User.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.AddAdmin(ctx, "TEST", 1)
@@ -121,7 +122,7 @@ func TestProjectUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/administrators", req.URL.Path)
-				return newJSONResponse(fixture.User.ListJSON), nil
+				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.AdminAll(ctx, "TEST")
@@ -147,7 +148,7 @@ func TestProjectUserService(t *testing.T) {
 				form, err := url.ParseQuery(string(body))
 				require.NoError(t, err)
 				assert.Equal(t, "1", form.Get("userId"))
-				return newJSONResponse(fixture.User.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Project.User.DeleteAdmin(ctx, "TEST", 1)
@@ -188,7 +189,7 @@ func TestUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users", req.URL.Path)
-				return newJSONResponse(fixture.User.ListJSON), nil
+				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.All(ctx)
@@ -209,7 +210,7 @@ func TestUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/1", req.URL.Path)
-				return newJSONResponse(fixture.User.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.One(ctx, 1)
@@ -230,7 +231,7 @@ func TestUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/myself", req.URL.Path)
-				return newJSONResponse(fixture.User.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Own(ctx)
@@ -256,7 +257,7 @@ func TestUserService(t *testing.T) {
 				assert.Equal(t, "password", req.PostForm.Get("password"))
 				assert.Equal(t, "New User", req.PostForm.Get("name"))
 				assert.Equal(t, "new@example.com", req.PostForm.Get("mailAddress"))
-				return newJSONResponse(fixture.User.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Add(ctx, "newuser", "password", "New User", "new@example.com", backlog.RoleAdministrator)
@@ -279,7 +280,7 @@ func TestUserService(t *testing.T) {
 				assert.Equal(t, "/api/v2/users/1", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "updated-user", req.PostForm.Get("name"))
-				return newJSONResponse(fixture.User.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Update(ctx, 1, c.User.Option.WithName("updated-user"))
@@ -305,7 +306,7 @@ func TestUserService(t *testing.T) {
 				form, err := url.ParseQuery(string(body))
 				require.NoError(t, err)
 				assert.Empty(t, form)
-				return newJSONResponse(fixture.User.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Delete(ctx, 1)
@@ -347,7 +348,7 @@ func TestUserActivityService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/1/activities", req.URL.Path)
 				assert.Equal(t, "5", req.URL.Query().Get("minId"))
-				return newJSONResponse(fixture.Activity.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Activity.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.User.Activity.List(ctx, 1, c.User.Activity.Option.WithMinID(5))

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -14,6 +14,7 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
 func TestWikiService(t *testing.T) {
@@ -28,7 +29,7 @@ func TestWikiService(t *testing.T) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis", req.URL.Path)
 				assert.Equal(t, "backlog", req.URL.Query().Get("keyword"))
-				return newJSONResponse(fixture.Wiki.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Wiki.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.All(ctx, "TEST", c.Wiki.Option.WithKeyword("backlog"))
@@ -49,7 +50,7 @@ func TestWikiService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/count", req.URL.Path)
-				return newJSONResponse(`{"count": 34}`), nil
+				return mock.NewJSONResponse(`{"count": 34}`), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Count(ctx, "TEST")
@@ -70,7 +71,7 @@ func TestWikiService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34", req.URL.Path)
-				return newJSONResponse(fixture.Wiki.MaximumJSON), nil
+				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.One(ctx, 34)
@@ -96,7 +97,7 @@ func TestWikiService(t *testing.T) {
 				assert.Equal(t, "Test Wiki", req.PostForm.Get("name"))
 				assert.Equal(t, "content", req.PostForm.Get("content"))
 				assert.Equal(t, "true", req.PostForm.Get("mailNotify"))
-				return newJSONResponse(fixture.Wiki.MinimumJSON), nil
+				return mock.NewJSONResponse(fixture.Wiki.MinimumJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Create(ctx, 56, "Test Wiki", "content", c.Wiki.Option.WithMailNotify(true))
@@ -119,7 +120,7 @@ func TestWikiService(t *testing.T) {
 				assert.Equal(t, "/api/v2/wikis/34", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, "New Name", req.PostForm.Get("name"))
-				return newJSONResponse(fixture.Wiki.MaximumJSON), nil
+				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Update(ctx, 34, c.Wiki.Option.WithName("New Name"))
@@ -145,7 +146,7 @@ func TestWikiService(t *testing.T) {
 				form, err := url.ParseQuery(string(body))
 				require.NoError(t, err)
 				assert.Equal(t, "true", form.Get("mailNotify"))
-				return newJSONResponse(fixture.Wiki.MaximumJSON), nil
+				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Delete(ctx, 34, c.Wiki.Option.WithMailNotify(true))
@@ -188,7 +189,7 @@ func TestWikiAttachmentService(t *testing.T) {
 				assert.Equal(t, "/api/v2/wikis/34/attachments", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, []string{"2", "5"}, req.PostForm["attachmentId[]"])
-				return newJSONResponse(fixture.Attachment.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Attachment.Attach(ctx, 34, []int{2, 5})
@@ -211,7 +212,7 @@ func TestWikiAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/attachments", req.URL.Path)
-				return newJSONResponse(fixture.Attachment.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Attachment.List(ctx, 34)
@@ -234,7 +235,7 @@ func TestWikiAttachmentService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/attachments/8", req.URL.Path)
-				return newJSONResponse(fixture.Attachment.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.Attachment.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Attachment.Remove(ctx, 34, 8)
@@ -275,7 +276,7 @@ func TestWikiHistoryService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/history", req.URL.Path)
-				return newJSONResponse(fixture.WikiHistory.ListJSON), nil
+				return mock.NewJSONResponse(fixture.WikiHistory.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.History.List(ctx, 34)
@@ -320,7 +321,7 @@ func TestWikiSharedFileService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/sharedFiles", req.URL.Path)
-				return newJSONResponse(fixture.SharedFile.ListJSON), nil
+				return mock.NewJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.SharedFile.List(ctx, 34)
@@ -347,7 +348,7 @@ func TestWikiSharedFileService(t *testing.T) {
 				assert.Equal(t, "/api/v2/wikis/34/sharedFiles", req.URL.Path)
 				require.NoError(t, req.ParseForm())
 				assert.Equal(t, []string{"454403", "454404"}, req.PostForm["fileId[]"])
-				return newJSONResponse(fixture.SharedFile.ListJSON), nil
+				return mock.NewJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.SharedFile.Link(ctx, 34, []int{454403, 454404})
@@ -370,7 +371,7 @@ func TestWikiSharedFileService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodDelete, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/sharedFiles/454403", req.URL.Path)
-				return newJSONResponse(fixture.SharedFile.SingleJSON), nil
+				return mock.NewJSONResponse(fixture.SharedFile.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.SharedFile.Unlink(ctx, 34, 454403)
@@ -413,7 +414,7 @@ func TestWikiStarService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis/34/stars", req.URL.Path)
-				return newJSONResponse(fixture.Star.ListJSON), nil
+				return mock.NewJSONResponse(fixture.Star.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.Wiki.Star.List(ctx, 34)


### PR DESCRIPTION
## Summary

Refactor test code to use shared HTTP response mock helpers from `internal/testutil/mock`.

## Changes

- Centralize JSON response mock helpers
- Replace duplicated local helpers in tests
- Remove inline response construction where shared helpers can be used

## Notes

- Refactoring only
- No functional changes