### PR TITLE
feat: implement IssueService.Participants

### DIFF
--- a/example_issue_test.go
+++ b/example_issue_test.go
@@ -10,12 +10,13 @@ import (
 
 var (
 	// IssueService
-	doerIssueAll    = newMockDoer(fixture.Issue.ListJSON)
-	doerIssueCount  = newMockDoer(`{"count":2}`)
-	doerIssueOne    = newMockDoer(fixture.Issue.SingleJSON)
-	doerIssueCreate = newMockDoer(fixture.Issue.SingleJSON)
-	doerIssueUpdate = newMockDoer(fixture.Issue.SingleJSON)
-	doerIssueDelete = newMockDoer(fixture.Issue.SingleJSON)
+	doerIssueAll          = newMockDoer(fixture.Issue.ListJSON)
+	doerIssueCount        = newMockDoer(`{"count":2}`)
+	doerIssueOne          = newMockDoer(fixture.Issue.SingleJSON)
+	doerIssueCreate       = newMockDoer(fixture.Issue.SingleJSON)
+	doerIssueUpdate       = newMockDoer(fixture.Issue.SingleJSON)
+	doerIssueDelete       = newMockDoer(fixture.Issue.SingleJSON)
+	doerIssueParticipants = newMockDoer(fixture.User.ListJSON)
 
 	// IssueAttachmentService
 	doerIssueAttachmentList   = newMockDoer(fixture.Attachment.ListJSON)
@@ -98,6 +99,19 @@ func ExampleIssueService_Delete() {
 	fmt.Printf("ID: %d, IssueKey: %s\n", issue.ID, issue.IssueKey)
 	// Output:
 	// ID: 1, IssueKey: PRJ-1
+}
+
+func ExampleIssueService_Participants() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerIssueParticipants),
+	)
+
+	users, _ := c.Issue.Participants(context.Background(), "PRJ-1")
+	fmt.Printf("Count: %d, ID: %d, Name: %s\n", len(users), users[0].ID, users[0].Name)
+	// Output:
+	// Count: 4, ID: 1, Name: admin
 }
 
 func ExampleIssueAttachmentService_List() {

--- a/internal/issue/service.go
+++ b/internal/issue/service.go
@@ -263,6 +263,28 @@ func (s *Service) Delete(ctx context.Context, issueIDOrKey string) (*model.Issue
 	return &v, nil
 }
 
+// Participants returns a list of participants on an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-participant-list
+func (s *Service) Participants(ctx context.Context, issueIDOrKey string) ([]*model.User, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "participants")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.User{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
 // ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────

--- a/internal/issue/service_test.go
+++ b/internal/issue/service_test.go
@@ -667,6 +667,93 @@ func TestIssueService_Delete(t *testing.T) {
 	}
 }
 
+func TestIssueService_Participants(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantIDs     []int
+	}{
+		"success-by-key": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/participants", spath)
+				return mock.NewJSONResponse(fixture.User.ListJSON), nil
+			},
+			wantIDs: []int{1, 2, 3, 4},
+		},
+		"success-by-id": {
+			issueIDOrKey: "1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/1/participants", spath)
+				return mock.NewJSONResponse(fixture.User.ListJSON), nil
+			},
+			wantIDs: []int{1, 2, 3, 4},
+		},
+		"success-empty-list": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/participants", spath)
+				return mock.NewJSONResponse(`[]`), nil
+			},
+			wantIDs: []int{},
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-zero-issueIDOrKey": {
+			issueIDOrKey: "0",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := issue.NewService(method)
+
+			got, err := s.Participants(context.Background(), tc.issueIDOrKey)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Len(t, got, len(tc.wantIDs))
+			for i := range got {
+				assert.Equal(t, tc.wantIDs[i], got[i].ID)
+			}
+		})
+	}
+}
+
 func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
@@ -714,6 +801,11 @@ func Test_contextPropagation(t *testing.T) {
 			m.Delete = makeMockFn(t)
 			s := issue.NewService(m)
 			s.Delete(ctx, "PRJ-1") //nolint:errcheck
+		}},
+		{"IssueService.Participants", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := issue.NewService(m)
+			s.Participants(ctx, "PRJ-1") //nolint:errcheck
 		}},
 	}
 

--- a/issue.go
+++ b/issue.go
@@ -210,6 +210,14 @@ func (s *IssueService) Delete(ctx context.Context, issueIDOrKey string) (*Issue,
 	return issueFromModel(v), convertError(err)
 }
 
+// Participants returns a list of participants on an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-participant-list
+func (s *IssueService) Participants(ctx context.Context, issueIDOrKey string) ([]*User, error) {
+	v, err := s.base.Participants(ctx, issueIDOrKey)
+	return usersFromModel(v), convertError(err)
+}
+
 // ──────────────────────────────────────────────────────────────
 //  IssueAttachmentService
 // ──────────────────────────────────────────────────────────────

--- a/issue_test.go
+++ b/issue_test.go
@@ -240,6 +240,29 @@ func TestIssueService(t *testing.T) {
 				assert.True(t, errors.As(err, &target))
 			},
 		},
+		"Participants": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues/PRJ-1/participants", req.URL.Path)
+				return mock.NewJSONResponse(fixture.User.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Issue.Participants(ctx, "PRJ-1")
+				require.NoError(t, err)
+				assert.Len(t, got, 4)
+				assert.Equal(t, 1, got[0].ID)
+				assert.Equal(t, "admin", got[0].Name)
+			},
+		},
+		"Participants/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.Participants(ctx, "PRJ-1")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
## Summary

Implements `GET /api/v2/issues/{issueIdOrKey}/participants` as `IssueService.Participants`, returning the list of participants on an issue.

## Changes

- Add `Service.Participants` to `internal/issue/service.go`
- Add `IssueService.Participants` to `issue.go` (delegates to the internal service via `usersFromModel`)
- Add `TestIssueService_Participants` and a context propagation case in `internal/issue/service_test.go`
- Add `Participants` / `Participants/error` cases to `TestIssueService` in `issue_test.go`
- Add `ExampleIssueService_Participants` to `example_issue_test.go`

Part of #216