### PR TITLE
feat: implement RepositoryService endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 - [Link Shared Files to Issue](https://developer.nulab.com/docs/backlog/api/2/link-shared-files-to-issue) - Links shared files to an issue.
 - [Remove Link to Shared File from Issue](https://developer.nulab.com/docs/backlog/api/2/remove-link-to-shared-file-from-issue) - Removes a shared file link from an issue.
 
+### Client.[Repository](https://pkg.go.dev/github.com/nattokin/go-backlog#RepositoryService)
+
+- [Get List of Git Repositories](https://developer.nulab.com/docs/backlog/api/2/get-list-of-git-repositories/) - Returns a list of Git repositories in a project.
+- [Get Git Repository](https://developer.nulab.com/docs/backlog/api/2/get-git-repository/) - Returns information about a specific Git repository.
+
 ### Client.[PullRequest](https://pkg.go.dev/github.com/nattokin/go-backlog#PullRequestService)
 
 - [Get Pull Request List](https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list) - Returns a list of pull requests.

--- a/client.go
+++ b/client.go
@@ -30,6 +30,7 @@ type Client struct {
 	Issue       *IssueService
 	Project     *ProjectService
 	PullRequest *PullRequestService
+	Repository  *RepositoryService
 	Space       *SpaceService
 	Star        *StarService
 	User        *UserService
@@ -77,6 +78,8 @@ func initServices(c *Client) {
 	c.Project = newProjectService(c.core.Method, baseOptionService)
 
 	c.PullRequest = newPullRequestService(c.core.Method, baseOptionService)
+
+	c.Repository = newRepositoryService(c.core.Method)
 
 	c.Space = newSpaceService(c.core.Method, baseOptionService)
 

--- a/example_repository_test.go
+++ b/example_repository_test.go
@@ -1,0 +1,41 @@
+package backlog_test
+
+import (
+	"context"
+	"fmt"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+var (
+	// RepositoryService
+	doerRepositoryAll = newMockDoer(fixture.Repository.ListJSON)
+	doerRepositoryOne = newMockDoer(fixture.Repository.SingleJSON)
+)
+
+func ExampleRepositoryService_All() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerRepositoryAll),
+	)
+
+	repos, _ := c.Repository.All(context.Background(), "TEST")
+	fmt.Printf("Count: %d, ID: %d, Name: %s\n", len(repos), repos[0].ID, repos[0].Name)
+	// Output:
+	// Count: 2, ID: 5, Name: foo
+}
+
+func ExampleRepositoryService_One() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerRepositoryOne),
+	)
+
+	repo, _ := c.Repository.One(context.Background(), "TEST", "foo")
+	fmt.Printf("ID: %d, Name: %s, Description: %s\n", repo.ID, repo.Name, repo.Description)
+	// Output:
+	// ID: 5, Name: foo, Description: test repo
+}

--- a/internal/repository/service.go
+++ b/internal/repository/service.go
@@ -1,0 +1,77 @@
+package repository
+
+import (
+	"context"
+	"net/url"
+	"path"
+	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/validate"
+)
+
+type Service struct {
+	method *core.Method
+}
+
+// All returns a list of Git repositories in a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-git-repositories
+func (s *Service) All(ctx context.Context, projectIDOrKey string) ([]*model.Repository, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories")
+	resp, err := s.method.Get(ctx, spath, url.Values{})
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.Repository{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// One returns information about a specific Git repository.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-git-repository
+func (s *Service) One(ctx context.Context, projectIDOrKey string, repoIDOrName string) (*model.Repository, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName)
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Repository{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
+func NewService(method *core.Method) *Service {
+	return &Service{
+		method: method,
+	}
+}
+
+// repositoryIDOrName is already validated by ValidateRepositoryIDOrName; this
+// helper is kept for symmetry with other services that need numeric IDs.
+var _ = strconv.Itoa // suppress unused import

--- a/internal/repository/service.go
+++ b/internal/repository/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/url"
 	"path"
-	"strconv"
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
@@ -71,7 +70,3 @@ func NewService(method *core.Method) *Service {
 		method: method,
 	}
 }
-
-// repositoryIDOrName is already validated by ValidateRepositoryIDOrName; this
-// helper is kept for symmetry with other services that need numeric IDs.
-var _ = strconv.Itoa // suppress unused import

--- a/internal/repository/service_test.go
+++ b/internal/repository/service_test.go
@@ -1,0 +1,215 @@
+package repository_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/repository"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
+)
+
+const (
+	testProject = "PRJ"
+	testRepo    = "repo1"
+)
+
+func TestRepositoryService_All(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantIDs     []int
+	}{
+		"success": {
+			projectIDOrKey: testProject,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/PRJ/git/repositories", spath)
+				return mock.NewJSONResponse(fixture.Repository.ListJSON), nil
+			},
+			wantIDs: []int{5, 6},
+		},
+		"error-empty-projectIDOrKey": {
+			projectIDOrKey: "",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-zero-projectIDOrKey": {
+			projectIDOrKey: "0",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: testProject,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: testProject,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := repository.NewService(method)
+			got, err := s.All(context.Background(), tc.projectIDOrKey)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Len(t, got, len(tc.wantIDs))
+			for i := range got {
+				assert.Equal(t, tc.wantIDs[i], got[i].ID)
+			}
+		})
+	}
+}
+
+func TestRepositoryService_One(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+		repoIDOrName   string
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantID      int
+		wantName    string
+	}{
+		"success-by-name": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/PRJ/git/repositories/repo1", spath)
+				return mock.NewJSONResponse(fixture.Repository.SingleJSON), nil
+			},
+			wantID:   5,
+			wantName: "foo",
+		},
+		"error-empty-projectIDOrKey": {
+			projectIDOrKey: "",
+			repoIDOrName:   testRepo,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-zero-projectIDOrKey": {
+			projectIDOrKey: "0",
+			repoIDOrName:   testRepo,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-empty-repoIDOrName": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   "",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-zero-repoIDOrName": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   "0",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: testProject,
+			repoIDOrName:   testRepo,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := repository.NewService(method)
+			got, err := s.One(context.Background(), tc.projectIDOrKey, tc.repoIDOrName)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantID, got.ID)
+			assert.Equal(t, tc.wantName, got.Name)
+		})
+	}
+}
+
+func Test_contextPropagation(t *testing.T) {
+	type ctxKey struct{}
+	sentinel := &struct{}{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
+
+	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
+		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
+			assert.Same(t, sentinel, got.Value(ctxKey{}))
+			return nil, errors.New("stop")
+		}
+	}
+
+	cases := []struct {
+		name string
+		call func(t *testing.T, m *core.Method)
+	}{
+		{"RepositoryService.All", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := repository.NewService(m)
+			s.All(ctx, testProject) //nolint:errcheck
+		}},
+		{"RepositoryService.One", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := repository.NewService(m)
+			s.One(ctx, testProject, testRepo) //nolint:errcheck
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.call(t, &core.Method{})
+		})
+	}
+}

--- a/internal/testutil/fixture/testdata_repository.go
+++ b/internal/testutil/fixture/testdata_repository.go
@@ -1,0 +1,190 @@
+package fixture
+
+import backlog "github.com/nattokin/go-backlog"
+
+type repositoryFixtures struct {
+	SingleJSON string
+	Single     backlog.Repository
+	ListJSON   string
+	List       []*backlog.Repository
+}
+
+// Repository provides test fixtures for Repository-related tests.
+var Repository = repositoryFixtures{
+	SingleJSON: `
+{
+    "id": 5,
+    "projectId": 3,
+    "name": "foo",
+    "description": "test repo",
+    "hookUrl": null,
+    "httpUrl": "https://example.backlog.com/git/TEST/foo.git",
+    "sshUrl": "git@example.backlog.com:TEST/foo.git",
+    "displayOrder": 0,
+    "pushedAt": null,
+    "createdUser": {
+        "id": 1,
+        "userId": "admin",
+        "name": "admin",
+        "roleType": 1,
+        "lang": "ja",
+        "mailAddress": "admin@example.com"
+    },
+    "created": "2024-01-10T09:00:00Z",
+    "updatedUser": {
+        "id": 1,
+        "userId": "admin",
+        "name": "admin",
+        "roleType": 1,
+        "lang": "ja",
+        "mailAddress": "admin@example.com"
+    },
+    "updated": "2024-01-10T09:00:00Z"
+}
+`,
+	Single: backlog.Repository{
+		ID:           5,
+		ProjectID:    3,
+		Name:         "foo",
+		Description:  "test repo",
+		HTTPURL:      "https://example.backlog.com/git/TEST/foo.git",
+		SSHURL:       "git@example.backlog.com:TEST/foo.git",
+		DisplayOrder: 0,
+		CreatedUser: &backlog.User{
+			ID:          1,
+			UserID:      "admin",
+			Name:        "admin",
+			RoleType:    backlog.RoleAdministrator,
+			Lang:        "ja",
+			MailAddress: "admin@example.com",
+		},
+		Created: mustTime("2024-01-10T09:00:00Z"),
+		UpdatedUser: &backlog.User{
+			ID:          1,
+			UserID:      "admin",
+			Name:        "admin",
+			RoleType:    backlog.RoleAdministrator,
+			Lang:        "ja",
+			MailAddress: "admin@example.com",
+		},
+		Updated: mustTime("2024-01-10T09:00:00Z"),
+	},
+	ListJSON: `
+[
+    {
+        "id": 5,
+        "projectId": 3,
+        "name": "foo",
+        "description": "test repo",
+        "hookUrl": null,
+        "httpUrl": "https://example.backlog.com/git/TEST/foo.git",
+        "sshUrl": "git@example.backlog.com:TEST/foo.git",
+        "displayOrder": 0,
+        "pushedAt": null,
+        "createdUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "admin@example.com"
+        },
+        "created": "2024-01-10T09:00:00Z",
+        "updatedUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "admin@example.com"
+        },
+        "updated": "2024-01-10T09:00:00Z"
+    },
+    {
+        "id": 6,
+        "projectId": 3,
+        "name": "bar",
+        "description": "second repo",
+        "hookUrl": null,
+        "httpUrl": "https://example.backlog.com/git/TEST/bar.git",
+        "sshUrl": "git@example.backlog.com:TEST/bar.git",
+        "displayOrder": 1,
+        "pushedAt": null,
+        "createdUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "admin@example.com"
+        },
+        "created": "2024-01-11T10:00:00Z",
+        "updatedUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "admin@example.com"
+        },
+        "updated": "2024-01-11T10:00:00Z"
+    }
+]
+`,
+	List: []*backlog.Repository{
+		{
+			ID:           5,
+			ProjectID:    3,
+			Name:         "foo",
+			Description:  "test repo",
+			HTTPURL:      "https://example.backlog.com/git/TEST/foo.git",
+			SSHURL:       "git@example.backlog.com:TEST/foo.git",
+			DisplayOrder: 0,
+			CreatedUser: &backlog.User{
+				ID:          1,
+				UserID:      "admin",
+				Name:        "admin",
+				RoleType:    backlog.RoleAdministrator,
+				Lang:        "ja",
+				MailAddress: "admin@example.com",
+			},
+			Created: mustTime("2024-01-10T09:00:00Z"),
+			UpdatedUser: &backlog.User{
+				ID:          1,
+				UserID:      "admin",
+				Name:        "admin",
+				RoleType:    backlog.RoleAdministrator,
+				Lang:        "ja",
+				MailAddress: "admin@example.com",
+			},
+			Updated: mustTime("2024-01-10T09:00:00Z"),
+		},
+		{
+			ID:           6,
+			ProjectID:    3,
+			Name:         "bar",
+			Description:  "second repo",
+			HTTPURL:      "https://example.backlog.com/git/TEST/bar.git",
+			SSHURL:       "git@example.backlog.com:TEST/bar.git",
+			DisplayOrder: 1,
+			CreatedUser: &backlog.User{
+				ID:          1,
+				UserID:      "admin",
+				Name:        "admin",
+				RoleType:    backlog.RoleAdministrator,
+				Lang:        "ja",
+				MailAddress: "admin@example.com",
+			},
+			Created: mustTime("2024-01-11T10:00:00Z"),
+			UpdatedUser: &backlog.User{
+				ID:          1,
+				UserID:      "admin",
+				Name:        "admin",
+				RoleType:    backlog.RoleAdministrator,
+				Lang:        "ja",
+				MailAddress: "admin@example.com",
+			},
+			Updated: mustTime("2024-01-11T10:00:00Z"),
+		},
+	},
+}

--- a/repository.go
+++ b/repository.go
@@ -1,9 +1,12 @@
 package backlog
 
 import (
+	"context"
 	"time"
 
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/repository"
 )
 
 // Repository represents repository of Backlog git.
@@ -28,8 +31,65 @@ type Repository struct {
 // ──────────────────────────────────────────────────────────────
 
 // RepositoryService handles communication with the repository-related methods of the Backlog API.
-//
-//nolint:unused // API not implemented yet
 type RepositoryService struct {
-	method *core.Method
+	base *repository.Service
+}
+
+// All returns a list of Git repositories in a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-git-repositories
+func (s *RepositoryService) All(ctx context.Context, projectIDOrKey string) ([]*Repository, error) {
+	v, err := s.base.All(ctx, projectIDOrKey)
+	return repositoriesFromModel(v), convertError(err)
+}
+
+// One returns information about a specific Git repository.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-git-repository
+func (s *RepositoryService) One(ctx context.Context, projectIDOrKey string, repoIDOrName string) (*Repository, error) {
+	v, err := s.base.One(ctx, projectIDOrKey, repoIDOrName)
+	return repositoryFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
+func newRepositoryService(method *core.Method) *RepositoryService {
+	return &RepositoryService{
+		base: repository.NewService(method),
+	}
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Helpers
+// ──────────────────────────────────────────────────────────────
+
+func repositoryFromModel(m *model.Repository) *Repository {
+	if m == nil {
+		return nil
+	}
+	return &Repository{
+		ID:           m.ID,
+		ProjectID:    m.ProjectID,
+		Name:         m.Name,
+		Description:  m.Description,
+		HookURL:      m.HookURL,
+		HTTPURL:      m.HTTPURL,
+		SSHURL:       m.SSHURL,
+		DisplayOrder: m.DisplayOrder,
+		PushedAt:     m.PushedAt,
+		CreatedUser:  userFromModel(m.CreatedUser),
+		Created:      m.Created,
+		UpdatedUser:  userFromModel(m.UpdatedUser),
+		Updated:      m.Updated,
+	}
+}
+
+func repositoriesFromModel(ms []*model.Repository) []*Repository {
+	result := make([]*Repository, len(ms))
+	for i, v := range ms {
+		result[i] = repositoryFromModel(v)
+	}
+	return result
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -1,0 +1,83 @@
+package backlog_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
+)
+
+func TestRepositoryService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"All": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories", req.URL.Path)
+				return mock.NewJSONResponse(fixture.Repository.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Repository.All(ctx, "TEST")
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, 5, got[0].ID)
+				assert.Equal(t, "foo", got[0].Name)
+				assert.Equal(t, 6, got[1].ID)
+				assert.Equal(t, "bar", got[1].Name)
+			},
+		},
+		"All/error": {
+			doFunc: newInternalServerErrorDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Repository.All(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"One": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/foo", req.URL.Path)
+				return mock.NewJSONResponse(fixture.Repository.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Repository.One(ctx, "TEST", "foo")
+				require.NoError(t, err)
+				assert.Equal(t, 5, got.ID)
+				assert.Equal(t, "foo", got.Name)
+				assert.Equal(t, "test repo", got.Description)
+			},
+		},
+		"One/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Repository.One(ctx, "TEST", "foo")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements the two missing Git Repository API endpoints as `RepositoryService` exposed on `*Client`.

## Changes

- Add `internal/repository/service.go` — internal `Service` with `All` and `One` methods
- Add `internal/repository/service_test.go` — `TestRepositoryService_All`, `TestRepositoryService_One`, `Test_contextPropagation`
- Add `RepositoryService` to `repository.go` — public wrapper with `All`, `One`, `repositoryFromModel`, `repositoriesFromModel`, and `newRepositoryService`
- Add `Repository *RepositoryService` field to `Client` in `client.go` and wire it in `initServices`
- Add `internal/testutil/fixture/testdata_repository.go` — `fixture.Repository` with `SingleJSON`, `Single`, `ListJSON`, `List`
- Add `repository_test.go` — `TestRepositoryService` covering `All`, `All/error`, `One`, `One/error`
- Add `example_repository_test.go` — `ExampleRepositoryService_All`, `ExampleRepositoryService_One`
- Update `README.md` — add `Client.Repository` section to supported endpoints

Part of #218