### PR TITLE
docs: add Example tests for IssueSharedFileService, UserStarService, WikiSharedFileService

### DIFF
--- a/example_issue_sharedfile_test.go
+++ b/example_issue_sharedfile_test.go
@@ -1,0 +1,54 @@
+package backlog_test
+
+import (
+	"context"
+	"fmt"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+var (
+	doerIssueSharedFileLink   = newMockDoer(fixture.SharedFile.ListJSON)
+	doerIssueSharedFileList   = newMockDoer(fixture.SharedFile.ListJSON)
+	doerIssueSharedFileUnlink = newMockDoer(fixture.SharedFile.SingleJSON)
+)
+
+func ExampleIssueSharedFileService_Link() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerIssueSharedFileLink),
+	)
+
+	files, _ := c.Issue.SharedFile.Link(context.Background(), "TEST-1", []int{454403, 454404})
+	fmt.Printf("ID: %d, Name: %s\n", files[0].ID, files[0].Name)
+	// Output:
+	// ID: 454403, Name: 01_buz.png
+}
+
+func ExampleIssueSharedFileService_List() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerIssueSharedFileList),
+	)
+
+	files, _ := c.Issue.SharedFile.List(context.Background(), "TEST-1")
+	fmt.Printf("ID: %d, Name: %s\n", files[0].ID, files[0].Name)
+	// Output:
+	// ID: 454403, Name: 01_buz.png
+}
+
+func ExampleIssueSharedFileService_Unlink() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerIssueSharedFileUnlink),
+	)
+
+	file, _ := c.Issue.SharedFile.Unlink(context.Background(), "TEST-1", 454403)
+	fmt.Printf("ID: %d, Name: %s\n", file.ID, file.Name)
+	// Output:
+	// ID: 454403, Name: 01_buz.png
+}

--- a/example_user_star_test.go
+++ b/example_user_star_test.go
@@ -1,0 +1,40 @@
+package backlog_test
+
+import (
+	"context"
+	"fmt"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+var (
+	doerUserStarCount = newMockDoer(fixture.Star.CountJSON)
+	doerUserStarList  = newMockDoer(fixture.Star.ListJSON)
+)
+
+func ExampleUserStarService_Count() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerUserStarCount),
+	)
+
+	count, _ := c.User.Star.Count(context.Background(), 1)
+	fmt.Printf("Count: %d\n", count)
+	// Output:
+	// Count: 42
+}
+
+func ExampleUserStarService_List() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerUserStarList),
+	)
+
+	stars, _ := c.User.Star.List(context.Background(), 1)
+	fmt.Printf("ID: %d, Title: %s\n", stars[0].ID, stars[0].Title)
+	// Output:
+	// ID: 10, Title: [TEST-1] first issue
+}

--- a/example_wiki_sharedfile_test.go
+++ b/example_wiki_sharedfile_test.go
@@ -1,0 +1,54 @@
+package backlog_test
+
+import (
+	"context"
+	"fmt"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+var (
+	doerWikiSharedFileLink   = newMockDoer(fixture.SharedFile.ListJSON)
+	doerWikiSharedFileList   = newMockDoer(fixture.SharedFile.ListJSON)
+	doerWikiSharedFileUnlink = newMockDoer(fixture.SharedFile.SingleJSON)
+)
+
+func ExampleWikiSharedFileService_Link() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiSharedFileLink),
+	)
+
+	files, _ := c.Wiki.SharedFile.Link(context.Background(), 34, []int{454403, 454404})
+	fmt.Printf("ID: %d, Name: %s\n", files[0].ID, files[0].Name)
+	// Output:
+	// ID: 454403, Name: 01_buz.png
+}
+
+func ExampleWikiSharedFileService_List() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiSharedFileList),
+	)
+
+	files, _ := c.Wiki.SharedFile.List(context.Background(), 34)
+	fmt.Printf("ID: %d, Name: %s\n", files[0].ID, files[0].Name)
+	// Output:
+	// ID: 454403, Name: 01_buz.png
+}
+
+func ExampleWikiSharedFileService_Unlink() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiSharedFileUnlink),
+	)
+
+	file, _ := c.Wiki.SharedFile.Unlink(context.Background(), 34, 454403)
+	fmt.Printf("ID: %d, Name: %s\n", file.ID, file.Name)
+	// Output:
+	// ID: 454403, Name: 01_buz.png
+}


### PR DESCRIPTION
## Summary

Add missing Example tests for three services that had no coverage in the example test files.

## Changes

- Add `example_issue_sharedfile_test.go`: `ExampleIssueSharedFileService_Link`, `_List`, `_Unlink`
- Add `example_user_star_test.go`: `ExampleUserStarService_Count`, `_List`
- Add `example_wiki_sharedfile_test.go`: `ExampleWikiSharedFileService_Link`, `_List`, `_Unlink`

All examples follow the established conventions: `package backlog_test`, fixture-backed mock doers, and `// Output:` comments.