### PR TITLE
feat: implement Project.Category service

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 
 - [Get Project Recent Updates](https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates) - Returns recent updates in the project.
 
+### Client.Project.[Category](https://pkg.go.dev/github.com/nattokin/go-backlog#ProjectCategoryService)
+
+- [Get Category List](https://developer.nulab.com/docs/backlog/api/2/get-category-list/) - Returns a list of categories in a project.
+- [Add Category](https://developer.nulab.com/docs/backlog/api/2/add-category/) - Adds a new category to a project.
+- [Update Category](https://developer.nulab.com/docs/backlog/api/2/update-category/) - Updates a category in a project.
+- [Delete Category](https://developer.nulab.com/docs/backlog/api/2/delete-category/) - Deletes a category from a project.
+
 ### Client.Project.[User](https://pkg.go.dev/github.com/nattokin/go-backlog#ProjectUserService)
 
 - [Add Project User](https://developer.nulab.com/docs/backlog/api/2/add-project-user) - Adds a user to the list of project members.

--- a/example_project_test.go
+++ b/example_project_test.go
@@ -19,6 +19,12 @@ var (
 	// ProjectActivityService
 	doerProjectActivityList = newMockDoer(fixture.Activity.ListJSON)
 
+	// ProjectCategoryService
+	doerProjectCategoryAll    = newMockDoer(fixture.Category.ListJSON)
+	doerProjectCategoryCreate = newMockDoer(fixture.Category.SingleJSON)
+	doerProjectCategoryUpdate = newMockDoer(fixture.Category.SingleJSON)
+	doerProjectCategoryDelete = newMockDoer(fixture.Category.SingleJSON)
+
 	// ProjectUserService
 	doerProjectUserAll         = newMockDoer(fixture.User.ListJSON)
 	doerProjectUserAdd         = newMockDoer(fixture.User.SingleJSON)
@@ -106,6 +112,58 @@ func ExampleProjectActivityService_List() {
 	fmt.Printf("ID: %d, Type: %d\n", activities[0].ID, activities[0].Type)
 	// Output:
 	// ID: 3153, Type: 2
+}
+
+func ExampleProjectCategoryService_All() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectCategoryAll),
+	)
+
+	categories, _ := c.Project.Category.All(context.Background(), "TEST")
+	fmt.Printf("ID: %d, Name: %s\n", categories[0].ID, categories[0].Name)
+	// Output:
+	// ID: 12, Name: Bug
+}
+
+func ExampleProjectCategoryService_Create() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectCategoryCreate),
+	)
+
+	category, _ := c.Project.Category.Create(context.Background(), "TEST", "Bug")
+	fmt.Printf("ID: %d, Name: %s\n", category.ID, category.Name)
+	// Output:
+	// ID: 12, Name: Bug
+}
+
+func ExampleProjectCategoryService_Update() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectCategoryUpdate),
+	)
+
+	category, _ := c.Project.Category.Update(context.Background(), "TEST", 12, "Bug Fixed")
+	fmt.Printf("ID: %d, Name: %s\n", category.ID, category.Name)
+	// Output:
+	// ID: 12, Name: Bug
+}
+
+func ExampleProjectCategoryService_Delete() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectCategoryDelete),
+	)
+
+	category, _ := c.Project.Category.Delete(context.Background(), "TEST", 12)
+	fmt.Printf("ID: %d, Name: %s\n", category.ID, category.Name)
+	// Output:
+	// ID: 12, Name: Bug
 }
 
 func ExampleProjectUserService_All() {

--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -11,6 +11,13 @@ type Attachment struct {
 	Created     time.Time `json:"created,omitempty"`
 }
 
+// Category represents an category.
+type Category struct {
+	ID           int    `json:"id,omitempty"`
+	Name         string `json:"name,omitempty"`
+	DisplayOrder int    `json:"displayOrder,omitempty"`
+}
+
 // ChangeLog represents a history of changes made to an issue.
 type ChangeLog struct {
 	Field         string `json:"field,omitempty"`

--- a/internal/model/issue.go
+++ b/internal/model/issue.go
@@ -2,13 +2,6 @@ package model
 
 import "time"
 
-// Category represents an issue category.
-type Category struct {
-	ID           int    `json:"id,omitempty"`
-	Name         string `json:"name,omitempty"`
-	DisplayOrder int    `json:"displayOrder,omitempty"`
-}
-
 // Issue represents a issue of Backlog.
 type Issue struct {
 	ID             int            `json:"id,omitempty"`

--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -11,3 +11,10 @@ type Project struct {
 	TextFormattingRule                Format `json:"textFormattingRule,omitempty"`
 	Archived                          bool   `json:"archived,omitempty"`
 }
+
+// Category represents a category in a Backlog project.
+type Category struct {
+	ID           int    `json:"id,omitempty"`
+	Name         string `json:"name,omitempty"`
+	DisplayOrder int    `json:"displayOrder,omitempty"`
+}

--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -11,10 +11,3 @@ type Project struct {
 	TextFormattingRule                Format `json:"textFormattingRule,omitempty"`
 	Archived                          bool   `json:"archived,omitempty"`
 }
-
-// Category represents a category in a Backlog project.
-type Category struct {
-	ID           int    `json:"id,omitempty"`
-	Name         string `json:"name,omitempty"`
-	DisplayOrder int    `json:"displayOrder,omitempty"`
-}

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -169,9 +169,7 @@ func (s *CategoryService) Create(ctx context.Context, projectIDOrKey string, nam
 		return nil, err
 	}
 	form := url.Values{}
-	if err := option.Set(form); err != nil {
-		return nil, err
-	}
+	option.Set(form)
 
 	spath := path.Join("projects", projectIDOrKey, "categories")
 	resp, err := s.method.Post(ctx, spath, form)
@@ -203,9 +201,7 @@ func (s *CategoryService) Update(ctx context.Context, projectIDOrKey string, cat
 		return nil, err
 	}
 	form := url.Values{}
-	if err := option.Set(form); err != nil {
-		return nil, err
-	}
+	option.Set(form)
 
 	spath := path.Join("projects", projectIDOrKey, "categories", strconv.Itoa(categoryID))
 	resp, err := s.method.Patch(ctx, spath, form)

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"path"
+	"strconv"
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
@@ -125,6 +126,127 @@ func (s *Service) Delete(ctx context.Context, projectIDOrKey string) (*model.Pro
 }
 
 // ──────────────────────────────────────────────────────────────
+//  CategoryService
+// ──────────────────────────────────────────────────────────────
+
+// CategoryService handles communication with the category-related methods of the Backlog API.
+type CategoryService struct {
+	method *core.Method
+}
+
+// All returns a list of categories in a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-category-list
+func (s *CategoryService) All(ctx context.Context, projectIDOrKey string) ([]*model.Category, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "categories")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.Category{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Create adds a new category to a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-category
+func (s *CategoryService) Create(ctx context.Context, projectIDOrKey string, name string) (*model.Category, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+
+	option := (&core.OptionService{}).WithName(name)
+	if err := option.Check(); err != nil {
+		return nil, err
+	}
+	form := url.Values{}
+	if err := option.Set(form); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "categories")
+	resp, err := s.method.Post(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Category{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Update updates a category in a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-category
+func (s *CategoryService) Update(ctx context.Context, projectIDOrKey string, categoryID int, name string) (*model.Category, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if categoryID < 1 {
+		return nil, core.NewValidationError("categoryId must not be less than 1")
+	}
+
+	option := (&core.OptionService{}).WithName(name)
+	if err := option.Check(); err != nil {
+		return nil, err
+	}
+	form := url.Values{}
+	if err := option.Set(form); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "categories", strconv.Itoa(categoryID))
+	resp, err := s.method.Patch(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Category{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Delete deletes a category from a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-category
+func (s *CategoryService) Delete(ctx context.Context, projectIDOrKey string, categoryID int) (*model.Category, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if categoryID < 1 {
+		return nil, core.NewValidationError("categoryId must not be less than 1")
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "categories", strconv.Itoa(categoryID))
+	resp, err := s.method.Delete(ctx, spath, url.Values{})
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Category{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
@@ -132,4 +254,8 @@ func NewService(method *core.Method) *Service {
 	return &Service{
 		method: method,
 	}
+}
+
+func NewCategoryService(method *core.Method) *CategoryService {
+	return &CategoryService{method: method}
 }

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -525,13 +525,11 @@ func TestProjectService_Delete(t *testing.T) {
 		},
 		"error-validation-projectIDOrKey-empty": {
 			projectIDOrKey: "",
-
-			wantErrType: &core.ValidationError{},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-validation-projectIDOrKey-zero": {
 			projectIDOrKey: "0",
-
-			wantErrType: &core.ValidationError{},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-client-network": {
 			projectIDOrKey: "TEST",
@@ -614,8 +612,7 @@ func TestCategoryService_All(t *testing.T) {
 		},
 		"error-validation-projectIDOrKey-empty": {
 			projectIDOrKey: "",
-
-			wantErrType: &core.ValidationError{},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-client-network": {
 			projectIDOrKey: "TEST",
@@ -687,14 +684,12 @@ func TestCategoryService_Create(t *testing.T) {
 		"error-validation-projectIDOrKey-empty": {
 			projectIDOrKey: "",
 			name:           "Bug",
-
-			wantErrType: &core.ValidationError{},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-validation-name-empty": {
 			projectIDOrKey: "TEST",
 			name:           "",
-
-			wantErrType: &core.ValidationError{},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-client-network": {
 			projectIDOrKey: "TEST",
@@ -772,22 +767,19 @@ func TestCategoryService_Update(t *testing.T) {
 			projectIDOrKey: "",
 			categoryID:     12,
 			name:           "Bug Fixed",
-
-			wantErrType: &core.ValidationError{},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-validation-categoryID-zero": {
 			projectIDOrKey: "TEST",
 			categoryID:     0,
 			name:           "Bug Fixed",
-
-			wantErrType: &core.ValidationError{},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-validation-name-empty": {
 			projectIDOrKey: "TEST",
 			categoryID:     12,
 			name:           "",
-
-			wantErrType: &core.ValidationError{},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-client-network": {
 			projectIDOrKey: "TEST",
@@ -863,14 +855,12 @@ func TestCategoryService_Delete(t *testing.T) {
 		"error-validation-projectIDOrKey-empty": {
 			projectIDOrKey: "",
 			categoryID:     12,
-
-			wantErrType: &core.ValidationError{},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-validation-categoryID-zero": {
 			projectIDOrKey: "TEST",
 			categoryID:     0,
-
-			wantErrType: &core.ValidationError{},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-client-network": {
 			projectIDOrKey: "TEST",

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -580,6 +580,347 @@ func TestProjectService_Delete(t *testing.T) {
 	}
 }
 
+func TestCategoryService_All(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantLen     int
+		wantErrType error
+	}{
+		"success-projectIDOrKey-key": {
+			projectIDOrKey: "TEST",
+
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/categories", spath)
+				assert.Nil(t, query)
+				return mock.NewJSONResponse(fixture.Category.ListJSON), nil
+			},
+
+			wantLen:     2,
+			wantErrType: nil,
+		},
+		"success-projectIDOrKey-id": {
+			projectIDOrKey: "6",
+
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/6/categories", spath)
+				return mock.NewJSONResponse(fixture.Category.ListJSON), nil
+			},
+
+			wantLen:     2,
+			wantErrType: nil,
+		},
+		"error-validation-projectIDOrKey-empty": {
+			projectIDOrKey: "",
+
+			wantErrType: &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: "TEST",
+
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "TEST",
+
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+			s := project.NewCategoryService(method)
+
+			categories, err := s.All(context.Background(), tc.projectIDOrKey)
+
+			if tc.wantErrType != nil {
+				require.Error(t, err)
+				assert.IsType(t, tc.wantErrType, err)
+				assert.Nil(t, categories)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, categories)
+			assert.Len(t, categories, tc.wantLen)
+		})
+	}
+}
+
+func TestCategoryService_Create(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+		name           string
+
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+	}{
+		"success": {
+			projectIDOrKey: "TEST",
+			name:           "Bug",
+
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/categories", spath)
+				assert.Equal(t, "Bug", form.Get("name"))
+				return mock.NewJSONResponse(fixture.Category.SingleJSON), nil
+			},
+
+			wantErrType: nil,
+		},
+		"error-validation-projectIDOrKey-empty": {
+			projectIDOrKey: "",
+			name:           "Bug",
+
+			wantErrType: &core.ValidationError{},
+		},
+		"error-validation-name-empty": {
+			projectIDOrKey: "TEST",
+			name:           "",
+
+			wantErrType: &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: "TEST",
+			name:           "Bug",
+
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "TEST",
+			name:           "Bug",
+
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPostFn != nil {
+				method.Post = tc.mockPostFn
+			}
+			s := project.NewCategoryService(method)
+
+			category, err := s.Create(context.Background(), tc.projectIDOrKey, tc.name)
+
+			if tc.wantErrType != nil {
+				require.Error(t, err)
+				assert.IsType(t, tc.wantErrType, err)
+				assert.Nil(t, category)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, category)
+			assert.Equal(t, 12, category.ID)
+			assert.Equal(t, "Bug", category.Name)
+		})
+	}
+}
+
+func TestCategoryService_Update(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+		categoryID     int
+		name           string
+
+		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+	}{
+		"success": {
+			projectIDOrKey: "TEST",
+			categoryID:     12,
+			name:           "Bug Fixed",
+
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/categories/12", spath)
+				assert.Equal(t, "Bug Fixed", form.Get("name"))
+				return mock.NewJSONResponse(fixture.Category.SingleJSON), nil
+			},
+
+			wantErrType: nil,
+		},
+		"error-validation-projectIDOrKey-empty": {
+			projectIDOrKey: "",
+			categoryID:     12,
+			name:           "Bug Fixed",
+
+			wantErrType: &core.ValidationError{},
+		},
+		"error-validation-categoryID-zero": {
+			projectIDOrKey: "TEST",
+			categoryID:     0,
+			name:           "Bug Fixed",
+
+			wantErrType: &core.ValidationError{},
+		},
+		"error-validation-name-empty": {
+			projectIDOrKey: "TEST",
+			categoryID:     12,
+			name:           "",
+
+			wantErrType: &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: "TEST",
+			categoryID:     12,
+			name:           "Bug Fixed",
+
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "TEST",
+			categoryID:     12,
+			name:           "Bug Fixed",
+
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPatchFn != nil {
+				method.Patch = tc.mockPatchFn
+			}
+			s := project.NewCategoryService(method)
+
+			category, err := s.Update(context.Background(), tc.projectIDOrKey, tc.categoryID, tc.name)
+
+			if tc.wantErrType != nil {
+				require.Error(t, err)
+				assert.IsType(t, tc.wantErrType, err)
+				assert.Nil(t, category)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, category)
+			assert.Equal(t, 12, category.ID)
+		})
+	}
+}
+
+func TestCategoryService_Delete(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+		categoryID     int
+
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+	}{
+		"success": {
+			projectIDOrKey: "TEST",
+			categoryID:     12,
+
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/categories/12", spath)
+				assert.NotNil(t, form)
+				return mock.NewJSONResponse(fixture.Category.SingleJSON), nil
+			},
+
+			wantErrType: nil,
+		},
+		"error-validation-projectIDOrKey-empty": {
+			projectIDOrKey: "",
+			categoryID:     12,
+
+			wantErrType: &core.ValidationError{},
+		},
+		"error-validation-categoryID-zero": {
+			projectIDOrKey: "TEST",
+			categoryID:     0,
+
+			wantErrType: &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: "TEST",
+			categoryID:     12,
+
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "TEST",
+			categoryID:     12,
+
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockDeleteFn != nil {
+				method.Delete = tc.mockDeleteFn
+			}
+			s := project.NewCategoryService(method)
+
+			category, err := s.Delete(context.Background(), tc.projectIDOrKey, tc.categoryID)
+
+			if tc.wantErrType != nil {
+				require.Error(t, err)
+				assert.IsType(t, tc.wantErrType, err)
+				assert.Nil(t, category)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, category)
+			assert.Equal(t, 12, category.ID)
+			assert.Equal(t, "Bug", category.Name)
+		})
+	}
+}
+
 func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
@@ -622,7 +963,28 @@ func Test_contextPropagation(t *testing.T) {
 			m.Delete = makeMockFn(t)
 			s := project.NewService(m)
 			s.Delete(ctx, "TEST") //nolint:errcheck
-		}}}
+		}},
+		{"CategoryService.All", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := project.NewCategoryService(m)
+			s.All(ctx, "TEST") //nolint:errcheck
+		}},
+		{"CategoryService.Create", func(t *testing.T, m *core.Method) {
+			m.Post = makeMockFn(t)
+			s := project.NewCategoryService(m)
+			s.Create(ctx, "TEST", "Bug") //nolint:errcheck
+		}},
+		{"CategoryService.Update", func(t *testing.T, m *core.Method) {
+			m.Patch = makeMockFn(t)
+			s := project.NewCategoryService(m)
+			s.Update(ctx, "TEST", 12, "Bug Fixed") //nolint:errcheck
+		}},
+		{"CategoryService.Delete", func(t *testing.T, m *core.Method) {
+			m.Delete = makeMockFn(t)
+			s := project.NewCategoryService(m)
+			s.Delete(ctx, "TEST", 12) //nolint:errcheck
+		}},
+	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/testutil/fixture/testdata_project.go
+++ b/internal/testutil/fixture/testdata_project.go
@@ -11,6 +11,13 @@ type projectFixtures struct {
 	List       []*backlog.Project
 }
 
+type categoryFixtures struct {
+	SingleJSON string
+	Single     *backlog.Category
+	ListJSON   string
+	List       []*backlog.Category
+}
+
 // Project provides test fixtures for Project-related tests.
 var Project = projectFixtures{
 	SingleJSON: `
@@ -85,6 +92,46 @@ var Project = projectFixtures{
 			ProjectKey:         "TEST3",
 			Name:               "test3",
 			TextFormattingRule: backlog.FormatMarkdown,
+		},
+	},
+}
+
+// Category provides test fixtures for Category-related tests.
+var Category = categoryFixtures{
+	SingleJSON: `
+{
+    "id": 12,
+    "name": "Bug",
+    "displayOrder": 0
+}
+`,
+	Single: &backlog.Category{
+		ID:   12,
+		Name: "Bug",
+	},
+	ListJSON: `
+[
+    {
+        "id": 12,
+        "name": "Bug",
+        "displayOrder": 0
+    },
+    {
+        "id": 13,
+        "name": "Feature",
+        "displayOrder": 1
+    }
+]
+`,
+	List: []*backlog.Category{
+		{
+			ID:   12,
+			Name: "Bug",
+		},
+		{
+			ID:           13,
+			Name:         "Feature",
+			DisplayOrder: 1,
 		},
 	},
 }

--- a/issue.go
+++ b/issue.go
@@ -16,13 +16,6 @@ import (
 //  Issue models
 // ──────────────────────────────────────────────────────────────
 
-// Category represents an issue category.
-type Category struct {
-	ID           int
-	Name         string
-	DisplayOrder int
-}
-
 // Issue represents a issue of Backlog.
 type Issue struct {
 	ID             int
@@ -699,21 +692,6 @@ func newIssueOptionService(option *core.OptionService) *IssueOptionService {
 // ──────────────────────────────────────────────────────────────
 //  Helpers
 // ──────────────────────────────────────────────────────────────
-
-func categoriesFromModel(m []*model.Category) []*Category {
-	if m == nil {
-		return nil
-	}
-	result := make([]*Category, len(m))
-	for i, v := range m {
-		if v == nil {
-			result[i] = nil
-		} else {
-			result[i] = &Category{ID: v.ID, Name: v.Name, DisplayOrder: v.DisplayOrder}
-		}
-	}
-	return result
-}
 
 func resolutionsFromModel(m []*model.Resolution) []*Resolution {
 	if m == nil {

--- a/models.go
+++ b/models.go
@@ -281,6 +281,9 @@ func categoryFromModel(m *model.Category) *Category {
 }
 
 func categoriesFromModel(ms []*model.Category) []*Category {
+	if ms == nil {
+		return nil
+	}
 	result := make([]*Category, len(ms))
 	for i, v := range ms {
 		result[i] = categoryFromModel(v)

--- a/models.go
+++ b/models.go
@@ -34,6 +34,13 @@ type ActivityContent struct {
 	Comment     *Comment
 }
 
+// Category represents an category.
+type Category struct {
+	ID           int
+	Name         string
+	DisplayOrder int
+}
+
 // ChangeLog represents a history of changes made to an issue.
 type ChangeLog struct {
 	Field         string
@@ -258,6 +265,25 @@ func activitiesFromModel(ms []*model.Activity) []*Activity {
 	result := make([]*Activity, len(ms))
 	for i, v := range ms {
 		result[i] = activityFromModel(v)
+	}
+	return result
+}
+
+func categoryFromModel(m *model.Category) *Category {
+	if m == nil {
+		return nil
+	}
+	return &Category{
+		ID:           m.ID,
+		Name:         m.Name,
+		DisplayOrder: m.DisplayOrder,
+	}
+}
+
+func categoriesFromModel(ms []*model.Category) []*Category {
+	result := make([]*Category, len(ms))
+	for i, v := range ms {
+		result[i] = categoryFromModel(v)
 	}
 	return result
 }

--- a/project.go
+++ b/project.go
@@ -25,13 +25,6 @@ type Project struct {
 	Archived                          bool
 }
 
-// Category represents a category in a Backlog project.
-type Category struct {
-	ID           int
-	Name         string
-	DisplayOrder int
-}
-
 // ──────────────────────────────────────────────────────────────
 //  ProjectService
 // ──────────────────────────────────────────────────────────────
@@ -283,25 +276,6 @@ func projectsFromModel(ms []*model.Project) []*Project {
 	result := make([]*Project, len(ms))
 	for i, v := range ms {
 		result[i] = projectFromModel(v)
-	}
-	return result
-}
-
-func categoryFromModel(m *model.Category) *Category {
-	if m == nil {
-		return nil
-	}
-	return &Category{
-		ID:           m.ID,
-		Name:         m.Name,
-		DisplayOrder: m.DisplayOrder,
-	}
-}
-
-func categoriesFromModel(ms []*model.Category) []*Category {
-	result := make([]*Category, len(ms))
-	for i, v := range ms {
-		result[i] = categoryFromModel(v)
 	}
 	return result
 }

--- a/project.go
+++ b/project.go
@@ -25,6 +25,13 @@ type Project struct {
 	Archived                          bool
 }
 
+// Category represents a category in a Backlog project.
+type Category struct {
+	ID           int
+	Name         string
+	DisplayOrder int
+}
+
 // ──────────────────────────────────────────────────────────────
 //  ProjectService
 // ──────────────────────────────────────────────────────────────
@@ -34,6 +41,7 @@ type ProjectService struct {
 	base *project.Service
 
 	Activity *ProjectActivityService
+	Category *ProjectCategoryService
 	User     *ProjectUserService
 	Option   *ProjectOptionService
 }
@@ -128,6 +136,47 @@ func (s *ProjectActivityService) List(ctx context.Context, projectIDOrKey string
 }
 
 // ──────────────────────────────────────────────────────────────
+//  ProjectCategoryService
+// ──────────────────────────────────────────────────────────────
+
+// ProjectCategoryService handles communication with the project category-related methods of the Backlog API.
+type ProjectCategoryService struct {
+	base *project.CategoryService
+}
+
+// All returns a list of categories in a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-category-list
+func (s *ProjectCategoryService) All(ctx context.Context, projectIDOrKey string) ([]*Category, error) {
+	v, err := s.base.All(ctx, projectIDOrKey)
+	return categoriesFromModel(v), convertError(err)
+}
+
+// Create adds a new category to a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-category
+func (s *ProjectCategoryService) Create(ctx context.Context, projectIDOrKey string, name string) (*Category, error) {
+	v, err := s.base.Create(ctx, projectIDOrKey, name)
+	return categoryFromModel(v), convertError(err)
+}
+
+// Update updates a category in a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-category
+func (s *ProjectCategoryService) Update(ctx context.Context, projectIDOrKey string, categoryID int, name string) (*Category, error) {
+	v, err := s.base.Update(ctx, projectIDOrKey, categoryID, name)
+	return categoryFromModel(v), convertError(err)
+}
+
+// Delete deletes a category from a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-category
+func (s *ProjectCategoryService) Delete(ctx context.Context, projectIDOrKey string, categoryID int) (*Category, error) {
+	v, err := s.base.Delete(ctx, projectIDOrKey, categoryID)
+	return categoryFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
 //  ProjectOptionService
 // ──────────────────────────────────────────────────────────────
 
@@ -185,6 +234,7 @@ func newProjectService(method *core.Method, option *core.OptionService) *Project
 	return &ProjectService{
 		base:     project.NewService(method),
 		Activity: newProjectActivityService(method, option),
+		Category: newProjectCategoryService(method),
 		User:     newProjectUserService(method, option),
 		Option:   newProjectOptionService(option),
 	}
@@ -194,6 +244,12 @@ func newProjectActivityService(method *core.Method, option *core.OptionService) 
 	return &ProjectActivityService{
 		base:   activity.NewProjectService(method),
 		Option: newActivityOptionService(option),
+	}
+}
+
+func newProjectCategoryService(method *core.Method) *ProjectCategoryService {
+	return &ProjectCategoryService{
+		base: project.NewCategoryService(method),
 	}
 }
 
@@ -227,6 +283,25 @@ func projectsFromModel(ms []*model.Project) []*Project {
 	result := make([]*Project, len(ms))
 	for i, v := range ms {
 		result[i] = projectFromModel(v)
+	}
+	return result
+}
+
+func categoryFromModel(m *model.Category) *Category {
+	if m == nil {
+		return nil
+	}
+	return &Category{
+		ID:           m.ID,
+		Name:         m.Name,
+		DisplayOrder: m.DisplayOrder,
+	}
+}
+
+func categoriesFromModel(ms []*model.Category) []*Category {
+	result := make([]*Category, len(ms))
+	for i, v := range ms {
+		result[i] = categoryFromModel(v)
 	}
 	return result
 }

--- a/project_test.go
+++ b/project_test.go
@@ -148,6 +148,114 @@ func TestProjectService(t *testing.T) {
 	}
 }
 
+func TestProjectCategoryService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"All": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/categories", req.URL.Path)
+				return mock.NewJSONResponse(fixture.Category.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Category.All(ctx, "TEST")
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+			},
+		},
+		"All/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Category.All(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Create": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/categories", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "Bug", req.PostForm.Get("name"))
+				return mock.NewJSONResponse(fixture.Category.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Category.Create(ctx, "TEST", "Bug")
+				require.NoError(t, err)
+				assert.Equal(t, "Bug", got.Name)
+			},
+		},
+		"Create/error": {
+			doFunc: newAuthErrorDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Category.Create(ctx, "TEST", "Bug")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Update": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPatch, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/categories/12", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "Bug Fixed", req.PostForm.Get("name"))
+				return mock.NewJSONResponse(fixture.Category.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Category.Update(ctx, "TEST", 12, "Bug Fixed")
+				require.NoError(t, err)
+				assert.Equal(t, 12, got.ID)
+			},
+		},
+		"Update/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Category.Update(ctx, "TEST", 12, "Bug Fixed")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Delete": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/categories/12", req.URL.Path)
+				return mock.NewJSONResponse(fixture.Category.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Category.Delete(ctx, "TEST", 12)
+				require.NoError(t, err)
+				assert.Equal(t, 12, got.ID)
+			},
+		},
+		"Delete/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Category.Delete(ctx, "TEST", 12)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}
+
 func TestProjectActivityService(t *testing.T) {
 	ctx := context.Background()
 

--- a/service.go
+++ b/service.go
@@ -4,13 +4,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 )
 
-// CategoryService handles communication with the category-related methods of the Backlog API.
-//
-//nolint:unused // API not implemented yet
-type CategoryService struct {
-	method *core.Method
-}
-
 // CustomFieldService handles communication with the custom field-related methods of the Backlog API.
 //
 //nolint:unused // API not implemented yet


### PR DESCRIPTION
## Summary

Implement `Project.Category` as a sub-service of `ProjectService`, covering all four CRUD operations exposed by the Backlog API.

## Changes

- Add `Category` model to `internal/model/project.go`
- Add `CategoryService` to `internal/project/service.go` with `All`, `Create`, `Update`, and `Delete` methods
- Add `TestCategoryService_{All,Create,Update,Delete}` and context propagation cases to `internal/project/service_test.go`
- Add public `ProjectCategoryService` to `project.go` and wire it into `ProjectService` as `Category` field
- Add `categoryFromModel` / `categoriesFromModel` helpers to `project.go`
- Remove `CategoryService` stub from `service.go`
- Add `Category` fixture to `internal/testutil/fixture/testdata_project.go`
- Add `TestProjectCategoryService` to `project_test.go`
- Add `ExampleProjectCategoryService_{All,Create,Update,Delete}` to `example_project_test.go`

Part of #215