### PR TITLE
feat: add project disk usage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 - [Get Project](https://developer.nulab.com/docs/backlog/api/2/get-project) - Returns information about a project.
 - [Update Project](https://developer.nulab.com/docs/backlog/api/2/update-project) - Updates information about project.
 - [Delete Project](https://developer.nulab.com/docs/backlog/api/2/delete-project) - Deletes a project.
+- [Get Project Disk Usage](https://developer.nulab.com/docs/backlog/api/2/get-project-disk-usage/) - Returns disk usage of a project.
 
 ### Client.Project.[Activity](https://pkg.go.dev/github.com/nattokin/go-backlog#ProjectActivityService)
 

--- a/example_project_test.go
+++ b/example_project_test.go
@@ -10,11 +10,12 @@ import (
 
 var (
 	// ProjectService
-	doerProjectAll    = newMockDoer(fixture.Project.ListJSON)
-	doerProjectOne    = newMockDoer(fixture.Project.SingleJSON)
-	doerProjectCreate = newMockDoer(fixture.Project.SingleJSON)
-	doerProjectUpdate = newMockDoer(fixture.Project.SingleJSON)
-	doerProjectDelete = newMockDoer(fixture.Project.SingleJSON)
+	doerProjectAll       = newMockDoer(fixture.Project.ListJSON)
+	doerProjectOne       = newMockDoer(fixture.Project.SingleJSON)
+	doerProjectCreate    = newMockDoer(fixture.Project.SingleJSON)
+	doerProjectUpdate    = newMockDoer(fixture.Project.SingleJSON)
+	doerProjectDelete    = newMockDoer(fixture.Project.SingleJSON)
+	doerProjectDiskUsage = newMockDoer(fixture.Project.DiskUsageJSON)
 
 	// ProjectActivityService
 	doerProjectActivityList = newMockDoer(fixture.Activity.ListJSON)
@@ -102,6 +103,19 @@ func ExampleProjectService_Delete() {
 	fmt.Printf("ID: %d, Key: %s\n", project.ID, project.ProjectKey)
 	// Output:
 	// ID: 6, Key: TEST
+}
+
+func ExampleProjectService_DiskUsage() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectDiskUsage),
+	)
+
+	usage, _ := c.Project.DiskUsage(context.Background(), "TEST")
+	fmt.Printf("ProjectID: %d, Issue: %d\n", usage.ProjectID, usage.Issue)
+	// Output:
+	// ProjectID: 1, Issue: 11931
 }
 
 func ExampleProjectActivityService_List() {

--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -11,3 +11,9 @@ type Project struct {
 	TextFormattingRule                Format `json:"textFormattingRule,omitempty"`
 	Archived                          bool   `json:"archived,omitempty"`
 }
+
+// DiskUsageProject represents project's disk usage.
+type DiskUsageProject struct {
+	DiskUsageBase
+	ProjectID int `json:"projectId,omitempty"`
+}

--- a/internal/model/space.go
+++ b/internal/model/space.go
@@ -2,12 +2,6 @@ package model
 
 import "time"
 
-// DiskUsageProject represents project's disk usage.
-type DiskUsageProject struct {
-	DiskUsageBase
-	ProjectID int `json:"projectId,omitempty"`
-}
-
 // DiskUsageSpace represents space's disk usage.
 type DiskUsageSpace struct {
 	DiskUsageBase

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -125,6 +125,28 @@ func (s *Service) Delete(ctx context.Context, projectIDOrKey string) (*model.Pro
 	return &v, nil
 }
 
+// DiskUsage returns disk usage of a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-disk-usage
+func (s *Service) DiskUsage(ctx context.Context, projectIDOrKey string) (*model.DiskUsageProject, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "diskUsage")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.DiskUsageProject{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
 // ──────────────────────────────────────────────────────────────
 //  CategoryService
 // ──────────────────────────────────────────────────────────────

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestProjectService_All(t *testing.T) {
+func TestService_All(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -123,7 +123,7 @@ func TestProjectService_All(t *testing.T) {
 	}
 }
 
-func TestProjectService_One(t *testing.T) {
+func TestService_One(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 
@@ -207,7 +207,7 @@ func TestProjectService_One(t *testing.T) {
 	}
 }
 
-func TestProjectService_Create(t *testing.T) {
+func TestService_Create(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -357,7 +357,7 @@ func TestProjectService_Create(t *testing.T) {
 	}
 }
 
-func TestProjectService_Update(t *testing.T) {
+func TestService_Update(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -494,7 +494,7 @@ func TestProjectService_Update(t *testing.T) {
 	}
 }
 
-func TestProjectService_Delete(t *testing.T) {
+func TestService_Delete(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 
@@ -574,6 +574,76 @@ func TestProjectService_Delete(t *testing.T) {
 			require.NotNil(t, project)
 
 			assert.Equal(t, "TEST", project.ProjectKey)
+		})
+	}
+}
+
+func TestService_DiskUsage(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType   error
+		wantProjectID int
+		wantIssue     int
+	}{
+		"success-project-key": {
+			projectIDOrKey: "TEST",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/diskUsage", spath)
+				assert.Nil(t, query)
+				return mock.NewJSONResponse(fixture.Project.DiskUsageJSON), nil
+			},
+			wantProjectID: 1,
+			wantIssue:     11931,
+		},
+		"error-validation-projectIDOrKey-empty": {
+			projectIDOrKey: "",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: "TEST",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/diskUsage", spath)
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "TEST",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/diskUsage", spath)
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := project.NewService(method)
+
+			got, err := s.DiskUsage(context.Background(), tc.projectIDOrKey)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantProjectID, got.ProjectID)
+			assert.Equal(t, tc.wantIssue, got.Issue)
 		})
 	}
 }
@@ -929,30 +999,35 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"ProjectService.All", func(t *testing.T, m *core.Method) {
+		{"Service.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewService(m)
 			s.All(ctx) //nolint:errcheck
 		}},
-		{"ProjectService.One", func(t *testing.T, m *core.Method) {
+		{"Service.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewService(m)
 			s.One(ctx, "TEST") //nolint:errcheck
 		}},
-		{"ProjectService.Create", func(t *testing.T, m *core.Method) {
+		{"Service.Create", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
 			s := project.NewService(m)
 			s.Create(ctx, "KEY", "name", o.WithChartEnabled(true)) //nolint:errcheck
 		}},
-		{"ProjectService.Update", func(t *testing.T, m *core.Method) {
+		{"Service.Update", func(t *testing.T, m *core.Method) {
 			m.Patch = makeMockFn(t)
 			s := project.NewService(m)
 			s.Update(ctx, "TEST") //nolint:errcheck
 		}},
-		{"ProjectService.Delete", func(t *testing.T, m *core.Method) {
+		{"Service.Delete", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)
 			s := project.NewService(m)
 			s.Delete(ctx, "TEST") //nolint:errcheck
+		}},
+		{"Service.DiskUsage", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := project.NewService(m)
+			s.DiskUsage(ctx, "TEST") //nolint:errcheck
 		}},
 		{"CategoryService.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)

--- a/internal/testutil/fixture/testdata_project.go
+++ b/internal/testutil/fixture/testdata_project.go
@@ -5,10 +5,12 @@ import (
 )
 
 type projectFixtures struct {
-	SingleJSON string
-	Single     *backlog.Project
-	ListJSON   string
-	List       []*backlog.Project
+	SingleJSON    string
+	Single        *backlog.Project
+	ListJSON      string
+	List          []*backlog.Project
+	DiskUsageJSON string
+	DiskUsage     *backlog.DiskUsageProject
 }
 
 type categoryFixtures struct {
@@ -93,6 +95,26 @@ var Project = projectFixtures{
 			Name:               "test3",
 			TextFormattingRule: backlog.FormatMarkdown,
 		},
+	},
+	DiskUsageJSON: `
+{
+	"projectId": 1,
+	"issue": 11931,
+	"wiki": 0,
+	"file": 0,
+	"subversion": 0,
+	"git": 0,
+	"gitLFS": 0
+}
+`,
+	DiskUsage: &backlog.DiskUsageProject{
+		ProjectID:  1,
+		Issue:      11931,
+		Wiki:       0,
+		File:       0,
+		Subversion: 0,
+		Git:        0,
+		GitLFS:     0,
 	},
 }
 

--- a/project.go
+++ b/project.go
@@ -104,6 +104,14 @@ func (s *ProjectService) Delete(ctx context.Context, projectIDOrKey string) (*Pr
 	return projectFromModel(v), convertError(err)
 }
 
+// DiskUsage returns information about the disk usage of your project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-disk-usage
+func (s *ProjectService) DiskUsage(ctx context.Context, projectIDOrKey string) (*DiskUsageProject, error) {
+	v, err := s.base.DiskUsage(ctx, projectIDOrKey)
+	return diskUsageProjectFromModel(v), convertError(err)
+}
+
 // ──────────────────────────────────────────────────────────────
 //  ProjectActivityService
 // ──────────────────────────────────────────────────────────────

--- a/project_test.go
+++ b/project_test.go
@@ -137,6 +137,28 @@ func TestProjectService(t *testing.T) {
 				assert.True(t, errors.As(err, &target))
 			},
 		},
+		"DiskUsage": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/diskUsage", req.URL.Path)
+				return mock.NewJSONResponse(fixture.Project.DiskUsageJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.DiskUsage(ctx, "TEST")
+				require.NoError(t, err)
+				assert.Equal(t, 1, got.ProjectID)
+				assert.Equal(t, 11931, got.Issue)
+			},
+		},
+		"DiskUsage/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.DiskUsage(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
## Summary

Add support for Project Disk Usage API.

This PR implements project disk usage retrieval, along with tests, examples, and client coverage.

## Changes

Added support for:
- Get Project Disk Usage

Implemented:
- `ProjectService.DiskUsage`
- public client support for `Client.Project.DiskUsage(...)`

## Tests
Added coverage for:

- internal service tests for project disk usage
- context propagation coverage
- client-level integration tests for project disk usage

## Documentation
Added:
- `ExampleProjectService_DiskUsage`
- pkg.go.dev example coverage

## Supported Endpoints
- `GET /api/v2/projects/{projectIdOrKey}/diskUsage`

Part of #215 