### PR TITLE
feat: implement Project Version/Milestone Service and Option Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 - [Update Webhook](https://developer.nulab.com/docs/backlog/api/2/update-webhook/) - Updates a webhook in a project.
 - [Delete Webhook](https://developer.nulab.com/docs/backlog/api/2/delete-webhook/) - Deletes a webhook from a project.
 
+### Client.Project.[Version](https://pkg.go.dev/github.com/nattokin/go-backlog#ProjectVersionService)
+
+- [Get Version/Milestone List](https://developer.nulab.com/docs/backlog/api/2/get-version-milestone-list/) - Returns a list of versions/milestones in a project.
+- [Add Version/Milestone](https://developer.nulab.com/docs/backlog/api/2/add-version-milestone/) - Adds a new version/milestone to a project.
+- [Update Version/Milestone](https://developer.nulab.com/docs/backlog/api/2/update-version-milestone/) - Updates a version/milestone in a project.
+- [Delete Version](https://developer.nulab.com/docs/backlog/api/2/delete-version/) - Deletes a version/milestone from a project.
+
 ### Client.[Issue](https://pkg.go.dev/github.com/nattokin/go-backlog#IssueService)
 
 - [Get Issue List](https://developer.nulab.com/docs/backlog/api/2/get-issue-list) - Returns a list of issues.

--- a/internal/core/option.go
+++ b/internal/core/option.go
@@ -61,6 +61,7 @@ const (
 	ParamProjectLeaderCanEditProjectLeader APIParamOptionType = "projectLeaderCanEditProjectLeader"
 	ParamPullRequestCommentID              APIParamOptionType = "pullRequestCommentId"
 	ParamPullRequestID                     APIParamOptionType = "pullRequestId"
+	ParamReleaseDueDate                    APIParamOptionType = "releaseDueDate"
 	ParamResolutionID                      APIParamOptionType = "resolutionId"
 	ParamResolutionIDs                     APIParamOptionType = "resolutionId[]"
 	ParamRoleType                          APIParamOptionType = "roleType"

--- a/internal/core/option_time.go
+++ b/internal/core/option_time.go
@@ -53,3 +53,8 @@ func (s *OptionService) WithDueDateSince(t time.Time) RequestOption {
 func (s *OptionService) WithDueDateUntil(t time.Time) RequestOption {
 	return timeOption(ParamDueDateUntil, t, issueDateFormat)
 }
+
+// WithReleaseDueDate returns an option to set the `releaseDueDate` parameter.
+func (s *OptionService) WithReleaseDueDate(t time.Time) RequestOption {
+	return timeOption(ParamReleaseDueDate, t, issueDateFormat)
+}

--- a/internal/core/option_time_test.go
+++ b/internal/core/option_time_test.go
@@ -26,6 +26,7 @@ func TestOptionService_time(t *testing.T) {
 		"WithDueDate":        {option: o.WithDueDate(date), key: core.ParamDueDate.Value()},
 		"WithDueDateSince":   {option: o.WithDueDateSince(date), key: core.ParamDueDateSince.Value()},
 		"WithDueDateUntil":   {option: o.WithDueDateUntil(date), key: core.ParamDueDateUntil.Value()},
+		"WithReleaseDueDate": {option: o.WithReleaseDueDate(date), key: core.ParamReleaseDueDate.Value()},
 		"WithStartDate":      {option: o.WithStartDate(date), key: core.ParamStartDate.Value()},
 		"WithStartDateSince": {option: o.WithStartDateSince(date), key: core.ParamStartDateSince.Value()},
 		"WithStartDateUntil": {option: o.WithStartDateUntil(date), key: core.ParamStartDateUntil.Value()},

--- a/internal/testutil/fixture/testdata_version.go
+++ b/internal/testutil/fixture/testdata_version.go
@@ -1,0 +1,71 @@
+package fixture
+
+import "github.com/nattokin/go-backlog"
+
+type versionFixtures struct {
+	SingleJSON string
+	Single     *backlog.Version
+	ListJSON   string
+	List       []*backlog.Version
+}
+
+var Version = versionFixtures{
+	SingleJSON: `{
+		"id": 1,
+		"projectId": 100,
+		"name": "Version 1.0",
+		"description": "Initial release milestone",
+		"startDate": null,
+		"releaseDueDate": null,
+		"archived": false,
+		"displayOrder": 1
+	}`,
+	Single: &backlog.Version{
+		ID:           1,
+		ProjectID:    100,
+		Name:         "Version 1.0",
+		Description:  "Initial release milestone",
+		Archived:     false,
+		DisplayOrder: 1,
+	},
+	ListJSON: `[
+		{
+			"id": 1,
+			"projectId": 100,
+			"name": "Version 1.0",
+			"description": "Initial release milestone",
+			"startDate": null,
+			"releaseDueDate": null,
+			"archived": false,
+			"displayOrder": 1
+		},
+		{
+			"id": 2,
+			"projectId": 100,
+			"name": "Version 2.0",
+			"description": "Second release milestone",
+			"startDate": null,
+			"releaseDueDate": null,
+			"archived": false,
+			"displayOrder": 2
+		}
+	]`,
+	List: []*backlog.Version{
+		{
+			ID:           1,
+			ProjectID:    100,
+			Name:         "Version 1.0",
+			Description:  "Initial release milestone",
+			Archived:     false,
+			DisplayOrder: 1,
+		},
+		{
+			ID:           2,
+			ProjectID:    100,
+			Name:         "Version 2.0",
+			Description:  "Second release milestone",
+			Archived:     false,
+			DisplayOrder: 2,
+		},
+	},
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -88,6 +88,13 @@ func ValidateUserID(userID int) error {
 	return nil
 }
 
+func ValidateVersionID(versionID int) error {
+	if versionID < 1 {
+		return core.NewValidationError("versionID must not be less than 1")
+	}
+	return nil
+}
+
 func ValidateWebhookID(webhookID int) error {
 	if webhookID < 1 {
 		return core.NewValidationError("webhookID must not be less than 1")

--- a/internal/version/service.go
+++ b/internal/version/service.go
@@ -1,0 +1,161 @@
+package version
+
+import (
+	"context"
+	"net/url"
+	"path"
+	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/validate"
+)
+
+// Service provides Version/Milestone API operations.
+type Service struct {
+	method *core.Method
+}
+
+// All returns versions/milestones in a project.
+func (s *Service) All(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Version, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+
+	query := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamArchived,
+		core.ParamAll,
+	}
+	if err := core.ApplyOptions(query, validTypes, opts...); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "versions")
+	resp, err := s.method.Get(ctx, spath, query)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.Version{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Add adds a version/milestone.
+func (s *Service) Add(ctx context.Context, projectIDOrKey, name string, opts ...core.RequestOption) (*model.Version, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if name == "" {
+		return nil, core.NewValidationError("name is required")
+	}
+
+	option := &core.OptionService{}
+	form := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamName,
+		core.ParamDescription,
+		core.ParamStartDate,
+		core.ParamReleaseDueDate,
+	}
+	options := append([]core.RequestOption{option.WithName(name)}, opts...)
+	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "versions")
+	resp, err := s.method.Post(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Version{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Update updates a version/milestone.
+func (s *Service) Update(ctx context.Context, projectIDOrKey string, versionID int, opts ...core.RequestOption) (*model.Version, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateVersionID(versionID); err != nil {
+		return nil, err
+	}
+
+	if !core.HasRequiredOption(opts, []core.APIParamOptionType{
+		core.ParamName,
+		core.ParamDescription,
+		core.ParamStartDate,
+		core.ParamReleaseDueDate,
+		core.ParamArchived,
+	}) {
+		return nil, core.NewValidationError(
+			"requires an option to modify version fields",
+		)
+	}
+
+	form := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamName,
+		core.ParamDescription,
+		core.ParamStartDate,
+		core.ParamReleaseDueDate,
+		core.ParamArchived,
+	}
+	if err := core.ApplyOptions(form, validTypes, opts...); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "versions", strconv.Itoa(versionID))
+	resp, err := s.method.Patch(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Version{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Delete deletes a version/milestone.
+func (s *Service) Delete(ctx context.Context, projectIDOrKey string, versionID int) (*model.Version, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateVersionID(versionID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "versions", strconv.Itoa(versionID))
+	resp, err := s.method.Delete(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Version{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
+// NewService returns a Version service.
+func NewService(method *core.Method) *Service {
+	return &Service{method: method}
+}

--- a/internal/version/service_test.go
+++ b/internal/version/service_test.go
@@ -45,6 +45,12 @@ func TestService_All(t *testing.T) {
 			wantErrType:    &core.ValidationError{},
 			mockGetFn:      mock.NewUnexpectedGetFn(t),
 		},
+		"error-option-invalid-type": {
+			projectIDOrKey: "TEST",
+			opts:           []core.RequestOption{mock.NewInvalidTypeOption()},
+			wantErrType:    &core.InvalidOptionKeyError{},
+		},
+
 		"error-client": {
 			projectIDOrKey: "TEST",
 			wantErrType:    errors.New(""),

--- a/internal/version/service_test.go
+++ b/internal/version/service_test.go
@@ -1,0 +1,317 @@
+package version_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+	"github.com/nattokin/go-backlog/internal/testutil/mock"
+	"github.com/nattokin/go-backlog/internal/version"
+)
+
+func TestService_All(t *testing.T) {
+	option := &core.OptionService{}
+
+	cases := map[string]struct {
+		projectIDOrKey string
+		opts           []core.RequestOption
+		wantErrType    error
+		wantLen        int
+		mockGetFn      func(context.Context, string, url.Values) (*http.Response, error)
+	}{
+		"success": {
+			projectIDOrKey: "TEST",
+			wantLen:        2,
+			opts: []core.RequestOption{
+				option.WithArchived(true),
+			},
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/versions", spath)
+				assert.Equal(t, "true", query.Get("archived"))
+				return mock.NewJSONResponse(fixture.Version.ListJSON), nil
+			},
+		},
+		"error-project-empty": {
+			projectIDOrKey: "",
+			wantErrType:    &core.ValidationError{},
+			mockGetFn:      mock.NewUnexpectedGetFn(t),
+		},
+		"error-client": {
+			projectIDOrKey: "TEST",
+			wantErrType:    errors.New(""),
+			mockGetFn: func(context.Context, string, url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+		},
+		"error-invalid-json": {
+			projectIDOrKey: "TEST",
+			wantErrType:    &json.SyntaxError{},
+			mockGetFn: func(context.Context, string, url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			m := mock.NewMethod(t)
+			m.Get = tc.mockGetFn
+			s := version.NewService(m)
+			got, err := s.All(context.Background(), tc.projectIDOrKey, tc.opts...)
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, got, tc.wantLen)
+		})
+	}
+}
+
+func TestService_Add(t *testing.T) {
+	o := &core.OptionService{}
+	date := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := map[string]struct {
+		projectIDOrKey string
+		name           string
+		opts           []core.RequestOption
+		wantErrType    error
+		wantID         int
+		mockPostFn     func(context.Context, string, url.Values) (*http.Response, error)
+	}{
+		"success": {
+			projectIDOrKey: "TEST",
+			name:           "v1",
+			opts:           []core.RequestOption{o.WithDescription("desc"), o.WithStartDate(date), o.WithReleaseDueDate(date)},
+			wantID:         fixture.Version.Single.ID,
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/versions", spath)
+				assert.Equal(t, "v1", form.Get("name"))
+				return mock.NewJSONResponse(fixture.Version.SingleJSON), nil
+			},
+		},
+		"error-name-empty": {
+			projectIDOrKey: "TEST",
+			name:           "",
+			opts:           []core.RequestOption{o.WithDescription("desc")},
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-project-empty": {
+			projectIDOrKey: "",
+			name:           "v1",
+			opts:           []core.RequestOption{o.WithDescription("desc")},
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-option-invalid-type": {
+			projectIDOrKey: "TEST",
+			name:           "v1",
+			opts:           []core.RequestOption{mock.NewInvalidTypeOption()},
+			wantErrType:    &core.InvalidOptionKeyError{},
+		},
+		"error-option-set-failed": {
+			projectIDOrKey: "TEST",
+			name:           "v1",
+			opts:           []core.RequestOption{mock.NewFailingSetOption(core.ParamDescription)},
+			wantErrType:    errors.New(""),
+		},
+		"error-client-network": {
+			projectIDOrKey: "TEST",
+			name:           "v1",
+			wantErrType:    errors.New(""),
+			mockPostFn:     func(context.Context, string, url.Values) (*http.Response, error) { return nil, errors.New("network") },
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "TEST",
+			name:           "v1",
+			wantErrType:    &json.SyntaxError{},
+			mockPostFn: func(context.Context, string, url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := mock.NewMethod(t)
+			if tc.mockPostFn != nil {
+				m.Post = tc.mockPostFn
+			}
+			s := version.NewService(m)
+			got, err := s.Add(context.Background(), tc.projectIDOrKey, tc.name, tc.opts...)
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}
+
+func TestService_Update(t *testing.T) {
+	o := &core.OptionService{}
+	date := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	cases := map[string]struct {
+		projectIDOrKey string
+		versionID      int
+		opts           []core.RequestOption
+		wantErrType    error
+		wantID         int
+		mockPatchFn    func(context.Context, string, url.Values) (*http.Response, error)
+	}{
+		"success": {
+			projectIDOrKey: "TEST",
+			versionID:      1,
+			opts:           []core.RequestOption{o.WithName("name"), o.WithReleaseDueDate(date)},
+			wantID:         fixture.Version.Single.ID,
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/versions/1", spath)
+				return mock.NewJSONResponse(fixture.Version.SingleJSON), nil
+			},
+		},
+		"error-versionID-negative": {
+			projectIDOrKey: "TEST",
+			versionID:      -1,
+			opts:           []core.RequestOption{o.WithName("name")},
+			wantErrType:    &core.ValidationError{},
+			mockPatchFn:    mock.NewUnexpectedPatchFn(t),
+		},
+		"error-option-invalid-type": {
+			projectIDOrKey: "TEST",
+			versionID:      1,
+			opts:           []core.RequestOption{o.WithName("name"), mock.NewInvalidTypeOption()},
+			wantErrType:    &core.InvalidOptionKeyError{},
+		},
+		"error-option-set-failed": {
+			projectIDOrKey: "TEST",
+			versionID:      1,
+			opts:           []core.RequestOption{mock.NewFailingSetOption(core.ParamArchived)},
+			wantErrType:    errors.New(""),
+		},
+		"error-no-options": {
+			projectIDOrKey: "TEST",
+			versionID:      1,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-project-empty": {
+			projectIDOrKey: "",
+			versionID:      1,
+			opts:           []core.RequestOption{o.WithName("name")},
+			wantErrType:    &core.ValidationError{},
+			mockPatchFn:    mock.NewUnexpectedPatchFn(t),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "TEST",
+			versionID:      1,
+			opts:           []core.RequestOption{o.WithName("name")},
+			wantErrType:    &json.SyntaxError{},
+			mockPatchFn: func(context.Context, string, url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+		},
+		"error-versionID-zero": {
+			projectIDOrKey: "TEST",
+			versionID:      0,
+			opts:           []core.RequestOption{o.WithName("name")},
+			wantErrType:    &core.ValidationError{},
+			mockPatchFn:    mock.NewUnexpectedPatchFn(t),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := mock.NewMethod(t)
+			if tc.mockPatchFn != nil {
+				m.Patch = tc.mockPatchFn
+			}
+			s := version.NewService(m)
+			got, err := s.Update(context.Background(), tc.projectIDOrKey, tc.versionID, tc.opts...)
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}
+
+func TestService_Delete(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+		versionID      int
+		wantErrType    error
+		wantID         int
+		mockDeleteFn   func(context.Context, string, url.Values) (*http.Response, error)
+	}{
+		"success": {
+			projectIDOrKey: "TEST", versionID: 1, wantID: fixture.Version.Single.ID,
+			mockDeleteFn: func(ctx context.Context, spath string, _ url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/versions/1", spath)
+				return mock.NewJSONResponse(fixture.Version.SingleJSON), nil
+			},
+		},
+		"error-versionID-zero": {
+			projectIDOrKey: "TEST", versionID: 0, wantErrType: &core.ValidationError{}, mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
+		},
+		"error-versionID-negative": {
+			projectIDOrKey: "TEST",
+			versionID:      -1,
+			wantErrType:    &core.ValidationError{},
+			mockDeleteFn:   mock.NewUnexpectedDeleteFn(t),
+		},
+		"error-project-empty": {
+			projectIDOrKey: "", versionID: 1, wantErrType: &core.ValidationError{}, mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
+		},
+		"error-client-network": {
+			projectIDOrKey: "TEST", versionID: 1, wantErrType: errors.New(""),
+			mockDeleteFn: func(context.Context, string, url.Values) (*http.Response, error) { return nil, errors.New("network") },
+		},
+		"error-invalid-json": {
+			projectIDOrKey: "TEST", versionID: 1, wantErrType: &json.SyntaxError{},
+			mockDeleteFn: func(context.Context, string, url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := mock.NewMethod(t)
+			m.Delete = tc.mockDeleteFn
+			s := version.NewService(m)
+			got, err := s.Delete(context.Background(), tc.projectIDOrKey, tc.versionID)
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -193,6 +193,10 @@ func (s *Service) Delete(ctx context.Context, projectIDOrKey string, webhookID i
 	return v, nil
 }
 
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
 // NewService creates and returns a new webhook Service.
 func NewService(method *core.Method) *Service {
 	return &Service{method: method}

--- a/project.go
+++ b/project.go
@@ -2,6 +2,7 @@ package backlog
 
 import (
 	"context"
+	"time"
 
 	"github.com/nattokin/go-backlog/internal/activity"
 	"github.com/nattokin/go-backlog/internal/core"
@@ -9,6 +10,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/project"
 	"github.com/nattokin/go-backlog/internal/sharedfile"
 	"github.com/nattokin/go-backlog/internal/user"
+	"github.com/nattokin/go-backlog/internal/version"
 	"github.com/nattokin/go-backlog/internal/webhook"
 )
 
@@ -41,7 +43,9 @@ type ProjectService struct {
 	User       *ProjectUserService
 	SharedFile *ProjectSharedFileService
 	Webhook    *ProjectWebhookService
-	Option     *ProjectOptionService
+	Version    *ProjectVersionService
+
+	Option *ProjectOptionService
 }
 
 // All returns a list of projects.
@@ -317,6 +321,66 @@ func (s *ProjectWebhookService) Delete(ctx context.Context, projectIDOrKey strin
 }
 
 // ──────────────────────────────────────────────────────────────
+//  ProjectVersionService
+// ──────────────────────────────────────────────────────────────
+
+// ProjectVersionService handles communication with the project version/milestone-related methods of the Backlog API.
+type ProjectVersionService struct {
+	base   *version.Service
+	Option *ProjectVersionOptionService
+}
+
+// All returns a list of versions/milestones in the project.
+//
+// This method supports options returned by methods in "*Client.Project.Version.Option",
+// such as:
+//   - WithArchived
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-version-milestone-list/
+func (s *ProjectVersionService) All(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*Version, error) {
+	v, err := s.base.All(ctx, projectIDOrKey, toCoreOptions(opts)...)
+	return versionsFromModel(v), convertError(err)
+}
+
+// Create adds a version/milestone to the project.
+//
+// This method supports options returned by methods in "*Client.Project.Version.Option",
+// such as:
+//   - WithDescription
+//   - WithReleaseDueDate
+//   - WithStartDate
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-version-milestone/
+func (s *ProjectVersionService) Create(ctx context.Context, projectIDOrKey, name string, opts ...RequestOption) (*Version, error) {
+	v, err := s.base.Add(ctx, projectIDOrKey, name, toCoreOptions(opts)...)
+	return versionFromModel(v), convertError(err)
+}
+
+// Update updates a version/milestone.
+//
+// This method supports options returned by methods in "*Client.Project.Version.Option",
+// such as:
+//   - WithArchived
+//   - WithDescription
+//   - WithName
+//   - WithReleaseDueDate
+//   - WithStartDate
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-version-milestone/
+func (s *ProjectVersionService) Update(ctx context.Context, projectIDOrKey string, versionID int, opts ...RequestOption) (*Version, error) {
+	v, err := s.base.Update(ctx, projectIDOrKey, versionID, toCoreOptions(opts)...)
+	return versionFromModel(v), convertError(err)
+}
+
+// Delete deletes a version/milestone.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-version/
+func (s *ProjectVersionService) Delete(ctx context.Context, projectIDOrKey string, versionID int) (*Version, error) {
+	v, err := s.base.Delete(ctx, projectIDOrKey, versionID)
+	return versionFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
 //  ProjectOptionService
 // ──────────────────────────────────────────────────────────────
 
@@ -402,6 +466,41 @@ func (s *ProjectWebhookOptionService) WithName(name string) RequestOption {
 }
 
 // ──────────────────────────────────────────────────────────────
+//  ProjectVersionOptionService
+// ──────────────────────────────────────────────────────────────
+
+// ProjectVersionOptionService provides a domain-specific set of option builders
+// for operations within the ProjectVersionService.
+type ProjectVersionOptionService struct {
+	base *core.OptionService
+}
+
+// WithArchived sets whether to include archived versions.
+func (s *ProjectVersionOptionService) WithArchived(enabled bool) RequestOption {
+	return s.base.WithArchived(enabled)
+}
+
+// WithDescription sets the version description.
+func (s *ProjectVersionOptionService) WithDescription(description string) RequestOption {
+	return s.base.WithDescription(description)
+}
+
+// WithName sets the version name.
+func (s *ProjectVersionOptionService) WithName(name string) RequestOption {
+	return s.base.WithName(name)
+}
+
+// WithReleaseDueDate sets the release due date.
+func (s *ProjectVersionOptionService) WithReleaseDueDate(t time.Time) RequestOption {
+	return s.base.WithReleaseDueDate(t)
+}
+
+// WithStartDate sets the version start date.
+func (s *ProjectVersionOptionService) WithStartDate(t time.Time) RequestOption {
+	return s.base.WithStartDate(t)
+}
+
+// ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
@@ -413,6 +512,7 @@ func newProjectService(method *core.Method, option *core.OptionService) *Project
 		User:       newProjectUserService(method, option),
 		SharedFile: newProjectSharedFileService(method),
 		Webhook:    newProjectWebhookService(method, option),
+		Version:    newProjectVersionService(method, option),
 		Option:     newProjectOptionService(option),
 	}
 }
@@ -443,6 +543,13 @@ func newProjectWebhookService(method *core.Method, option *core.OptionService) *
 	}
 }
 
+func newProjectVersionService(method *core.Method, option *core.OptionService) *ProjectVersionService {
+	return &ProjectVersionService{
+		base:   version.NewService(method),
+		Option: newVersionOptionService(option),
+	}
+}
+
 func newProjectOptionService(option *core.OptionService) *ProjectOptionService {
 	return &ProjectOptionService{
 		base: option,
@@ -451,6 +558,10 @@ func newProjectOptionService(option *core.OptionService) *ProjectOptionService {
 
 func newWebhookOptionService(option *core.OptionService) *ProjectWebhookOptionService {
 	return &ProjectWebhookOptionService{base: option}
+}
+
+func newVersionOptionService(option *core.OptionService) *ProjectVersionOptionService {
+	return &ProjectVersionOptionService{base: option}
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/project_test.go
+++ b/project_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -530,6 +531,136 @@ func TestProjectWebhookService(t *testing.T) {
 	}
 }
 
+func TestProjectVersionService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"All": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/versions", req.URL.Path)
+				return mock.NewJSONResponse(fixture.Version.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Version.All(ctx, "TEST")
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, fixture.Version.Single.ID, got[0].ID)
+			},
+		},
+		"All/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Version.All(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Create": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/versions", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "v1.0.0", req.PostForm.Get("name"))
+				assert.Equal(t, "first release", req.PostForm.Get("description"))
+				return mock.NewJSONResponse(fixture.Version.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Version.Create(
+					ctx,
+					"TEST",
+					"v1.0.0",
+					c.Project.Version.Option.WithDescription("first release"),
+				)
+				require.NoError(t, err)
+				assert.Equal(t, fixture.Version.Single.ID, got.ID)
+			},
+		},
+		"Create/error": {
+			doFunc: newAuthErrorDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Version.Create(ctx, "TEST", "v1.0.0")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Update": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPatch, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/versions/1", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "v1.0.1", req.PostForm.Get("name"))
+				return mock.NewJSONResponse(fixture.Version.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Version.Update(
+					ctx,
+					"TEST",
+					1,
+					c.Project.Version.Option.WithName("v1.0.1"),
+				)
+				require.NoError(t, err)
+				assert.Equal(t, fixture.Version.Single.ID, got.ID)
+			},
+		},
+		"Update/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Version.Update(
+					ctx,
+					"TEST",
+					1,
+					c.Project.Version.Option.WithName("v1.0.1"),
+				)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Delete": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/versions/1", req.URL.Path)
+				return mock.NewJSONResponse(fixture.Version.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Version.Delete(ctx, "TEST", 1)
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				assert.Equal(t, fixture.Version.Single.ID, got.ID)
+			},
+		},
+		"Delete/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Version.Delete(ctx, "TEST", 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient(
+				"https://example.backlog.com",
+				"token",
+				backlog.WithDoer(&mockDoer{do: tc.doFunc}),
+			)
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}
+
 func TestProjectUserService(t *testing.T) {
 	ctx := context.Background()
 
@@ -770,6 +901,47 @@ func TestProjectWebhookOptionService(t *testing.T) {
 		"WithDescription": {
 			option:  s.WithDescription("desc"),
 			wantKey: core.ParamDescription.Value(),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.wantKey, tc.option.Key())
+		})
+	}
+}
+
+func TestProjectVersionOptionService(t *testing.T) {
+	c, err := backlog.NewClient("https://example.backlog.com", "token")
+	require.NoError(t, err)
+
+	date := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+	s := c.Project.Version.Option
+
+	cases := map[string]struct {
+		option  backlog.RequestOption
+		wantKey string
+	}{
+		"WithArchived": {
+			option:  s.WithArchived(true),
+			wantKey: core.ParamArchived.Value(),
+		},
+		"WithDescription": {
+			option:  s.WithDescription("desc"),
+			wantKey: core.ParamDescription.Value(),
+		},
+		"WithName": {
+			option:  s.WithName("v1.0.0"),
+			wantKey: core.ParamName.Value(),
+		},
+		"WithReleaseDueDate": {
+			option:  s.WithReleaseDueDate(date),
+			wantKey: core.ParamReleaseDueDate.Value(),
+		},
+		"WithStartDate": {
+			option:  s.WithStartDate(date),
+			wantKey: core.ParamStartDate.Value(),
 		},
 	}
 


### PR DESCRIPTION
## Summary

Implement Version/Milestone support for Project APIs, including service methods, option builders, fixtures, and test coverage.

## Changes

### Added Project Version service support
- Implement `ProjectVersionService`
- Add support for:
  - Get Version/Milestone List
  - Add Version/Milestone
  - Update Version/Milestone
  - Delete Version

### Added option support
- Implement `ProjectVersionOptionService`
- Add new option support:
  - `WithName`
  - `WithDescription`
  - `WithStartDate`
  - `WithReleaseDueDate`
  - `WithArchived`

### Internal improvements
- Add Version fixtures and JSON responses for tests

### Test coverage
- Add unit tests for `Service`
  - success cases
  - client error cases
  - validation errors
  - invalid JSON handling
  - parameter validation coverage for `projectIDOrKey`, `versionID`, and `name`

- Add option service tests
  - `TestProjectVersionOptionService`

- Add client integration tests
  - `TestProjectVersionService`

Part of #215 