### PR TITLE
feat: implement Status API endpoints and unify Status type

### DIFF
--- a/internal/core/option.go
+++ b/internal/core/option.go
@@ -21,6 +21,7 @@ const (
 	ParamBranch                            APIParamOptionType = "branch"
 	ParamCategoryIDs                       APIParamOptionType = "categoryId[]"
 	ParamChartEnabled                      APIParamOptionType = "chartEnabled"
+	ParamColor                             APIParamOptionType = "color"
 	ParamComment                           APIParamOptionType = "comment"
 	ParamCommentID                         APIParamOptionType = "commentId"
 	ParamContent                           APIParamOptionType = "content"

--- a/internal/core/option_string.go
+++ b/internal/core/option_string.go
@@ -16,6 +16,11 @@ func (s *OptionService) WithBranch(branch string) RequestOption {
 	return nonEmptyStringOption(ParamBranch, branch)
 }
 
+// WithColor returns an option that sets the `color` field.
+func (s *OptionService) WithColor(color string) RequestOption {
+	return nonEmptyStringOption(ParamColor, color)
+}
+
 // WithComment returns an option to set the `comment` parameter.
 func (s *OptionService) WithComment(comment string) RequestOption {
 	return &APIParamOption{

--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -141,10 +141,13 @@ type Star struct {
 	Created   time.Time `json:"created,omitempty"`
 }
 
-// Status represents any status.
+// Status represents a project status that can be assigned to issues.
 type Status struct {
-	ID   int    `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	ID           int    `json:"id,omitempty"`
+	ProjectID    int    `json:"projectId,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Color        string `json:"color,omitempty"`
+	DisplayOrder int    `json:"displayOrder,omitempty"`
 }
 
 // Tag represents one of tags in Wiki.

--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -12,17 +12,8 @@ type Project struct {
 	Archived                          bool   `json:"archived,omitempty"`
 }
 
-// DiskUsageProject represents project's disk usage.
+// DiskUsageProject represents disk usage of a specific project.
 type DiskUsageProject struct {
 	DiskUsageBase
 	ProjectID int `json:"projectId,omitempty"`
-}
-
-// ProjectStatus represents a status defined within a project.
-type ProjectStatus struct {
-	ID           int    `json:"id,omitempty"`
-	ProjectID    int    `json:"projectId,omitempty"`
-	Name         string `json:"name,omitempty"`
-	Color        string `json:"color,omitempty"`
-	DisplayOrder int    `json:"displayOrder,omitempty"`
 }

--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -17,3 +17,12 @@ type DiskUsageProject struct {
 	DiskUsageBase
 	ProjectID int `json:"projectId,omitempty"`
 }
+
+// ProjectStatus represents a status defined within a project.
+type ProjectStatus struct {
+	ID           int    `json:"id,omitempty"`
+	ProjectID    int    `json:"projectId,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Color        string `json:"color,omitempty"`
+	DisplayOrder int    `json:"displayOrder,omitempty"`
+}

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -11,18 +11,31 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// ──────────────────────────────────────────────────────────────
-//  Service
-// ──────────────────────────────────────────────────────────────
-
-// Service handles communication with the project-related methods of the Backlog API.
 type Service struct {
 	method *core.Method
 }
 
-// One returns a single project by its ID or key.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project
+func (s *Service) All(ctx context.Context, opts ...core.RequestOption) ([]*model.Project, error) {
+
+	query := url.Values{}
+	validTypes := []core.APIParamOptionType{core.ParamAll, core.ParamArchived}
+	if err := core.ApplyOptions(query, validTypes, opts...); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.method.Get(ctx, "projects", query)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.Project{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
 func (s *Service) One(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -42,54 +55,13 @@ func (s *Service) One(ctx context.Context, projectIDOrKey string) (*model.Projec
 	return &v, nil
 }
 
-// All returns a list of projects.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-list
-func (s *Service) All(ctx context.Context, opts ...core.RequestOption) ([]*model.Project, error) {
-	form := url.Values{}
-	validTypes := []core.APIParamOptionType{core.ParamArchived}
-	if err := core.ApplyOptions(form, validTypes, opts...); err != nil {
-		return nil, err
-	}
-
-	resp, err := s.method.Get(ctx, "projects", form)
-	if err != nil {
-		return nil, err
-	}
-
-	v := []*model.Project{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return v, nil
-}
-
-// Create creates a new project.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project
-func (s *Service) Create(ctx context.Context, name, key string, opts ...core.RequestOption) (*model.Project, error) {
-	opt := &core.OptionService{}
-	nameOpt := opt.WithName(name)
-	if err := nameOpt.Check(); err != nil {
-		return nil, err
-	}
-	keyOpt := opt.WithKey(key)
-	if err := keyOpt.Check(); err != nil {
-		return nil, err
-	}
+func (s *Service) Create(ctx context.Context, key, name string, opts ...core.RequestOption) (*model.Project, error) {
+	option := &core.OptionService{}
 
 	form := url.Values{}
-	nameOpt.Set(form)
-	keyOpt.Set(form)
-
-	validTypes := []core.APIParamOptionType{
-		core.ParamChartEnabled,
-		core.ParamSubtaskingEnabled,
-		core.ParamProjectLeaderCanEditProjectLeader,
-		core.ParamTextFormattingRule,
-	}
-	if err := core.ApplyOptions(form, validTypes, opts...); err != nil {
+	validTypes := []core.APIParamOptionType{core.ParamKey, core.ParamName, core.ParamChartEnabled, core.ParamSubtaskingEnabled, core.ParamProjectLeaderCanEditProjectLeader, core.ParamTextFormattingRule}
+	options := append([]core.RequestOption{option.WithKey(key), option.WithName(name)}, opts...)
+	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
 		return nil, err
 	}
 
@@ -106,9 +78,6 @@ func (s *Service) Create(ctx context.Context, name, key string, opts ...core.Req
 	return &v, nil
 }
 
-// Update updates a project.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-project
 func (s *Service) Update(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -116,13 +85,8 @@ func (s *Service) Update(ctx context.Context, projectIDOrKey string, opts ...cor
 
 	form := url.Values{}
 	validTypes := []core.APIParamOptionType{
-		core.ParamName,
-		core.ParamKey,
-		core.ParamChartEnabled,
-		core.ParamSubtaskingEnabled,
-		core.ParamProjectLeaderCanEditProjectLeader,
-		core.ParamTextFormattingRule,
-		core.ParamArchived,
+		core.ParamKey, core.ParamName, core.ParamChartEnabled, core.ParamSubtaskingEnabled,
+		core.ParamProjectLeaderCanEditProjectLeader, core.ParamTextFormattingRule, core.ParamArchived,
 	}
 	if err := core.ApplyOptions(form, validTypes, opts...); err != nil {
 		return nil, err
@@ -142,16 +106,13 @@ func (s *Service) Update(ctx context.Context, projectIDOrKey string, opts ...cor
 	return &v, nil
 }
 
-// Delete deletes a project.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-project
 func (s *Service) Delete(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("projects", projectIDOrKey)
-	resp, err := s.method.Delete(ctx, spath, nil)
+	resp, err := s.method.Delete(ctx, spath, url.Values{})
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +158,7 @@ type CategoryService struct {
 
 // All returns a list of categories in a project.
 //
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-category-list
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-category-list
 func (s *CategoryService) All(ctx context.Context, projectIDOrKey string) ([]*model.Category, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -217,22 +178,20 @@ func (s *CategoryService) All(ctx context.Context, projectIDOrKey string) ([]*mo
 	return v, nil
 }
 
-// Create adds a category to a project.
+// Create adds a new category to a project.
 //
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-issue-category
-func (s *CategoryService) Create(ctx context.Context, projectIDOrKey, name string) (*model.Category, error) {
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-category
+func (s *CategoryService) Create(ctx context.Context, projectIDOrKey string, name string) (*model.Category, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
-	opt := &core.OptionService{}
-	nameOpt := opt.WithName(name)
-	if err := nameOpt.Check(); err != nil {
+	option := (&core.OptionService{}).WithName(name)
+	if err := option.Check(); err != nil {
 		return nil, err
 	}
-
 	form := url.Values{}
-	nameOpt.Set(form)
+	option.Set(form)
 
 	spath := path.Join("projects", projectIDOrKey, "categories")
 	resp, err := s.method.Post(ctx, spath, form)
@@ -250,7 +209,7 @@ func (s *CategoryService) Create(ctx context.Context, projectIDOrKey, name strin
 
 // Update updates a category in a project.
 //
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-issue-category
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-category
 func (s *CategoryService) Update(ctx context.Context, projectIDOrKey string, categoryID int, name string) (*model.Category, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -259,14 +218,12 @@ func (s *CategoryService) Update(ctx context.Context, projectIDOrKey string, cat
 		return nil, core.NewValidationError("categoryId must not be less than 1")
 	}
 
-	opt := &core.OptionService{}
-	nameOpt := opt.WithName(name)
-	if err := nameOpt.Check(); err != nil {
+	option := (&core.OptionService{}).WithName(name)
+	if err := option.Check(); err != nil {
 		return nil, err
 	}
-
 	form := url.Values{}
-	nameOpt.Set(form)
+	option.Set(form)
 
 	spath := path.Join("projects", projectIDOrKey, "categories", strconv.Itoa(categoryID))
 	resp, err := s.method.Patch(ctx, spath, form)
@@ -284,7 +241,7 @@ func (s *CategoryService) Update(ctx context.Context, projectIDOrKey string, cat
 
 // Delete deletes a category from a project.
 //
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-issue-category
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-category
 func (s *CategoryService) Delete(ctx context.Context, projectIDOrKey string, categoryID int) (*model.Category, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -294,7 +251,7 @@ func (s *CategoryService) Delete(ctx context.Context, projectIDOrKey string, cat
 	}
 
 	spath := path.Join("projects", projectIDOrKey, "categories", strconv.Itoa(categoryID))
-	resp, err := s.method.Delete(ctx, spath, nil)
+	resp, err := s.method.Delete(ctx, spath, url.Values{})
 	if err != nil {
 		return nil, err
 	}
@@ -476,7 +433,9 @@ func (s *StatusService) UpdateOrder(ctx context.Context, projectIDOrKey string, 
 // ──────────────────────────────────────────────────────────────
 
 func NewService(method *core.Method) *Service {
-	return &Service{method: method}
+	return &Service{
+		method: method,
+	}
 }
 
 func NewCategoryService(method *core.Method) *CategoryService {

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -164,6 +164,28 @@ func (s *Service) Delete(ctx context.Context, projectIDOrKey string) (*model.Pro
 	return &v, nil
 }
 
+// DiskUsage returns disk usage of a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-disk-usage
+func (s *Service) DiskUsage(ctx context.Context, projectIDOrKey string) (*model.DiskUsageProject, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "diskUsage")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.DiskUsageProject{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
 // ──────────────────────────────────────────────────────────────
 //  CategoryService
 // ──────────────────────────────────────────────────────────────

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -265,6 +265,170 @@ func (s *CategoryService) Delete(ctx context.Context, projectIDOrKey string, cat
 }
 
 // ──────────────────────────────────────────────────────────────
+//  StatusService
+// ──────────────────────────────────────────────────────────────
+
+// StatusService handles communication with the status-related methods of the Backlog API.
+type StatusService struct {
+	method *core.Method
+}
+
+// All returns a list of statuses in a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-status-list-of-project
+func (s *StatusService) All(ctx context.Context, projectIDOrKey string) ([]*model.ProjectStatus, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "statuses")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.ProjectStatus{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Create adds a new status to a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-status
+func (s *StatusService) Create(ctx context.Context, projectIDOrKey, name, color string) (*model.ProjectStatus, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+
+	opt := &core.OptionService{}
+	nameOpt := opt.WithName(name)
+	if err := nameOpt.Check(); err != nil {
+		return nil, err
+	}
+	colorOpt := opt.WithColor(color)
+	if err := colorOpt.Check(); err != nil {
+		return nil, err
+	}
+
+	form := url.Values{}
+	nameOpt.Set(form)
+	colorOpt.Set(form)
+
+	spath := path.Join("projects", projectIDOrKey, "statuses")
+	resp, err := s.method.Post(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.ProjectStatus{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Update updates a status in a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-status
+func (s *StatusService) Update(ctx context.Context, projectIDOrKey string, statusID int, opts ...core.RequestOption) (*model.ProjectStatus, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if statusID < 1 {
+		return nil, core.NewValidationError("statusId must not be less than 1")
+	}
+
+	form := url.Values{}
+	validTypes := []core.APIParamOptionType{core.ParamName, core.ParamColor}
+	if err := core.ApplyOptions(form, validTypes, opts...); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "statuses", strconv.Itoa(statusID))
+	resp, err := s.method.Patch(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.ProjectStatus{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Delete deletes a status from a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-status
+func (s *StatusService) Delete(ctx context.Context, projectIDOrKey string, statusID, substituteStatusID int) (*model.ProjectStatus, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if statusID < 1 {
+		return nil, core.NewValidationError("statusId must not be less than 1")
+	}
+	if substituteStatusID < 1 {
+		return nil, core.NewValidationError("substituteStatusId must not be less than 1")
+	}
+
+	form := url.Values{}
+	form.Set("substituteStatusId", strconv.Itoa(substituteStatusID))
+
+	spath := path.Join("projects", projectIDOrKey, "statuses", strconv.Itoa(statusID))
+	resp, err := s.method.Delete(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.ProjectStatus{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// UpdateOrder updates the display order of statuses in a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-order-of-status
+func (s *StatusService) UpdateOrder(ctx context.Context, projectIDOrKey string, statusIDs []int) ([]*model.ProjectStatus, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if len(statusIDs) == 0 {
+		return nil, core.NewValidationError("statusIDs must not be empty")
+	}
+	for _, id := range statusIDs {
+		if id < 1 {
+			return nil, core.NewValidationError("each statusId must not be less than 1")
+		}
+	}
+
+	form := url.Values{}
+	for _, id := range statusIDs {
+		form.Add("statusId[]", strconv.Itoa(id))
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "statuses", "updateDisplayOrder")
+	resp, err := s.method.Patch(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.ProjectStatus{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
@@ -276,4 +440,8 @@ func NewService(method *core.Method) *Service {
 
 func NewCategoryService(method *core.Method) *CategoryService {
 	return &CategoryService{method: method}
+}
+
+func NewStatusService(method *core.Method) *StatusService {
+	return &StatusService{method: method}
 }

--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -11,31 +11,18 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// ──────────────────────────────────────────────────────────────
+//  Service
+// ──────────────────────────────────────────────────────────────
+
+// Service handles communication with the project-related methods of the Backlog API.
 type Service struct {
 	method *core.Method
 }
 
-func (s *Service) All(ctx context.Context, opts ...core.RequestOption) ([]*model.Project, error) {
-
-	query := url.Values{}
-	validTypes := []core.APIParamOptionType{core.ParamAll, core.ParamArchived}
-	if err := core.ApplyOptions(query, validTypes, opts...); err != nil {
-		return nil, err
-	}
-
-	resp, err := s.method.Get(ctx, "projects", query)
-	if err != nil {
-		return nil, err
-	}
-
-	v := []*model.Project{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return v, nil
-}
-
+// One returns a single project by its ID or key.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project
 func (s *Service) One(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -55,13 +42,54 @@ func (s *Service) One(ctx context.Context, projectIDOrKey string) (*model.Projec
 	return &v, nil
 }
 
-func (s *Service) Create(ctx context.Context, key, name string, opts ...core.RequestOption) (*model.Project, error) {
-	option := &core.OptionService{}
+// All returns a list of projects.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-list
+func (s *Service) All(ctx context.Context, opts ...core.RequestOption) ([]*model.Project, error) {
+	form := url.Values{}
+	validTypes := []core.APIParamOptionType{core.ParamArchived}
+	if err := core.ApplyOptions(form, validTypes, opts...); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.method.Get(ctx, "projects", form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.Project{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Create creates a new project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project
+func (s *Service) Create(ctx context.Context, name, key string, opts ...core.RequestOption) (*model.Project, error) {
+	opt := &core.OptionService{}
+	nameOpt := opt.WithName(name)
+	if err := nameOpt.Check(); err != nil {
+		return nil, err
+	}
+	keyOpt := opt.WithKey(key)
+	if err := keyOpt.Check(); err != nil {
+		return nil, err
+	}
 
 	form := url.Values{}
-	validTypes := []core.APIParamOptionType{core.ParamKey, core.ParamName, core.ParamChartEnabled, core.ParamSubtaskingEnabled, core.ParamProjectLeaderCanEditProjectLeader, core.ParamTextFormattingRule}
-	options := append([]core.RequestOption{option.WithKey(key), option.WithName(name)}, opts...)
-	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
+	nameOpt.Set(form)
+	keyOpt.Set(form)
+
+	validTypes := []core.APIParamOptionType{
+		core.ParamChartEnabled,
+		core.ParamSubtaskingEnabled,
+		core.ParamProjectLeaderCanEditProjectLeader,
+		core.ParamTextFormattingRule,
+	}
+	if err := core.ApplyOptions(form, validTypes, opts...); err != nil {
 		return nil, err
 	}
 
@@ -78,6 +106,9 @@ func (s *Service) Create(ctx context.Context, key, name string, opts ...core.Req
 	return &v, nil
 }
 
+// Update updates a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-project
 func (s *Service) Update(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -85,8 +116,13 @@ func (s *Service) Update(ctx context.Context, projectIDOrKey string, opts ...cor
 
 	form := url.Values{}
 	validTypes := []core.APIParamOptionType{
-		core.ParamKey, core.ParamName, core.ParamChartEnabled, core.ParamSubtaskingEnabled,
-		core.ParamProjectLeaderCanEditProjectLeader, core.ParamTextFormattingRule, core.ParamArchived,
+		core.ParamName,
+		core.ParamKey,
+		core.ParamChartEnabled,
+		core.ParamSubtaskingEnabled,
+		core.ParamProjectLeaderCanEditProjectLeader,
+		core.ParamTextFormattingRule,
+		core.ParamArchived,
 	}
 	if err := core.ApplyOptions(form, validTypes, opts...); err != nil {
 		return nil, err
@@ -106,40 +142,21 @@ func (s *Service) Update(ctx context.Context, projectIDOrKey string, opts ...cor
 	return &v, nil
 }
 
+// Delete deletes a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-project
 func (s *Service) Delete(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("projects", projectIDOrKey)
-	resp, err := s.method.Delete(ctx, spath, url.Values{})
+	resp, err := s.method.Delete(ctx, spath, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	v := model.Project{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return &v, nil
-}
-
-// DiskUsage returns disk usage of a project.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-disk-usage
-func (s *Service) DiskUsage(ctx context.Context, projectIDOrKey string) (*model.DiskUsageProject, error) {
-	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
-		return nil, err
-	}
-
-	spath := path.Join("projects", projectIDOrKey, "diskUsage")
-	resp, err := s.method.Get(ctx, spath, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	v := model.DiskUsageProject{}
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
@@ -158,7 +175,7 @@ type CategoryService struct {
 
 // All returns a list of categories in a project.
 //
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-category-list
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-category-list
 func (s *CategoryService) All(ctx context.Context, projectIDOrKey string) ([]*model.Category, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -178,20 +195,22 @@ func (s *CategoryService) All(ctx context.Context, projectIDOrKey string) ([]*mo
 	return v, nil
 }
 
-// Create adds a new category to a project.
+// Create adds a category to a project.
 //
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-category
-func (s *CategoryService) Create(ctx context.Context, projectIDOrKey string, name string) (*model.Category, error) {
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-issue-category
+func (s *CategoryService) Create(ctx context.Context, projectIDOrKey, name string) (*model.Category, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
-	option := (&core.OptionService{}).WithName(name)
-	if err := option.Check(); err != nil {
+	opt := &core.OptionService{}
+	nameOpt := opt.WithName(name)
+	if err := nameOpt.Check(); err != nil {
 		return nil, err
 	}
+
 	form := url.Values{}
-	option.Set(form)
+	nameOpt.Set(form)
 
 	spath := path.Join("projects", projectIDOrKey, "categories")
 	resp, err := s.method.Post(ctx, spath, form)
@@ -209,7 +228,7 @@ func (s *CategoryService) Create(ctx context.Context, projectIDOrKey string, nam
 
 // Update updates a category in a project.
 //
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-category
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-issue-category
 func (s *CategoryService) Update(ctx context.Context, projectIDOrKey string, categoryID int, name string) (*model.Category, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -218,12 +237,14 @@ func (s *CategoryService) Update(ctx context.Context, projectIDOrKey string, cat
 		return nil, core.NewValidationError("categoryId must not be less than 1")
 	}
 
-	option := (&core.OptionService{}).WithName(name)
-	if err := option.Check(); err != nil {
+	opt := &core.OptionService{}
+	nameOpt := opt.WithName(name)
+	if err := nameOpt.Check(); err != nil {
 		return nil, err
 	}
+
 	form := url.Values{}
-	option.Set(form)
+	nameOpt.Set(form)
 
 	spath := path.Join("projects", projectIDOrKey, "categories", strconv.Itoa(categoryID))
 	resp, err := s.method.Patch(ctx, spath, form)
@@ -241,7 +262,7 @@ func (s *CategoryService) Update(ctx context.Context, projectIDOrKey string, cat
 
 // Delete deletes a category from a project.
 //
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-category
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-issue-category
 func (s *CategoryService) Delete(ctx context.Context, projectIDOrKey string, categoryID int) (*model.Category, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -251,7 +272,7 @@ func (s *CategoryService) Delete(ctx context.Context, projectIDOrKey string, cat
 	}
 
 	spath := path.Join("projects", projectIDOrKey, "categories", strconv.Itoa(categoryID))
-	resp, err := s.method.Delete(ctx, spath, url.Values{})
+	resp, err := s.method.Delete(ctx, spath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +297,7 @@ type StatusService struct {
 // All returns a list of statuses in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-status-list-of-project
-func (s *StatusService) All(ctx context.Context, projectIDOrKey string) ([]*model.ProjectStatus, error) {
+func (s *StatusService) All(ctx context.Context, projectIDOrKey string) ([]*model.Status, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -287,7 +308,7 @@ func (s *StatusService) All(ctx context.Context, projectIDOrKey string) ([]*mode
 		return nil, err
 	}
 
-	v := []*model.ProjectStatus{}
+	v := []*model.Status{}
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
@@ -298,7 +319,7 @@ func (s *StatusService) All(ctx context.Context, projectIDOrKey string) ([]*mode
 // Create adds a new status to a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-status
-func (s *StatusService) Create(ctx context.Context, projectIDOrKey, name, color string) (*model.ProjectStatus, error) {
+func (s *StatusService) Create(ctx context.Context, projectIDOrKey, name, color string) (*model.Status, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -323,7 +344,7 @@ func (s *StatusService) Create(ctx context.Context, projectIDOrKey, name, color 
 		return nil, err
 	}
 
-	v := model.ProjectStatus{}
+	v := model.Status{}
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
@@ -334,7 +355,7 @@ func (s *StatusService) Create(ctx context.Context, projectIDOrKey, name, color 
 // Update updates a status in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-status
-func (s *StatusService) Update(ctx context.Context, projectIDOrKey string, statusID int, opts ...core.RequestOption) (*model.ProjectStatus, error) {
+func (s *StatusService) Update(ctx context.Context, projectIDOrKey string, statusID int, opts ...core.RequestOption) (*model.Status, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -354,7 +375,7 @@ func (s *StatusService) Update(ctx context.Context, projectIDOrKey string, statu
 		return nil, err
 	}
 
-	v := model.ProjectStatus{}
+	v := model.Status{}
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
@@ -365,7 +386,7 @@ func (s *StatusService) Update(ctx context.Context, projectIDOrKey string, statu
 // Delete deletes a status from a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-status
-func (s *StatusService) Delete(ctx context.Context, projectIDOrKey string, statusID, substituteStatusID int) (*model.ProjectStatus, error) {
+func (s *StatusService) Delete(ctx context.Context, projectIDOrKey string, statusID, substituteStatusID int) (*model.Status, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -385,7 +406,7 @@ func (s *StatusService) Delete(ctx context.Context, projectIDOrKey string, statu
 		return nil, err
 	}
 
-	v := model.ProjectStatus{}
+	v := model.Status{}
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
@@ -396,7 +417,7 @@ func (s *StatusService) Delete(ctx context.Context, projectIDOrKey string, statu
 // UpdateOrder updates the display order of statuses in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-order-of-status
-func (s *StatusService) UpdateOrder(ctx context.Context, projectIDOrKey string, statusIDs []int) ([]*model.ProjectStatus, error) {
+func (s *StatusService) UpdateOrder(ctx context.Context, projectIDOrKey string, statusIDs []int) ([]*model.Status, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -420,7 +441,7 @@ func (s *StatusService) UpdateOrder(ctx context.Context, projectIDOrKey string, 
 		return nil, err
 	}
 
-	v := []*model.ProjectStatus{}
+	v := []*model.Status{}
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
@@ -433,9 +454,7 @@ func (s *StatusService) UpdateOrder(ctx context.Context, projectIDOrKey string, 
 // ──────────────────────────────────────────────────────────────
 
 func NewService(method *core.Method) *Service {
-	return &Service{
-		method: method,
-	}
+	return &Service{method: method}
 }
 
 func NewCategoryService(method *core.Method) *CategoryService {

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -981,6 +981,463 @@ func TestCategoryService_Delete(t *testing.T) {
 	}
 }
 
+func TestStatusService_All(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantLen     int
+		wantErrType error
+	}{
+		"success-projectIDOrKey-key": {
+			projectIDOrKey: "TEST",
+
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/statuses", spath)
+				assert.Nil(t, query)
+				return mock.NewJSONResponse(fixture.Status.ListJSON), nil
+			},
+
+			wantLen:     2,
+			wantErrType: nil,
+		},
+		"success-projectIDOrKey-id": {
+			projectIDOrKey: "6",
+
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/6/statuses", spath)
+				return mock.NewJSONResponse(fixture.Status.ListJSON), nil
+			},
+
+			wantLen:     2,
+			wantErrType: nil,
+		},
+		"error-validation-projectIDOrKey-empty": {
+			projectIDOrKey: "",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: "TEST",
+
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "TEST",
+
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+			s := project.NewStatusService(method)
+
+			statuses, err := s.All(context.Background(), tc.projectIDOrKey)
+
+			if tc.wantErrType != nil {
+				require.Error(t, err)
+				assert.IsType(t, tc.wantErrType, err)
+				assert.Nil(t, statuses)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, statuses)
+			assert.Len(t, statuses, tc.wantLen)
+		})
+	}
+}
+
+func TestStatusService_Create(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+		name           string
+		color          string
+
+		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+	}{
+		"success": {
+			projectIDOrKey: "TEST",
+			name:           "Open",
+			color:          "#ed8077",
+
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/statuses", spath)
+				assert.Equal(t, "Open", form.Get("name"))
+				assert.Equal(t, "#ed8077", form.Get("color"))
+				return mock.NewJSONResponse(fixture.Status.SingleJSON), nil
+			},
+
+			wantErrType: nil,
+		},
+		"error-validation-projectIDOrKey-empty": {
+			projectIDOrKey: "",
+			name:           "Open",
+			color:          "#ed8077",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-validation-name-empty": {
+			projectIDOrKey: "TEST",
+			name:           "",
+			color:          "#ed8077",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-validation-color-empty": {
+			projectIDOrKey: "TEST",
+			name:           "Open",
+			color:          "",
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: "TEST",
+			name:           "Open",
+			color:          "#ed8077",
+
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "TEST",
+			name:           "Open",
+			color:          "#ed8077",
+
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPostFn != nil {
+				method.Post = tc.mockPostFn
+			}
+			s := project.NewStatusService(method)
+
+			status, err := s.Create(context.Background(), tc.projectIDOrKey, tc.name, tc.color)
+
+			if tc.wantErrType != nil {
+				require.Error(t, err)
+				assert.IsType(t, tc.wantErrType, err)
+				assert.Nil(t, status)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, status)
+			assert.Equal(t, 1, status.ID)
+			assert.Equal(t, "Open", status.Name)
+			assert.Equal(t, "#ed8077", status.Color)
+		})
+	}
+}
+
+func TestStatusService_Update(t *testing.T) {
+	o := &core.OptionService{}
+
+	cases := map[string]struct {
+		projectIDOrKey string
+		statusID       int
+		opts           []core.RequestOption
+
+		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+	}{
+		"success": {
+			projectIDOrKey: "TEST",
+			statusID:       1,
+			opts: []core.RequestOption{
+				o.WithName("Open Updated"),
+				o.WithColor("#f5ab35"),
+			},
+
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/statuses/1", spath)
+				assert.Equal(t, "Open Updated", form.Get("name"))
+				assert.Equal(t, "#f5ab35", form.Get("color"))
+				return mock.NewJSONResponse(fixture.Status.SingleJSON), nil
+			},
+
+			wantErrType: nil,
+		},
+		"success-without-option": {
+			projectIDOrKey: "TEST",
+			statusID:       1,
+
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/statuses/1", spath)
+				return mock.NewJSONResponse(fixture.Status.SingleJSON), nil
+			},
+
+			wantErrType: nil,
+		},
+		"error-validation-projectIDOrKey-empty": {
+			projectIDOrKey: "",
+			statusID:       1,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-validation-statusID-zero": {
+			projectIDOrKey: "TEST",
+			statusID:       0,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-option-invalid-type": {
+			projectIDOrKey: "TEST",
+			statusID:       1,
+			opts:           []core.RequestOption{mock.NewInvalidTypeOption()},
+			wantErrType:    &core.InvalidOptionKeyError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: "TEST",
+			statusID:       1,
+
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "TEST",
+			statusID:       1,
+
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPatchFn != nil {
+				method.Patch = tc.mockPatchFn
+			}
+			s := project.NewStatusService(method)
+
+			status, err := s.Update(context.Background(), tc.projectIDOrKey, tc.statusID, tc.opts...)
+
+			if tc.wantErrType != nil {
+				require.Error(t, err)
+				assert.IsType(t, tc.wantErrType, err)
+				assert.Nil(t, status)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, status)
+			assert.Equal(t, 1, status.ID)
+		})
+	}
+}
+
+func TestStatusService_Delete(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey     string
+		statusID           int
+		substituteStatusID int
+
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+	}{
+		"success": {
+			projectIDOrKey:     "TEST",
+			statusID:           1,
+			substituteStatusID: 2,
+
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/statuses/1", spath)
+				assert.Equal(t, "2", form.Get("substituteStatusId"))
+				return mock.NewJSONResponse(fixture.Status.SingleJSON), nil
+			},
+
+			wantErrType: nil,
+		},
+		"error-validation-projectIDOrKey-empty": {
+			projectIDOrKey:     "",
+			statusID:           1,
+			substituteStatusID: 2,
+			wantErrType:        &core.ValidationError{},
+		},
+		"error-validation-statusID-zero": {
+			projectIDOrKey:     "TEST",
+			statusID:           0,
+			substituteStatusID: 2,
+			wantErrType:        &core.ValidationError{},
+		},
+		"error-validation-substituteStatusID-zero": {
+			projectIDOrKey:     "TEST",
+			statusID:           1,
+			substituteStatusID: 0,
+			wantErrType:        &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey:     "TEST",
+			statusID:           1,
+			substituteStatusID: 2,
+
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey:     "TEST",
+			statusID:           1,
+			substituteStatusID: 2,
+
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockDeleteFn != nil {
+				method.Delete = tc.mockDeleteFn
+			}
+			s := project.NewStatusService(method)
+
+			status, err := s.Delete(context.Background(), tc.projectIDOrKey, tc.statusID, tc.substituteStatusID)
+
+			if tc.wantErrType != nil {
+				require.Error(t, err)
+				assert.IsType(t, tc.wantErrType, err)
+				assert.Nil(t, status)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, status)
+			assert.Equal(t, 1, status.ID)
+		})
+	}
+}
+
+func TestStatusService_UpdateOrder(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+		statusIDs      []int
+
+		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantLen     int
+		wantErrType error
+	}{
+		"success": {
+			projectIDOrKey: "TEST",
+			statusIDs:      []int{2, 1},
+
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/TEST/statuses/updateDisplayOrder", spath)
+				assert.Equal(t, []string{"2", "1"}, form["statusId[]"])
+				return mock.NewJSONResponse(fixture.Status.ListJSON), nil
+			},
+
+			wantLen:     2,
+			wantErrType: nil,
+		},
+		"error-validation-projectIDOrKey-empty": {
+			projectIDOrKey: "",
+			statusIDs:      []int{1, 2},
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-validation-statusIDs-empty": {
+			projectIDOrKey: "TEST",
+			statusIDs:      []int{},
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-validation-statusID-zero": {
+			projectIDOrKey: "TEST",
+			statusIDs:      []int{1, 0},
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: "TEST",
+			statusIDs:      []int{1, 2},
+
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("error")
+			},
+
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "TEST",
+			statusIDs:      []int{1, 2},
+
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPatchFn != nil {
+				method.Patch = tc.mockPatchFn
+			}
+			s := project.NewStatusService(method)
+
+			statuses, err := s.UpdateOrder(context.Background(), tc.projectIDOrKey, tc.statusIDs)
+
+			if tc.wantErrType != nil {
+				require.Error(t, err)
+				assert.IsType(t, tc.wantErrType, err)
+				assert.Nil(t, statuses)
+				return
+			}
+
+			assert.NoError(t, err)
+			require.NotNil(t, statuses)
+			assert.Len(t, statuses, tc.wantLen)
+		})
+	}
+}
+
 func Test_contextPropagation(t *testing.T) {
 	type ctxKey struct{}
 	sentinel := &struct{}{}
@@ -1048,6 +1505,31 @@ func Test_contextPropagation(t *testing.T) {
 			m.Delete = makeMockFn(t)
 			s := project.NewCategoryService(m)
 			s.Delete(ctx, "TEST", 12) //nolint:errcheck
+		}},
+		{"StatusService.All", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := project.NewStatusService(m)
+			s.All(ctx, "TEST") //nolint:errcheck
+		}},
+		{"StatusService.Create", func(t *testing.T, m *core.Method) {
+			m.Post = makeMockFn(t)
+			s := project.NewStatusService(m)
+			s.Create(ctx, "TEST", "Open", "#ed8077") //nolint:errcheck
+		}},
+		{"StatusService.Update", func(t *testing.T, m *core.Method) {
+			m.Patch = makeMockFn(t)
+			s := project.NewStatusService(m)
+			s.Update(ctx, "TEST", 1) //nolint:errcheck
+		}},
+		{"StatusService.Delete", func(t *testing.T, m *core.Method) {
+			m.Delete = makeMockFn(t)
+			s := project.NewStatusService(m)
+			s.Delete(ctx, "TEST", 1, 2) //nolint:errcheck
+		}},
+		{"StatusService.UpdateOrder", func(t *testing.T, m *core.Method) {
+			m.Patch = makeMockFn(t)
+			s := project.NewStatusService(m)
+			s.UpdateOrder(ctx, "TEST", []int{1, 2}) //nolint:errcheck
 		}},
 	}
 

--- a/internal/testutil/fixture/testdata_project.go
+++ b/internal/testutil/fixture/testdata_project.go
@@ -3,10 +3,10 @@ package fixture
 import backlog "github.com/nattokin/go-backlog"
 
 type projectFixtures struct {
-	SingleJSON   string
-	Single       *backlog.Project
-	ListJSON     string
-	List         []*backlog.Project
+	SingleJSON    string
+	Single        *backlog.Project
+	ListJSON      string
+	List          []*backlog.Project
 	DiskUsageJSON string
 }
 

--- a/internal/testutil/fixture/testdata_project.go
+++ b/internal/testutil/fixture/testdata_project.go
@@ -20,6 +20,13 @@ type categoryFixtures struct {
 	List       []*backlog.Category
 }
 
+type statusFixtures struct {
+	SingleJSON string
+	Single     *backlog.ProjectStatus
+	ListJSON   string
+	List       []*backlog.ProjectStatus
+}
+
 // Project provides test fixtures for Project-related tests.
 var Project = projectFixtures{
 	SingleJSON: `
@@ -154,6 +161,60 @@ var Category = categoryFixtures{
 			ID:           13,
 			Name:         "Feature",
 			DisplayOrder: 1,
+		},
+	},
+}
+
+// Status provides test fixtures for ProjectStatus-related tests.
+var Status = statusFixtures{
+	SingleJSON: `
+{
+    "id": 1,
+    "projectId": 6,
+    "name": "Open",
+    "color": "#ed8077",
+    "displayOrder": 1000
+}
+`,
+	Single: &backlog.ProjectStatus{
+		ID:           1,
+		ProjectID:    6,
+		Name:         "Open",
+		Color:        "#ed8077",
+		DisplayOrder: 1000,
+	},
+	ListJSON: `
+[
+    {
+        "id": 1,
+        "projectId": 6,
+        "name": "Open",
+        "color": "#ed8077",
+        "displayOrder": 1000
+    },
+    {
+        "id": 2,
+        "projectId": 6,
+        "name": "In Progress",
+        "color": "#f5ab35",
+        "displayOrder": 2000
+    }
+]
+`,
+	List: []*backlog.ProjectStatus{
+		{
+			ID:           1,
+			ProjectID:    6,
+			Name:         "Open",
+			Color:        "#ed8077",
+			DisplayOrder: 1000,
+		},
+		{
+			ID:           2,
+			ProjectID:    6,
+			Name:         "In Progress",
+			Color:        "#f5ab35",
+			DisplayOrder: 2000,
 		},
 	},
 }

--- a/internal/testutil/fixture/testdata_project.go
+++ b/internal/testutil/fixture/testdata_project.go
@@ -3,10 +3,11 @@ package fixture
 import backlog "github.com/nattokin/go-backlog"
 
 type projectFixtures struct {
-	SingleJSON string
-	Single     *backlog.Project
-	ListJSON   string
-	List       []*backlog.Project
+	SingleJSON   string
+	Single       *backlog.Project
+	ListJSON     string
+	List         []*backlog.Project
+	DiskUsageJSON string
 }
 
 type categoryFixtures struct {
@@ -68,6 +69,16 @@ var Project = projectFixtures{
         "projectLeaderCanEditProjectLeader": true,
         "textFormattingRule": "backlog",
         "archived": true
+    },
+    {
+        "id": 3,
+        "projectKey": "TEST3",
+        "name": "test3",
+        "chartEnabled": false,
+        "subtaskingEnabled": false,
+        "projectLeaderCanEditProjectLeader": false,
+        "textFormattingRule": "markdown",
+        "archived": false
     }
 ]
 `,
@@ -92,7 +103,28 @@ var Project = projectFixtures{
 			TextFormattingRule:                backlog.FormatBacklog,
 			Archived:                          true,
 		},
+		{
+			ID:                                3,
+			ProjectKey:                        "TEST3",
+			Name:                              "test3",
+			ChartEnabled:                      false,
+			SubtaskingEnabled:                 false,
+			ProjectLeaderCanEditProjectLeader: false,
+			TextFormattingRule:                backlog.FormatMarkdown,
+			Archived:                          false,
+		},
 	},
+	DiskUsageJSON: `
+{
+    "projectId": 1,
+    "issue": 11931,
+    "wiki": 0,
+    "file": 512,
+    "subversion": 0,
+    "git": 1024,
+    "gitLFS": 0
+}
+`,
 }
 
 // Category provides test fixtures for Category-related tests.

--- a/internal/testutil/fixture/testdata_project.go
+++ b/internal/testutil/fixture/testdata_project.go
@@ -1,16 +1,12 @@
 package fixture
 
-import (
-	backlog "github.com/nattokin/go-backlog"
-)
+import backlog "github.com/nattokin/go-backlog"
 
 type projectFixtures struct {
-	SingleJSON    string
-	Single        *backlog.Project
-	ListJSON      string
-	List          []*backlog.Project
-	DiskUsageJSON string
-	DiskUsage     *backlog.DiskUsageProject
+	SingleJSON string
+	Single     *backlog.Project
+	ListJSON   string
+	List       []*backlog.Project
 }
 
 type categoryFixtures struct {
@@ -22,16 +18,16 @@ type categoryFixtures struct {
 
 type statusFixtures struct {
 	SingleJSON string
-	Single     *backlog.ProjectStatus
+	Single     *backlog.Status
 	ListJSON   string
-	List       []*backlog.ProjectStatus
+	List       []*backlog.Status
 }
 
 // Project provides test fixtures for Project-related tests.
 var Project = projectFixtures{
 	SingleJSON: `
 {
-    "id": 6,
+    "id": 1,
     "projectKey": "TEST",
     "name": "test",
     "chartEnabled": false,
@@ -42,10 +38,14 @@ var Project = projectFixtures{
 }
 `,
 	Single: &backlog.Project{
-		ID:                 6,
-		ProjectKey:         "TEST",
-		Name:               "test",
-		TextFormattingRule: backlog.FormatMarkdown,
+		ID:                                1,
+		ProjectKey:                        "TEST",
+		Name:                              "test",
+		ChartEnabled:                      false,
+		SubtaskingEnabled:                 false,
+		ProjectLeaderCanEditProjectLeader: false,
+		TextFormattingRule:                backlog.FormatMarkdown,
+		Archived:                          false,
 	},
 	ListJSON: `
 [
@@ -64,64 +64,34 @@ var Project = projectFixtures{
         "projectKey": "TEST2",
         "name": "test2",
         "chartEnabled": true,
-        "subtaskingEnabled": false,
+        "subtaskingEnabled": true,
         "projectLeaderCanEditProjectLeader": true,
-        "textFormattingRule": "markdown",
-        "archived": false
-    },
-    {
-        "id": 3,
-        "projectKey": "TEST3",
-        "name": "test3",
-        "chartEnabled": false,
-        "subtaskingEnabled": false,
-        "projectLeaderCanEditProjectLeader": false,
-        "textFormattingRule": "markdown",
-        "archived": false
+        "textFormattingRule": "backlog",
+        "archived": true
     }
 ]
 `,
 	List: []*backlog.Project{
 		{
-			ID:                 1,
-			ProjectKey:         "TEST",
-			Name:               "test",
-			TextFormattingRule: backlog.FormatMarkdown,
+			ID:                                1,
+			ProjectKey:                        "TEST",
+			Name:                              "test",
+			ChartEnabled:                      false,
+			SubtaskingEnabled:                 false,
+			ProjectLeaderCanEditProjectLeader: false,
+			TextFormattingRule:                backlog.FormatMarkdown,
+			Archived:                          false,
 		},
 		{
 			ID:                                2,
 			ProjectKey:                        "TEST2",
 			Name:                              "test2",
 			ChartEnabled:                      true,
+			SubtaskingEnabled:                 true,
 			ProjectLeaderCanEditProjectLeader: true,
-			TextFormattingRule:                backlog.FormatMarkdown,
+			TextFormattingRule:                backlog.FormatBacklog,
+			Archived:                          true,
 		},
-		{
-			ID:                 3,
-			ProjectKey:         "TEST3",
-			Name:               "test3",
-			TextFormattingRule: backlog.FormatMarkdown,
-		},
-	},
-	DiskUsageJSON: `
-{
-	"projectId": 1,
-	"issue": 11931,
-	"wiki": 0,
-	"file": 0,
-	"subversion": 0,
-	"git": 0,
-	"gitLFS": 0
-}
-`,
-	DiskUsage: &backlog.DiskUsageProject{
-		ProjectID:  1,
-		Issue:      11931,
-		Wiki:       0,
-		File:       0,
-		Subversion: 0,
-		Git:        0,
-		GitLFS:     0,
 	},
 }
 
@@ -129,43 +99,45 @@ var Project = projectFixtures{
 var Category = categoryFixtures{
 	SingleJSON: `
 {
-    "id": 12,
+    "id": 1,
     "name": "Bug",
     "displayOrder": 0
 }
 `,
 	Single: &backlog.Category{
-		ID:   12,
-		Name: "Bug",
+		ID:           1,
+		Name:         "Bug",
+		DisplayOrder: 0,
 	},
 	ListJSON: `
 [
     {
-        "id": 12,
+        "id": 1,
         "name": "Bug",
         "displayOrder": 0
     },
     {
-        "id": 13,
-        "name": "Feature",
+        "id": 2,
+        "name": "Document",
         "displayOrder": 1
     }
 ]
 `,
 	List: []*backlog.Category{
 		{
-			ID:   12,
-			Name: "Bug",
+			ID:           1,
+			Name:         "Bug",
+			DisplayOrder: 0,
 		},
 		{
-			ID:           13,
-			Name:         "Feature",
+			ID:           2,
+			Name:         "Document",
 			DisplayOrder: 1,
 		},
 	},
 }
 
-// Status provides test fixtures for ProjectStatus-related tests.
+// Status provides test fixtures for Status-related tests.
 var Status = statusFixtures{
 	SingleJSON: `
 {
@@ -176,7 +148,7 @@ var Status = statusFixtures{
     "displayOrder": 1000
 }
 `,
-	Single: &backlog.ProjectStatus{
+	Single: &backlog.Status{
 		ID:           1,
 		ProjectID:    6,
 		Name:         "Open",
@@ -201,7 +173,7 @@ var Status = statusFixtures{
     }
 ]
 `,
-	List: []*backlog.ProjectStatus{
+	List: []*backlog.Status{
 		{
 			ID:           1,
 			ProjectID:    6,

--- a/internal/testutil/fixture/testdata_project.go
+++ b/internal/testutil/fixture/testdata_project.go
@@ -1,6 +1,8 @@
 package fixture
 
-import backlog "github.com/nattokin/go-backlog"
+import (
+	backlog "github.com/nattokin/go-backlog"
+)
 
 type projectFixtures struct {
 	SingleJSON    string
@@ -8,6 +10,7 @@ type projectFixtures struct {
 	ListJSON      string
 	List          []*backlog.Project
 	DiskUsageJSON string
+	DiskUsage     *backlog.DiskUsageProject
 }
 
 type categoryFixtures struct {
@@ -28,7 +31,7 @@ type statusFixtures struct {
 var Project = projectFixtures{
 	SingleJSON: `
 {
-    "id": 1,
+    "id": 6,
     "projectKey": "TEST",
     "name": "test",
     "chartEnabled": false,
@@ -39,14 +42,10 @@ var Project = projectFixtures{
 }
 `,
 	Single: &backlog.Project{
-		ID:                                1,
-		ProjectKey:                        "TEST",
-		Name:                              "test",
-		ChartEnabled:                      false,
-		SubtaskingEnabled:                 false,
-		ProjectLeaderCanEditProjectLeader: false,
-		TextFormattingRule:                backlog.FormatMarkdown,
-		Archived:                          false,
+		ID:                 6,
+		ProjectKey:         "TEST",
+		Name:               "test",
+		TextFormattingRule: backlog.FormatMarkdown,
 	},
 	ListJSON: `
 [
@@ -65,10 +64,10 @@ var Project = projectFixtures{
         "projectKey": "TEST2",
         "name": "test2",
         "chartEnabled": true,
-        "subtaskingEnabled": true,
+        "subtaskingEnabled": false,
         "projectLeaderCanEditProjectLeader": true,
-        "textFormattingRule": "backlog",
-        "archived": true
+        "textFormattingRule": "markdown",
+        "archived": false
     },
     {
         "id": 3,
@@ -84,86 +83,83 @@ var Project = projectFixtures{
 `,
 	List: []*backlog.Project{
 		{
-			ID:                                1,
-			ProjectKey:                        "TEST",
-			Name:                              "test",
-			ChartEnabled:                      false,
-			SubtaskingEnabled:                 false,
-			ProjectLeaderCanEditProjectLeader: false,
-			TextFormattingRule:                backlog.FormatMarkdown,
-			Archived:                          false,
+			ID:                 1,
+			ProjectKey:         "TEST",
+			Name:               "test",
+			TextFormattingRule: backlog.FormatMarkdown,
 		},
 		{
 			ID:                                2,
 			ProjectKey:                        "TEST2",
 			Name:                              "test2",
 			ChartEnabled:                      true,
-			SubtaskingEnabled:                 true,
 			ProjectLeaderCanEditProjectLeader: true,
-			TextFormattingRule:                backlog.FormatBacklog,
-			Archived:                          true,
+			TextFormattingRule:                backlog.FormatMarkdown,
 		},
 		{
-			ID:                                3,
-			ProjectKey:                        "TEST3",
-			Name:                              "test3",
-			ChartEnabled:                      false,
-			SubtaskingEnabled:                 false,
-			ProjectLeaderCanEditProjectLeader: false,
-			TextFormattingRule:                backlog.FormatMarkdown,
-			Archived:                          false,
+			ID:                 3,
+			ProjectKey:         "TEST3",
+			Name:               "test3",
+			TextFormattingRule: backlog.FormatMarkdown,
 		},
 	},
 	DiskUsageJSON: `
 {
-    "projectId": 1,
-    "issue": 11931,
-    "wiki": 0,
-    "file": 512,
-    "subversion": 0,
-    "git": 1024,
-    "gitLFS": 0
+	"projectId": 1,
+	"issue": 11931,
+	"wiki": 0,
+	"file": 0,
+	"subversion": 0,
+	"git": 0,
+	"gitLFS": 0
 }
 `,
+	DiskUsage: &backlog.DiskUsageProject{
+		ProjectID:  1,
+		Issue:      11931,
+		Wiki:       0,
+		File:       0,
+		Subversion: 0,
+		Git:        0,
+		GitLFS:     0,
+	},
 }
 
 // Category provides test fixtures for Category-related tests.
 var Category = categoryFixtures{
 	SingleJSON: `
 {
-    "id": 1,
+    "id": 12,
     "name": "Bug",
     "displayOrder": 0
 }
 `,
 	Single: &backlog.Category{
-		ID:           1,
-		Name:         "Bug",
-		DisplayOrder: 0,
+		ID:   12,
+		Name: "Bug",
 	},
 	ListJSON: `
 [
     {
-        "id": 1,
+        "id": 12,
         "name": "Bug",
         "displayOrder": 0
     },
     {
-        "id": 2,
-        "name": "Document",
+        "id": 13,
+        "name": "Feature",
         "displayOrder": 1
     }
 ]
 `,
 	List: []*backlog.Category{
 		{
-			ID:           1,
-			Name:         "Bug",
-			DisplayOrder: 0,
+			ID:   12,
+			Name: "Bug",
 		},
 		{
-			ID:           2,
-			Name:         "Document",
+			ID:           13,
+			Name:         "Feature",
 			DisplayOrder: 1,
 		},
 	},

--- a/models.go
+++ b/models.go
@@ -164,10 +164,13 @@ type Star struct {
 	Created   time.Time
 }
 
-// Status represents any status.
+// Status represents a project status that can be assigned to issues.
 type Status struct {
-	ID   int
-	Name string
+	ID           int
+	ProjectID    int
+	Name         string
+	Color        string
+	DisplayOrder int
 }
 
 // Tag represents one of tags in Wiki.
@@ -469,9 +472,23 @@ func statusFromModel(m *model.Status) *Status {
 		return nil
 	}
 	return &Status{
-		ID:   m.ID,
-		Name: m.Name,
+		ID:           m.ID,
+		ProjectID:    m.ProjectID,
+		Name:         m.Name,
+		Color:        m.Color,
+		DisplayOrder: m.DisplayOrder,
 	}
+}
+
+func statusesFromModel(ms []*model.Status) []*Status {
+	if ms == nil {
+		return nil
+	}
+	result := make([]*Status, len(ms))
+	for i, v := range ms {
+		result[i] = statusFromModel(v)
+	}
+	return result
 }
 
 func tagFromModel(m *model.Tag) *Tag {

--- a/models_test.go
+++ b/models_test.go
@@ -189,7 +189,7 @@ func Test_issueFromModel(t *testing.T) {
 					{ID: 1, Name: "Won't Fix"},
 				},
 				Priority: &model.Priority{ID: 3, Name: "Normal"},
-				Status:   &model.Status{ID: 1, Name: "Open"},
+				Status:   &model.Status{ID: 1, ProjectID: 10, Name: "Open", Color: "#ed8077", DisplayOrder: 1000},
 				Assignee: user,
 				Category: []*model.Category{
 					{ID: 5, Name: "Frontend", DisplayOrder: 0},
@@ -237,7 +237,7 @@ func Test_issueFromModel(t *testing.T) {
 					{ID: 1, Name: "Won't Fix"},
 				},
 				Priority: &Priority{ID: 3, Name: "Normal"},
-				Status:   &Status{ID: 1, Name: "Open"},
+				Status:   &Status{ID: 1, ProjectID: 10, Name: "Open", Color: "#ed8077", DisplayOrder: 1000},
 				Assignee: wantUser,
 				Category: []*Category{
 					{ID: 5, Name: "Frontend", DisplayOrder: 0},
@@ -326,7 +326,7 @@ func Test_pullRequestFromModel(t *testing.T) {
 		Description:  "PR desc",
 		Base:         "main",
 		Branch:       "feature",
-		Status:       &model.Status{ID: 1, Name: "Open"},
+		Status:       &model.Status{ID: 1, ProjectID: 3, Name: "Open", Color: "#ed8077", DisplayOrder: 1000},
 		Assignee:     user,
 		Issue:        &model.Issue{ID: 10, Summary: "related issue"},
 		BaseCommit:   "abc123",
@@ -353,7 +353,7 @@ func Test_pullRequestFromModel(t *testing.T) {
 		Description:  "PR desc",
 		Base:         "main",
 		Branch:       "feature",
-		Status:       &Status{ID: 1, Name: "Open"},
+		Status:       &Status{ID: 1, ProjectID: 3, Name: "Open", Color: "#ed8077", DisplayOrder: 1000},
 		Assignee:     wantUser,
 		Issue: &Issue{
 			ID:      10,
@@ -425,8 +425,8 @@ func Test_spaceNotificationFromModel(t *testing.T) {
 func Test_statusFromModel(t *testing.T) {
 	t.Parallel()
 
-	input := &model.Status{ID: 1, Name: "Open"}
-	want := &Status{ID: 1, Name: "Open"}
+	input := &model.Status{ID: 1, ProjectID: 6, Name: "Open", Color: "#ed8077", DisplayOrder: 1000}
+	want := &Status{ID: 1, ProjectID: 6, Name: "Open", Color: "#ed8077", DisplayOrder: 1000}
 	assert.Equal(t, want, statusFromModel(input))
 }
 

--- a/project.go
+++ b/project.go
@@ -30,6 +30,15 @@ type Project struct {
 	Archived                          bool
 }
 
+// ProjectStatus represents a status defined within a project.
+type ProjectStatus struct {
+	ID           int
+	ProjectID    int
+	Name         string
+	Color        string
+	DisplayOrder int
+}
+
 // ──────────────────────────────────────────────────────────────
 //  ProjectService
 // ──────────────────────────────────────────────────────────────
@@ -40,6 +49,7 @@ type ProjectService struct {
 
 	Activity   *ProjectActivityService
 	Category   *ProjectCategoryService
+	Status     *ProjectStatusService
 	User       *ProjectUserService
 	SharedFile *ProjectSharedFileService
 	Webhook    *ProjectWebhookService
@@ -184,6 +194,61 @@ func (s *ProjectCategoryService) Update(ctx context.Context, projectIDOrKey stri
 func (s *ProjectCategoryService) Delete(ctx context.Context, projectIDOrKey string, categoryID int) (*Category, error) {
 	v, err := s.base.Delete(ctx, projectIDOrKey, categoryID)
 	return categoryFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  ProjectStatusService
+// ──────────────────────────────────────────────────────────────
+
+// ProjectStatusService handles communication with the project status-related methods of the Backlog API.
+type ProjectStatusService struct {
+	base   *project.StatusService
+	Option *ProjectStatusOptionService
+}
+
+// All returns a list of statuses in a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-status-list-of-project
+func (s *ProjectStatusService) All(ctx context.Context, projectIDOrKey string) ([]*ProjectStatus, error) {
+	v, err := s.base.All(ctx, projectIDOrKey)
+	return projectStatusesFromModel(v), convertError(err)
+}
+
+// Create adds a new status to a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-status
+func (s *ProjectStatusService) Create(ctx context.Context, projectIDOrKey, name, color string) (*ProjectStatus, error) {
+	v, err := s.base.Create(ctx, projectIDOrKey, name, color)
+	return projectStatusFromModel(v), convertError(err)
+}
+
+// Update updates a status in a project.
+//
+// This method supports options returned by methods in "*Client.Project.Status.Option",
+// such as:
+//   - WithColor
+//   - WithName
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-status
+func (s *ProjectStatusService) Update(ctx context.Context, projectIDOrKey string, statusID int, opts ...RequestOption) (*ProjectStatus, error) {
+	v, err := s.base.Update(ctx, projectIDOrKey, statusID, toCoreOptions(opts)...)
+	return projectStatusFromModel(v), convertError(err)
+}
+
+// Delete deletes a status from a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-status
+func (s *ProjectStatusService) Delete(ctx context.Context, projectIDOrKey string, statusID, substituteStatusID int) (*ProjectStatus, error) {
+	v, err := s.base.Delete(ctx, projectIDOrKey, statusID, substituteStatusID)
+	return projectStatusFromModel(v), convertError(err)
+}
+
+// UpdateOrder updates the display order of statuses in a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-order-of-status
+func (s *ProjectStatusService) UpdateOrder(ctx context.Context, projectIDOrKey string, statusIDs []int) ([]*ProjectStatus, error) {
+	v, err := s.base.UpdateOrder(ctx, projectIDOrKey, statusIDs)
+	return projectStatusesFromModel(v), convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -431,6 +496,26 @@ func (s *ProjectOptionService) WithTextFormattingRule(format model.Format) Reque
 }
 
 // ──────────────────────────────────────────────────────────────
+//  ProjectStatusOptionService
+// ──────────────────────────────────────────────────────────────
+
+// ProjectStatusOptionService provides a domain-specific set of option builders
+// for operations within the ProjectStatusService.
+type ProjectStatusOptionService struct {
+	base *core.OptionService
+}
+
+// WithColor sets the status color.
+func (s *ProjectStatusOptionService) WithColor(color string) RequestOption {
+	return s.base.WithColor(color)
+}
+
+// WithName sets the status name.
+func (s *ProjectStatusOptionService) WithName(name string) RequestOption {
+	return s.base.WithName(name)
+}
+
+// ──────────────────────────────────────────────────────────────
 //  ProjectWebhookOptionService
 // ──────────────────────────────────────────────────────────────
 
@@ -509,6 +594,7 @@ func newProjectService(method *core.Method, option *core.OptionService) *Project
 		base:       project.NewService(method),
 		Activity:   newProjectActivityService(method, option),
 		Category:   newProjectCategoryService(method),
+		Status:     newProjectStatusService(method, option),
 		User:       newProjectUserService(method, option),
 		SharedFile: newProjectSharedFileService(method),
 		Webhook:    newProjectWebhookService(method, option),
@@ -527,6 +613,13 @@ func newProjectActivityService(method *core.Method, option *core.OptionService) 
 func newProjectCategoryService(method *core.Method) *ProjectCategoryService {
 	return &ProjectCategoryService{
 		base: project.NewCategoryService(method),
+	}
+}
+
+func newProjectStatusService(method *core.Method, option *core.OptionService) *ProjectStatusService {
+	return &ProjectStatusService{
+		base:   project.NewStatusService(method),
+		Option: newProjectStatusOptionService(option),
 	}
 }
 
@@ -554,6 +647,10 @@ func newProjectOptionService(option *core.OptionService) *ProjectOptionService {
 	return &ProjectOptionService{
 		base: option,
 	}
+}
+
+func newProjectStatusOptionService(option *core.OptionService) *ProjectStatusOptionService {
+	return &ProjectStatusOptionService{base: option}
 }
 
 func newWebhookOptionService(option *core.OptionService) *ProjectWebhookOptionService {
@@ -592,6 +689,30 @@ func projectsFromModel(ms []*model.Project) []*Project {
 	result := make([]*Project, len(ms))
 	for i, v := range ms {
 		result[i] = projectFromModel(v)
+	}
+	return result
+}
+
+func projectStatusFromModel(m *model.ProjectStatus) *ProjectStatus {
+	if m == nil {
+		return nil
+	}
+	return &ProjectStatus{
+		ID:           m.ID,
+		ProjectID:    m.ProjectID,
+		Name:         m.Name,
+		Color:        m.Color,
+		DisplayOrder: m.DisplayOrder,
+	}
+}
+
+func projectStatusesFromModel(ms []*model.ProjectStatus) []*ProjectStatus {
+	if ms == nil {
+		return nil
+	}
+	result := make([]*ProjectStatus, len(ms))
+	for i, v := range ms {
+		result[i] = projectStatusFromModel(v)
 	}
 	return result
 }

--- a/project.go
+++ b/project.go
@@ -30,15 +30,6 @@ type Project struct {
 	Archived                          bool
 }
 
-// ProjectStatus represents a status defined within a project.
-type ProjectStatus struct {
-	ID           int
-	ProjectID    int
-	Name         string
-	Color        string
-	DisplayOrder int
-}
-
 // ──────────────────────────────────────────────────────────────
 //  ProjectService
 // ──────────────────────────────────────────────────────────────
@@ -209,17 +200,17 @@ type ProjectStatusService struct {
 // All returns a list of statuses in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-status-list-of-project
-func (s *ProjectStatusService) All(ctx context.Context, projectIDOrKey string) ([]*ProjectStatus, error) {
+func (s *ProjectStatusService) All(ctx context.Context, projectIDOrKey string) ([]*Status, error) {
 	v, err := s.base.All(ctx, projectIDOrKey)
-	return projectStatusesFromModel(v), convertError(err)
+	return statusesFromModel(v), convertError(err)
 }
 
 // Create adds a new status to a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-status
-func (s *ProjectStatusService) Create(ctx context.Context, projectIDOrKey, name, color string) (*ProjectStatus, error) {
+func (s *ProjectStatusService) Create(ctx context.Context, projectIDOrKey, name, color string) (*Status, error) {
 	v, err := s.base.Create(ctx, projectIDOrKey, name, color)
-	return projectStatusFromModel(v), convertError(err)
+	return statusFromModel(v), convertError(err)
 }
 
 // Update updates a status in a project.
@@ -230,25 +221,25 @@ func (s *ProjectStatusService) Create(ctx context.Context, projectIDOrKey, name,
 //   - WithName
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-status
-func (s *ProjectStatusService) Update(ctx context.Context, projectIDOrKey string, statusID int, opts ...RequestOption) (*ProjectStatus, error) {
+func (s *ProjectStatusService) Update(ctx context.Context, projectIDOrKey string, statusID int, opts ...RequestOption) (*Status, error) {
 	v, err := s.base.Update(ctx, projectIDOrKey, statusID, toCoreOptions(opts)...)
-	return projectStatusFromModel(v), convertError(err)
+	return statusFromModel(v), convertError(err)
 }
 
 // Delete deletes a status from a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-status
-func (s *ProjectStatusService) Delete(ctx context.Context, projectIDOrKey string, statusID, substituteStatusID int) (*ProjectStatus, error) {
+func (s *ProjectStatusService) Delete(ctx context.Context, projectIDOrKey string, statusID, substituteStatusID int) (*Status, error) {
 	v, err := s.base.Delete(ctx, projectIDOrKey, statusID, substituteStatusID)
-	return projectStatusFromModel(v), convertError(err)
+	return statusFromModel(v), convertError(err)
 }
 
 // UpdateOrder updates the display order of statuses in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-order-of-status
-func (s *ProjectStatusService) UpdateOrder(ctx context.Context, projectIDOrKey string, statusIDs []int) ([]*ProjectStatus, error) {
+func (s *ProjectStatusService) UpdateOrder(ctx context.Context, projectIDOrKey string, statusIDs []int) ([]*Status, error) {
 	v, err := s.base.UpdateOrder(ctx, projectIDOrKey, statusIDs)
-	return projectStatusesFromModel(v), convertError(err)
+	return statusesFromModel(v), convertError(err)
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -689,30 +680,6 @@ func projectsFromModel(ms []*model.Project) []*Project {
 	result := make([]*Project, len(ms))
 	for i, v := range ms {
 		result[i] = projectFromModel(v)
-	}
-	return result
-}
-
-func projectStatusFromModel(m *model.ProjectStatus) *ProjectStatus {
-	if m == nil {
-		return nil
-	}
-	return &ProjectStatus{
-		ID:           m.ID,
-		ProjectID:    m.ProjectID,
-		Name:         m.Name,
-		Color:        m.Color,
-		DisplayOrder: m.DisplayOrder,
-	}
-}
-
-func projectStatusesFromModel(ms []*model.ProjectStatus) []*ProjectStatus {
-	if ms == nil {
-		return nil
-	}
-	result := make([]*ProjectStatus, len(ms))
-	for i, v := range ms {
-		result[i] = projectStatusFromModel(v)
 	}
 	return result
 }

--- a/project_test.go
+++ b/project_test.go
@@ -821,6 +821,155 @@ func TestProjectUserService(t *testing.T) {
 	}
 }
 
+func TestProjectStatusService(t *testing.T) {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		doFunc func(req *http.Request) (*http.Response, error)
+		call   func(t *testing.T, c *backlog.Client)
+	}{
+		"All": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/statuses", req.URL.Path)
+				return mock.NewJSONResponse(fixture.Status.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Status.All(ctx, "TEST")
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+				assert.Equal(t, fixture.Status.Single.ID, got[0].ID)
+				assert.Equal(t, fixture.Status.Single.Name, got[0].Name)
+				assert.Equal(t, fixture.Status.Single.Color, got[0].Color)
+			},
+		},
+		"All/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Status.All(ctx, "TEST")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Create": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/statuses", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "Open", req.PostForm.Get("name"))
+				assert.Equal(t, "#ed8077", req.PostForm.Get("color"))
+				return mock.NewJSONResponse(fixture.Status.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Status.Create(ctx, "TEST", "Open", "#ed8077")
+				require.NoError(t, err)
+				assert.Equal(t, fixture.Status.Single.ID, got.ID)
+				assert.Equal(t, fixture.Status.Single.Name, got.Name)
+				assert.Equal(t, fixture.Status.Single.Color, got.Color)
+			},
+		},
+		"Create/error": {
+			doFunc: newAuthErrorDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Status.Create(ctx, "TEST", "Open", "#ed8077")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Update": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPatch, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/statuses/1", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, "Closed", req.PostForm.Get("name"))
+				assert.Equal(t, "#f5ab35", req.PostForm.Get("color"))
+				return mock.NewJSONResponse(fixture.Status.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Status.Update(
+					ctx,
+					"TEST",
+					1,
+					c.Project.Status.Option.WithName("Closed"),
+					c.Project.Status.Option.WithColor("#f5ab35"),
+				)
+				require.NoError(t, err)
+				assert.Equal(t, fixture.Status.Single.ID, got.ID)
+			},
+		},
+		"Update/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Status.Update(ctx, "TEST", 1)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"Delete": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodDelete, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/statuses/1", req.URL.Path)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				form, err := url.ParseQuery(string(body))
+				require.NoError(t, err)
+				assert.Equal(t, "2", form.Get("substituteStatusId"))
+				return mock.NewJSONResponse(fixture.Status.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Status.Delete(ctx, "TEST", 1, 2)
+				require.NoError(t, err)
+				assert.Equal(t, fixture.Status.Single.ID, got.ID)
+			},
+		},
+		"Delete/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Status.Delete(ctx, "TEST", 1, 2)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+		"UpdateOrder": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodPatch, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/statuses/updateDisplayOrder", req.URL.Path)
+				require.NoError(t, req.ParseForm())
+				assert.Equal(t, []string{"2", "1"}, req.PostForm["statusId[]"])
+				return mock.NewJSONResponse(fixture.Status.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.Status.UpdateOrder(ctx, "TEST", []int{2, 1})
+				require.NoError(t, err)
+				assert.Len(t, got, 2)
+			},
+		},
+		"UpdateOrder/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Project.Status.UpdateOrder(ctx, "TEST", []int{2, 1})
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
+			require.NoError(t, err)
+			tc.call(t, c)
+		})
+	}
+}
+
 func TestProjectOptionService(t *testing.T) {
 	c, err := backlog.NewClient("https://example.backlog.com", "token")
 	require.NoError(t, err)
@@ -861,6 +1010,34 @@ func TestProjectOptionService(t *testing.T) {
 		"WithTextFormattingRule": {
 			option:  s.WithTextFormattingRule(model.FormatBacklog),
 			wantKey: core.ParamTextFormattingRule.Value(),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.wantKey, tc.option.Key())
+		})
+	}
+}
+
+func TestProjectStatusOptionService(t *testing.T) {
+	c, err := backlog.NewClient("https://example.backlog.com", "token")
+	require.NoError(t, err)
+
+	s := c.Project.Status.Option
+
+	cases := map[string]struct {
+		option  backlog.RequestOption
+		wantKey string
+	}{
+		"WithColor": {
+			option:  s.WithColor("#ed8077"),
+			wantKey: core.ParamColor.Value(),
+		},
+		"WithName": {
+			option:  s.WithName("Open"),
+			wantKey: core.ParamName.Value(),
 		},
 	}
 


### PR DESCRIPTION
## Summary

Implements the Status-related endpoints from the Backlog API as part of #215.

The Backlog API returns the same `{id, projectId, name, color, displayOrder}` shape for
status objects everywhere — both as a standalone resource (`GET /projects/{key}/statuses`)
and embedded inside Issue / PullRequest responses. The existing `model.Status` only had
`id` and `name`, so this PR unifies the types: `model.Status` is extended with the missing
fields and the redundant `model.ProjectStatus` is removed.

## Changes

- `internal/model/common.go`: Extend `Status` with `projectId`, `color`, `displayOrder`
- `internal/model/project.go`: Remove `ProjectStatus` (merged into `Status`)
- `internal/core/option.go`: Add `ParamColor` constant
- `internal/core/option_string.go`: Add `WithColor` option builder
- `internal/project/service.go`: Add `StatusService` (`All`, `Create`, `Update`, `Delete`, `UpdateOrder`) returning `*model.Status`; add `NewStatusService` constructor
- `internal/testutil/fixture/testdata_project.go`: Add `statusFixtures` type and `Status` fixture
- `internal/project/service_test.go`: Add `TestStatusService_All/Create/Update/Delete/UpdateOrder` and context propagation cases
- `models.go`: Add `ProjectID`, `Color`, `DisplayOrder` to root `Status`; update `statusFromModel`; add `statusesFromModel`
- `project.go`: Remove `ProjectStatus` type; `ProjectStatusService` methods now return `*Status` / `[]*Status` via `statusFromModel`/`statusesFromModel`
- `project_test.go`: Add `TestProjectStatusService` and `TestProjectStatusOptionService`
- `models_test.go`: Update `Test_statusFromModel`, `Test_issueFromModel`, `Test_pullRequestFromModel` to use full `Status` fields

Part of #215