### PR TITLE
refactor!: require at least one option in Update methods that have no effect without options

### DIFF
--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -78,7 +78,7 @@ func (s *Service) Create(ctx context.Context, key, name string, opts ...core.Req
 	return &v, nil
 }
 
-func (s *Service) Update(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) (*model.Project, error) {
+func (s *Service) Update(ctx context.Context, projectIDOrKey string, option core.RequestOption, opts ...core.RequestOption) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -88,7 +88,8 @@ func (s *Service) Update(ctx context.Context, projectIDOrKey string, opts ...cor
 		core.ParamKey, core.ParamName, core.ParamChartEnabled, core.ParamSubtaskingEnabled,
 		core.ParamProjectLeaderCanEditProjectLeader, core.ParamTextFormattingRule, core.ParamArchived,
 	}
-	if err := core.ApplyOptions(form, validTypes, opts...); err != nil {
+	options := append([]core.RequestOption{option}, opts...)
+	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
 		return nil, err
 	}
 
@@ -458,7 +459,7 @@ func (s *StatusService) Create(ctx context.Context, projectIDOrKey, name, color 
 // Update updates a status in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-status
-func (s *StatusService) Update(ctx context.Context, projectIDOrKey string, statusID int, opts ...core.RequestOption) (*model.Status, error) {
+func (s *StatusService) Update(ctx context.Context, projectIDOrKey string, statusID int, option core.RequestOption, opts ...core.RequestOption) (*model.Status, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -468,7 +469,8 @@ func (s *StatusService) Update(ctx context.Context, projectIDOrKey string, statu
 
 	form := url.Values{}
 	validTypes := []core.APIParamOptionType{core.ParamName, core.ParamColor}
-	if err := core.ApplyOptions(form, validTypes, opts...); err != nil {
+	options := append([]core.RequestOption{option}, opts...)
+	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
 		return nil, err
 	}
 

--- a/internal/project/service_context_test.go
+++ b/internal/project/service_context_test.go
@@ -50,7 +50,7 @@ func Test_contextPropagation(t *testing.T) {
 		{"Service.Update", func(t *testing.T, m *core.Method) {
 			m.Patch = makeMockFn(t)
 			s := project.NewService(m)
-			s.Update(ctx, "TEST") //nolint:errcheck
+			s.Update(ctx, "TEST", o.WithName("test")) //nolint:errcheck
 		}},
 		{"Service.Delete", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)
@@ -115,7 +115,7 @@ func Test_contextPropagation(t *testing.T) {
 		{"StatusService.Update", func(t *testing.T, m *core.Method) {
 			m.Patch = makeMockFn(t)
 			s := project.NewStatusService(m)
-			s.Update(ctx, "TEST", 1) //nolint:errcheck
+			s.Update(ctx, "TEST", 1, o.WithName("Open")) //nolint:errcheck
 		}},
 		{"StatusService.Delete", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)

--- a/internal/project/service_status_test.go
+++ b/internal/project/service_status_test.go
@@ -199,6 +199,7 @@ func TestStatusService_Update(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 		statusID       int
+		option         core.RequestOption
 		opts           []core.RequestOption
 
 		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
@@ -208,8 +209,8 @@ func TestStatusService_Update(t *testing.T) {
 		"success": {
 			projectIDOrKey: "TEST",
 			statusID:       1,
+			option:         o.WithName("Open Updated"),
 			opts: []core.RequestOption{
-				o.WithName("Open Updated"),
 				o.WithColor("#f5ab35"),
 			},
 
@@ -222,36 +223,28 @@ func TestStatusService_Update(t *testing.T) {
 
 			wantErrType: nil,
 		},
-		"success-without-option": {
-			projectIDOrKey: "TEST",
-			statusID:       1,
-
-			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				assert.Equal(t, "projects/TEST/statuses/1", spath)
-				return mock.NewJSONResponse(fixture.Status.SingleJSON), nil
-			},
-
-			wantErrType: nil,
-		},
 		"error-validation-projectIDOrKey-empty": {
 			projectIDOrKey: "",
 			statusID:       1,
+			option:         o.WithName("Open"),
 			wantErrType:    &core.ValidationError{},
 		},
 		"error-validation-statusID-zero": {
 			projectIDOrKey: "TEST",
 			statusID:       0,
+			option:         o.WithName("Open"),
 			wantErrType:    &core.ValidationError{},
 		},
 		"error-option-invalid-type": {
 			projectIDOrKey: "TEST",
 			statusID:       1,
-			opts:           []core.RequestOption{mock.NewInvalidTypeOption()},
+			option:         mock.NewInvalidTypeOption(),
 			wantErrType:    &core.InvalidOptionKeyError{},
 		},
 		"error-client-network": {
 			projectIDOrKey: "TEST",
 			statusID:       1,
+			option:         o.WithName("Open"),
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
@@ -262,6 +255,7 @@ func TestStatusService_Update(t *testing.T) {
 		"error-response-invalid-json": {
 			projectIDOrKey: "TEST",
 			statusID:       1,
+			option:         o.WithName("Open"),
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return mock.NewJSONResponse(fixture.InvalidJSON), nil
@@ -281,7 +275,7 @@ func TestStatusService_Update(t *testing.T) {
 			}
 			s := project.NewStatusService(method)
 
-			status, err := s.Update(context.Background(), tc.projectIDOrKey, tc.statusID, tc.opts...)
+			status, err := s.Update(context.Background(), tc.projectIDOrKey, tc.statusID, tc.option, tc.opts...)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -362,6 +362,7 @@ func TestService_Update(t *testing.T) {
 
 	cases := map[string]struct {
 		projectIDOrKey string
+		option         core.RequestOption
 		opts           []core.RequestOption
 
 		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
@@ -370,6 +371,7 @@ func TestService_Update(t *testing.T) {
 	}{
 		"success-projectIDOrKey-key": {
 			projectIDOrKey: "TEST",
+			option:         o.WithName("test"),
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST", spath)
@@ -382,6 +384,7 @@ func TestService_Update(t *testing.T) {
 
 		"success-projectIDOrKey-id": {
 			projectIDOrKey: "1234",
+			option:         o.WithName("test"),
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/1234", spath)
@@ -393,21 +396,23 @@ func TestService_Update(t *testing.T) {
 
 		"error-validation-projectIDOrKey-empty": {
 			projectIDOrKey: "",
+			option:         o.WithName("test"),
 
 			wantErrType: &core.ValidationError{},
 		},
 
 		"error-validation-projectIDOrKey-zero": {
 			projectIDOrKey: "0",
+			option:         o.WithName("test"),
 
 			wantErrType: &core.ValidationError{},
 		},
 
 		"success-with-options": {
 			projectIDOrKey: "TEST",
+			option:         o.WithKey("TEST1"),
 
 			opts: []core.RequestOption{
-				o.WithKey("TEST1"),
 				o.WithName("test1"),
 				o.WithChartEnabled(true),
 				o.WithSubtaskingEnabled(true),
@@ -432,24 +437,21 @@ func TestService_Update(t *testing.T) {
 
 		"error-option-invalid-value": {
 			projectIDOrKey: "TEST",
-
-			opts: []core.RequestOption{
-				o.WithTextFormattingRule("invalid"),
-			},
+			option:         o.WithTextFormattingRule("invalid"),
 
 			wantErrType: &core.ValidationError{},
 		},
 
 		"error-option-invalid-type": {
 			projectIDOrKey: "TEST",
-
-			opts: []core.RequestOption{mock.NewInvalidTypeOption()},
+			option:         mock.NewInvalidTypeOption(),
 
 			wantErrType: &core.InvalidOptionKeyError{},
 		},
 
 		"error-client-network": {
 			projectIDOrKey: "TEST",
+			option:         o.WithName("test"),
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
@@ -460,6 +462,7 @@ func TestService_Update(t *testing.T) {
 
 		"error-response-invalid-json": {
 			projectIDOrKey: "TEST",
+			option:         o.WithName("test"),
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return mock.NewJSONResponse(fixture.InvalidJSON), nil
@@ -479,7 +482,7 @@ func TestService_Update(t *testing.T) {
 			}
 			s := project.NewService(method)
 
-			project, err := s.Update(context.Background(), tc.projectIDOrKey, tc.opts...)
+			project, err := s.Update(context.Background(), tc.projectIDOrKey, tc.option, tc.opts...)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -125,11 +125,11 @@ func (s *Service) Add(ctx context.Context, userID, password, name, mailAddress s
 	return add(ctx, s.method, "users", form)
 }
 
-func (s *Service) Update(ctx context.Context, id int, opts ...core.RequestOption) (*model.User, error) {
-	option := &core.OptionService{}
+func (s *Service) Update(ctx context.Context, id int, option core.RequestOption, opts ...core.RequestOption) (*model.User, error) {
+	baseOpt := &core.OptionService{}
 	form := url.Values{}
 	validTypes := []core.APIParamOptionType{core.ParamUserID, core.ParamName, core.ParamPassword, core.ParamMailAddress, core.ParamRoleType}
-	options := append([]core.RequestOption{option.WithUserID(id)}, opts...)
+	options := append([]core.RequestOption{baseOpt.WithUserID(id), option}, opts...)
 	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
 		return nil, err
 	}

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -309,8 +309,9 @@ func TestUserService_Update(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
-		id   int
-		opts []core.RequestOption
+		id     int
+		option core.RequestOption
+		opts   []core.RequestOption
 
 		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
@@ -318,9 +319,9 @@ func TestUserService_Update(t *testing.T) {
 		wantErrType error
 	}{
 		"success-update-user": {
-			id: 1,
+			id:     1,
+			option: o.WithPassword("password"),
 			opts: []core.RequestOption{
-				o.WithPassword("password"),
 				o.WithName("admin"),
 				o.WithMailAddress("eguchi@nulab.example"),
 				o.WithRoleType(model.RoleAdministrator),
@@ -342,13 +343,9 @@ func TestUserService_Update(t *testing.T) {
 				RoleType:    model.RoleAdministrator,
 			},
 		},
-		"error-validation-id-zero": {
-			id: 0,
-
-			wantErrType: &core.ValidationError{},
-		},
 		"error-response-invalid-json": {
-			id: 1234,
+			id:     1234,
+			option: o.WithName("test"),
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1234", spath)
@@ -358,10 +355,8 @@ func TestUserService_Update(t *testing.T) {
 			wantErrType: &json.SyntaxError{},
 		},
 		"success-option-withName": {
-			id: 1,
-			opts: []core.RequestOption{
-				o.WithName("testname"),
-			},
+			id:     1,
+			option: o.WithName("testname"),
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
@@ -372,10 +367,8 @@ func TestUserService_Update(t *testing.T) {
 			wantErrType: errors.New(""),
 		},
 		"success-option-withPassword": {
-			id: 1,
-			opts: []core.RequestOption{
-				o.WithPassword("testpassword"),
-			},
+			id:     1,
+			option: o.WithPassword("testpassword"),
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
@@ -386,10 +379,8 @@ func TestUserService_Update(t *testing.T) {
 			wantErrType: errors.New(""),
 		},
 		"success-option-withMailAddress": {
-			id: 1,
-			opts: []core.RequestOption{
-				o.WithMailAddress("test@test.com"),
-			},
+			id:     1,
+			option: o.WithMailAddress("test@test.com"),
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
@@ -400,10 +391,8 @@ func TestUserService_Update(t *testing.T) {
 			wantErrType: errors.New(""),
 		},
 		"success-option-withRoleType": {
-			id: 1,
-			opts: []core.RequestOption{
-				o.WithRoleType(model.RoleAdministrator),
-			},
+			id:     1,
+			option: o.WithRoleType(model.RoleAdministrator),
 
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1", spath)
@@ -414,9 +403,9 @@ func TestUserService_Update(t *testing.T) {
 			wantErrType: errors.New(""),
 		},
 		"success-option-multiple": {
-			id: 1,
+			id:     1,
+			option: o.WithPassword("testpassword1"),
 			opts: []core.RequestOption{
-				o.WithPassword("testpassword1"),
 				o.WithName("testname1"),
 				o.WithMailAddress("test1@test.com"),
 				o.WithRoleType(model.RoleAdministrator),
@@ -434,22 +423,20 @@ func TestUserService_Update(t *testing.T) {
 			wantErrType: errors.New(""),
 		},
 		"error-option-invalid-value": {
-			id: 1,
-			opts: []core.RequestOption{
-				o.WithName(""),
-			},
+			id:     1,
+			option: o.WithName(""),
 
 			wantErrType: &core.ValidationError{},
 		},
 		"error-option-invalid-type": {
-			id:   1,
-			opts: []core.RequestOption{mock.NewInvalidTypeOption()},
+			id:     1,
+			option: mock.NewInvalidTypeOption(),
 
 			wantErrType: &core.InvalidOptionKeyError{},
 		},
 		"error-option-set-faild": {
 			id:          1,
-			opts:        []core.RequestOption{mock.NewFailingSetOption(core.ParamName)},
+			option:      mock.NewFailingSetOption(core.ParamName),
 			wantErrType: errors.New(""),
 		},
 	}
@@ -464,7 +451,7 @@ func TestUserService_Update(t *testing.T) {
 			}
 			s := user.NewService(method)
 
-			user, err := s.Update(context.Background(), tc.id, tc.opts...)
+			user, err := s.Update(context.Background(), tc.id, tc.option, tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)

--- a/internal/version/service.go
+++ b/internal/version/service.go
@@ -82,24 +82,12 @@ func (s *Service) Add(ctx context.Context, projectIDOrKey, name string, opts ...
 }
 
 // Update updates a version/milestone.
-func (s *Service) Update(ctx context.Context, projectIDOrKey string, versionID int, opts ...core.RequestOption) (*model.Version, error) {
+func (s *Service) Update(ctx context.Context, projectIDOrKey string, versionID int, option core.RequestOption, opts ...core.RequestOption) (*model.Version, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 	if err := validate.ValidateVersionID(versionID); err != nil {
 		return nil, err
-	}
-
-	if !core.HasRequiredOption(opts, []core.APIParamOptionType{
-		core.ParamName,
-		core.ParamDescription,
-		core.ParamStartDate,
-		core.ParamReleaseDueDate,
-		core.ParamArchived,
-	}) {
-		return nil, core.NewValidationError(
-			"requires an option to modify version fields",
-		)
 	}
 
 	form := url.Values{}
@@ -110,7 +98,8 @@ func (s *Service) Update(ctx context.Context, projectIDOrKey string, versionID i
 		core.ParamReleaseDueDate,
 		core.ParamArchived,
 	}
-	if err := core.ApplyOptions(form, validTypes, opts...); err != nil {
+	options := append([]core.RequestOption{option}, opts...)
+	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
 		return nil, err
 	}
 

--- a/internal/version/service_test.go
+++ b/internal/version/service_test.go
@@ -177,6 +177,7 @@ func TestService_Update(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 		versionID      int
+		option         core.RequestOption
 		opts           []core.RequestOption
 		wantErrType    error
 		wantID         int
@@ -185,7 +186,8 @@ func TestService_Update(t *testing.T) {
 		"success": {
 			projectIDOrKey: "TEST",
 			versionID:      1,
-			opts:           []core.RequestOption{o.WithName("name"), o.WithReleaseDueDate(date)},
+			option:         o.WithName("name"),
+			opts:           []core.RequestOption{o.WithReleaseDueDate(date)},
 			wantID:         fixture.Version.Single.ID,
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/versions/1", spath)
@@ -195,38 +197,33 @@ func TestService_Update(t *testing.T) {
 		"error-versionID-negative": {
 			projectIDOrKey: "TEST",
 			versionID:      -1,
-			opts:           []core.RequestOption{o.WithName("name")},
+			option:         o.WithName("name"),
 			wantErrType:    &core.ValidationError{},
 			mockPatchFn:    mock.NewUnexpectedPatchFn(t),
 		},
 		"error-option-invalid-type": {
 			projectIDOrKey: "TEST",
 			versionID:      1,
-			opts:           []core.RequestOption{o.WithName("name"), mock.NewInvalidTypeOption()},
+			option:         mock.NewInvalidTypeOption(),
 			wantErrType:    &core.InvalidOptionKeyError{},
 		},
 		"error-option-set-failed": {
 			projectIDOrKey: "TEST",
 			versionID:      1,
-			opts:           []core.RequestOption{mock.NewFailingSetOption(core.ParamArchived)},
+			option:         mock.NewFailingSetOption(core.ParamArchived),
 			wantErrType:    errors.New(""),
-		},
-		"error-no-options": {
-			projectIDOrKey: "TEST",
-			versionID:      1,
-			wantErrType:    &core.ValidationError{},
 		},
 		"error-project-empty": {
 			projectIDOrKey: "",
 			versionID:      1,
-			opts:           []core.RequestOption{o.WithName("name")},
+			option:         o.WithName("name"),
 			wantErrType:    &core.ValidationError{},
 			mockPatchFn:    mock.NewUnexpectedPatchFn(t),
 		},
 		"error-response-invalid-json": {
 			projectIDOrKey: "TEST",
 			versionID:      1,
-			opts:           []core.RequestOption{o.WithName("name")},
+			option:         o.WithName("name"),
 			wantErrType:    &json.SyntaxError{},
 			mockPatchFn: func(context.Context, string, url.Values) (*http.Response, error) {
 				return mock.NewJSONResponse(fixture.InvalidJSON), nil
@@ -235,7 +232,7 @@ func TestService_Update(t *testing.T) {
 		"error-versionID-zero": {
 			projectIDOrKey: "TEST",
 			versionID:      0,
-			opts:           []core.RequestOption{o.WithName("name")},
+			option:         o.WithName("name"),
 			wantErrType:    &core.ValidationError{},
 			mockPatchFn:    mock.NewUnexpectedPatchFn(t),
 		},
@@ -250,7 +247,7 @@ func TestService_Update(t *testing.T) {
 				m.Patch = tc.mockPatchFn
 			}
 			s := version.NewService(m)
-			got, err := s.Update(context.Background(), tc.projectIDOrKey, tc.versionID, tc.opts...)
+			got, err := s.Update(context.Background(), tc.projectIDOrKey, tc.versionID, tc.option, tc.opts...)
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
 				assert.Nil(t, got)

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -117,7 +117,7 @@ func (s *Service) Get(ctx context.Context, projectIDOrKey string, webhookID int)
 // Update updates a webhook.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-webhook/
-func (s *Service) Update(ctx context.Context, projectIDOrKey string, webhookID int, opts ...core.RequestOption) (*model.Webhook, error) {
+func (s *Service) Update(ctx context.Context, projectIDOrKey string, webhookID int, option core.RequestOption, opts ...core.RequestOption) (*model.Webhook, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -125,24 +125,15 @@ func (s *Service) Update(ctx context.Context, projectIDOrKey string, webhookID i
 		return nil, err
 	}
 
-	if !core.HasRequiredOption(opts, []core.APIParamOptionType{
-		core.ParamName,
-		core.ParamDescription,
-		core.ParamHookURL,
-		core.ParamAllEvent,
-		core.ParamActivityTypeIDs,
-	}) {
-		return nil, core.NewValidationError("requires at least one webhook update option")
-	}
-
 	form := url.Values{}
+	options := append([]core.RequestOption{option}, opts...)
 	if err := core.ApplyOptions(form, []core.APIParamOptionType{
 		core.ParamName,
 		core.ParamDescription,
 		core.ParamHookURL,
 		core.ParamAllEvent,
 		core.ParamActivityTypeIDs,
-	}, opts...); err != nil {
+	}, options...); err != nil {
 		return nil, err
 	}
 

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -327,6 +327,7 @@ func TestService_Update(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 		webhookID      int
+		opt            core.RequestOption
 		opts           []core.RequestOption
 		wantErrType    error
 		wantID         int
@@ -335,10 +336,8 @@ func TestService_Update(t *testing.T) {
 		"success-activity-types-only": {
 			projectIDOrKey: "TEST",
 			webhookID:      1,
-			opts: []core.RequestOption{
-				option.WithActivityTypeIDs([]int{1, 2}),
-			},
-			wantID: fixture.Webhook.ActivityTypes.ID,
+			opt:            option.WithActivityTypeIDs([]int{1, 2}),
+			wantID:         fixture.Webhook.ActivityTypes.ID,
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/webhooks/1", spath)
 				assert.Equal(t, []string{"1", "2"}, form["activityTypeId[]"])
@@ -348,11 +347,9 @@ func TestService_Update(t *testing.T) {
 		"success-all-event-false-with-activity-types": {
 			projectIDOrKey: "TEST",
 			webhookID:      1,
-			opts: []core.RequestOption{
-				option.WithAllEvent(false),
-				option.WithActivityTypeIDs([]int{1, 2}),
-			},
-			wantID: fixture.Webhook.ActivityTypes.ID,
+			opt:            option.WithAllEvent(false),
+			opts:           []core.RequestOption{option.WithActivityTypeIDs([]int{1, 2})},
+			wantID:         fixture.Webhook.ActivityTypes.ID,
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/webhooks/1", spath)
 				assert.Equal(t, "false", form.Get("allEvent"))
@@ -363,10 +360,8 @@ func TestService_Update(t *testing.T) {
 		"success-all-event-true": {
 			projectIDOrKey: "TEST",
 			webhookID:      1,
-			opts: []core.RequestOption{
-				option.WithAllEvent(true),
-			},
-			wantID: fixture.Webhook.AllEvent.ID,
+			opt:            option.WithAllEvent(true),
+			wantID:         fixture.Webhook.AllEvent.ID,
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/webhooks/1", spath)
 				assert.Equal(t, "true", form.Get("allEvent"))
@@ -376,25 +371,21 @@ func TestService_Update(t *testing.T) {
 		"error-all-event-false-without-activity-types": {
 			projectIDOrKey: "TEST",
 			webhookID:      1,
-			opts:           []core.RequestOption{option.WithAllEvent(false)},
+			opt:            option.WithAllEvent(false),
 			wantErrType:    &core.ValidationError{},
 		},
 		"error-all-event-true-with-activity-types": {
 			projectIDOrKey: "TEST",
 			webhookID:      1,
-			opts: []core.RequestOption{
-				option.WithAllEvent(true),
-				option.WithActivityTypeIDs([]int{1, 2}),
-			},
-			wantErrType: &core.ValidationError{},
+			opt:            option.WithAllEvent(true),
+			opts:           []core.RequestOption{option.WithActivityTypeIDs([]int{1, 2})},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-client-network": {
 			projectIDOrKey: "TEST",
 			webhookID:      1,
-			opts: []core.RequestOption{
-				option.WithAllEvent(true),
-			},
-			wantErrType: errors.New(""),
+			opt:            option.WithAllEvent(true),
+			wantErrType:    errors.New(""),
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("network error")
 			},
@@ -402,72 +393,56 @@ func TestService_Update(t *testing.T) {
 		"error-hookURL-empty": {
 			projectIDOrKey: "TEST",
 			webhookID:      1,
-			opts: []core.RequestOption{
-				option.WithHookURL(""),
-				option.WithAllEvent(true),
-			},
-			wantErrType: &core.ValidationError{},
+			opt:            option.WithHookURL(""),
+			opts:           []core.RequestOption{option.WithAllEvent(true)},
+			wantErrType:    &core.ValidationError{},
 		},
 		"error-invalid-option-type": {
 			projectIDOrKey: "TEST",
 			webhookID:      1,
-			opts:           []core.RequestOption{option.WithAllEvent(true), mock.NewInvalidTypeOption()},
+			opt:            option.WithAllEvent(true),
+			opts:           []core.RequestOption{mock.NewInvalidTypeOption()},
 			wantErrType:    &core.InvalidOptionKeyError{},
 		},
 		"error-name-empty": {
 			projectIDOrKey: "TEST",
 			webhookID:      1,
-			opts: []core.RequestOption{
-				option.WithName(""),
-				option.WithAllEvent(true),
-			},
-			wantErrType: &core.ValidationError{},
-		},
-		"error-no-options": {
-			projectIDOrKey: "TEST",
-			webhookID:      1,
+			opt:            option.WithName(""),
+			opts:           []core.RequestOption{option.WithAllEvent(true)},
 			wantErrType:    &core.ValidationError{},
 		},
 		"error-option-set-failed": {
 			projectIDOrKey: "TEST",
 			webhookID:      1,
-			opts:           []core.RequestOption{mock.NewFailingSetOption(core.ParamAllEvent)},
+			opt:            mock.NewFailingSetOption(core.ParamAllEvent),
 			wantErrType:    errors.New(""),
 		},
 		"error-project-empty": {
 			projectIDOrKey: "",
 			webhookID:      1,
-			opts: []core.RequestOption{
-				option.WithAllEvent(true),
-			},
-			wantErrType: &core.ValidationError{},
-			mockPatchFn: mock.NewUnexpectedPatchFn(t),
+			opt:            option.WithAllEvent(true),
+			wantErrType:    &core.ValidationError{},
+			mockPatchFn:    mock.NewUnexpectedPatchFn(t),
 		},
 		"error-webhookID-zero": {
 			projectIDOrKey: "TEST",
 			webhookID:      0,
-			opts: []core.RequestOption{
-				option.WithAllEvent(true),
-			},
-			wantErrType: &core.ValidationError{},
-			mockPatchFn: mock.NewUnexpectedPatchFn(t),
+			opt:            option.WithAllEvent(true),
+			wantErrType:    &core.ValidationError{},
+			mockPatchFn:    mock.NewUnexpectedPatchFn(t),
 		},
 		"error-webhookID-negative": {
 			projectIDOrKey: "TEST",
 			webhookID:      -1,
-			opts: []core.RequestOption{
-				option.WithAllEvent(true),
-			},
-			wantErrType: &core.ValidationError{},
-			mockPatchFn: mock.NewUnexpectedPatchFn(t),
+			opt:            option.WithAllEvent(true),
+			wantErrType:    &core.ValidationError{},
+			mockPatchFn:    mock.NewUnexpectedPatchFn(t),
 		},
 		"error-response-invalid-json": {
 			projectIDOrKey: "TEST",
 			webhookID:      1,
-			opts: []core.RequestOption{
-				option.WithAllEvent(true),
-			},
-			wantErrType: &json.SyntaxError{},
+			opt:            option.WithAllEvent(true),
+			wantErrType:    &json.SyntaxError{},
 			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
@@ -482,7 +457,7 @@ func TestService_Update(t *testing.T) {
 				m.Patch = tc.mockPatchFn
 			}
 			s := webhook.NewService(m)
-			got, err := s.Update(context.Background(), tc.projectIDOrKey, tc.webhookID, tc.opts...)
+			got, err := s.Update(context.Background(), tc.projectIDOrKey, tc.webhookID, tc.opt, tc.opts...)
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
 				assert.Nil(t, got)

--- a/project.go
+++ b/project.go
@@ -83,8 +83,8 @@ func (s *ProjectService) Create(ctx context.Context, key, name string, opts ...R
 
 // Update updates a project.
 //
-// This method supports options returned by methods in "*Client.Project.Option",
-// such as:
+// At least one option is required. This method supports options returned by
+// methods in "*Client.Project.Option", such as:
 //   - WithArchived
 //   - WithChartEnabled
 //   - WithKey
@@ -94,8 +94,8 @@ func (s *ProjectService) Create(ctx context.Context, key, name string, opts ...R
 //   - WithTextFormattingRule
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-project
-func (s *ProjectService) Update(ctx context.Context, projectIDOrKey string, opts ...RequestOption) (*Project, error) {
-	v, err := s.base.Update(ctx, projectIDOrKey, toCoreOptions(opts)...)
+func (s *ProjectService) Update(ctx context.Context, projectIDOrKey string, option RequestOption, opts ...RequestOption) (*Project, error) {
+	v, err := s.base.Update(ctx, projectIDOrKey, option, toCoreOptions(opts)...)
 	return projectFromModel(v), convertError(err)
 }
 

--- a/project_events.go
+++ b/project_events.go
@@ -93,8 +93,8 @@ func (s *ProjectWebhookService) One(ctx context.Context, projectIDOrKey string, 
 
 // Update updates a webhook.
 //
-// This method supports options returned by methods in "*Client.Project.Webhook.Option",
-// such as:
+// At least one option is required. This method supports options returned by
+// methods in "*Client.Project.Webhook.Option", such as:
 //   - WithActivityTypeIDs
 //   - WithAllEvent
 //   - WithDescription
@@ -102,8 +102,8 @@ func (s *ProjectWebhookService) One(ctx context.Context, projectIDOrKey string, 
 //   - WithName
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-webhook
-func (s *ProjectWebhookService) Update(ctx context.Context, projectIDOrKey string, webhookID int, opts ...RequestOption) (*Webhook, error) {
-	v, err := s.base.Update(ctx, projectIDOrKey, webhookID, toCoreOptions(opts)...)
+func (s *ProjectWebhookService) Update(ctx context.Context, projectIDOrKey string, webhookID int, option RequestOption, opts ...RequestOption) (*Webhook, error) {
+	v, err := s.base.Update(ctx, projectIDOrKey, webhookID, option, toCoreOptions(opts)...)
 	return webhookFromModel(v), convertError(err)
 }
 

--- a/project_process.go
+++ b/project_process.go
@@ -37,14 +37,14 @@ func (s *ProjectStatusService) Create(ctx context.Context, projectIDOrKey, name,
 
 // Update updates a status in a project.
 //
-// This method supports options returned by methods in "*Client.Project.Status.Option",
-// such as:
+// At least one option is required. This method supports options returned by
+// methods in "*Client.Project.Status.Option", such as:
 //   - WithColor
 //   - WithName
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-status
-func (s *ProjectStatusService) Update(ctx context.Context, projectIDOrKey string, statusID int, opts ...RequestOption) (*Status, error) {
-	v, err := s.base.Update(ctx, projectIDOrKey, statusID, toCoreOptions(opts)...)
+func (s *ProjectStatusService) Update(ctx context.Context, projectIDOrKey string, statusID int, option RequestOption, opts ...RequestOption) (*Status, error) {
+	v, err := s.base.Update(ctx, projectIDOrKey, statusID, option, toCoreOptions(opts)...)
 	return statusFromModel(v), convertError(err)
 }
 
@@ -102,8 +102,8 @@ func (s *ProjectVersionService) Create(ctx context.Context, projectIDOrKey, name
 
 // Update updates a version/milestone.
 //
-// This method supports options returned by methods in "*Client.Project.Version.Option",
-// such as:
+// At least one option is required. This method supports options returned by
+// methods in "*Client.Project.Version.Option", such as:
 //   - WithArchived
 //   - WithDescription
 //   - WithName
@@ -111,8 +111,8 @@ func (s *ProjectVersionService) Create(ctx context.Context, projectIDOrKey, name
 //   - WithStartDate
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-version-milestone/
-func (s *ProjectVersionService) Update(ctx context.Context, projectIDOrKey string, versionID int, opts ...RequestOption) (*Version, error) {
-	v, err := s.base.Update(ctx, projectIDOrKey, versionID, toCoreOptions(opts)...)
+func (s *ProjectVersionService) Update(ctx context.Context, projectIDOrKey string, versionID int, option RequestOption, opts ...RequestOption) (*Version, error) {
+	v, err := s.base.Update(ctx, projectIDOrKey, versionID, option, toCoreOptions(opts)...)
 	return versionFromModel(v), convertError(err)
 }
 

--- a/project_process_test.go
+++ b/project_process_test.go
@@ -229,7 +229,12 @@ func TestProjectStatusService(t *testing.T) {
 		"Update/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.Status.Update(ctx, "TEST", 1)
+				_, err := c.Project.Status.Update(
+					ctx,
+					"TEST",
+					1,
+					c.Project.Status.Option.WithName("Closed"),
+				)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/project_test.go
+++ b/project_test.go
@@ -108,7 +108,7 @@ func TestProjectService(t *testing.T) {
 		"Update/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.Update(ctx, "TEST")
+				_, err := c.Project.Update(ctx, "TEST", c.Project.Option.WithName("new-name"))
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/user.go
+++ b/user.go
@@ -70,16 +70,16 @@ func (s *UserService) Add(ctx context.Context, userID, password, name, mailAddre
 
 // Update updates a user in your space.
 //
-// This method supports options returned by methods in "*Client.User.Option",
-// such as:
+// At least one option is required. This method supports options returned by
+// methods in "*Client.User.Option", such as:
 //   - WithMailAddress
 //   - WithName
 //   - WithPassword
 //   - WithRoleType
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-user
-func (s *UserService) Update(ctx context.Context, id int, opts ...RequestOption) (*User, error) {
-	v, err := s.base.Update(ctx, id, toCoreOptions(opts)...)
+func (s *UserService) Update(ctx context.Context, id int, option RequestOption, opts ...RequestOption) (*User, error) {
+	v, err := s.base.Update(ctx, id, option, toCoreOptions(opts)...)
 	return userFromModel(v), convertError(err)
 }
 

--- a/user_test.go
+++ b/user_test.go
@@ -131,7 +131,7 @@ func TestUserService(t *testing.T) {
 		"Update/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.User.Update(ctx, 1)
+				_, err := c.User.Update(ctx, 1, c.User.Option.WithName("updated-user"))
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))


### PR DESCRIPTION
## Summary

Several `Update` methods accepted `opts ...RequestOption`, making it possible to call them with zero options — a silent no-op that successfully calls the API but changes nothing. This PR enforces at least one option at compile time by changing the signature to `option RequestOption, opts ...RequestOption`, consistent with the pattern already established in `IssueService.Update`, `WikiService.Update`, and others.

## Changes

### Internal
- `internal/project/service.go`: `Service.Update`, `StatusService.Update`
- `internal/version/service.go`: `Service.Update` (also removes the now-unnecessary `HasRequiredOption` runtime check)
- `internal/webhook/service.go`: `Service.Update` (same)
- `internal/user/service.go`: `Service.Update`

### Root
- `project.go`: `ProjectService.Update`
- `project_process.go`: `ProjectStatusService.Update`, `ProjectVersionService.Update`
- `project_events.go`: `ProjectWebhookService.Update`
- `user.go`: `UserService.Update`

### Tests
- Updated all internal and root-level test files to pass at least one option; removed `success-without-option` cases and updated `*/error` cases that previously relied on passing zero options.

BREAKING CHANGE: `ProjectService.Update`, `ProjectStatusService.Update`, `ProjectVersionService.Update`, `ProjectWebhookService.Update`, and `UserService.Update` now require at least one `RequestOption`. Callers passing zero options will fail to compile.

Closes #268