### PR TITLE
refactor: replace HasRequiredOption with form.Has check in Wiki.Update

### DIFF
--- a/internal/core/option.go
+++ b/internal/core/option.go
@@ -205,15 +205,3 @@ func ApplyOptions(v url.Values, validTypes []APIParamOptionType, opts ...Request
 	}
 	return nil
 }
-
-// HasRequiredOption checks whether the provided options include at least one of the required form types.
-func HasRequiredOption(options []RequestOption, requiredTypes []APIParamOptionType) bool {
-	for _, opt := range options {
-		for _, requiredType := range requiredTypes {
-			if opt.Key() == requiredType.Value() {
-				return true
-			}
-		}
-	}
-	return false
-}

--- a/internal/wiki/service.go
+++ b/internal/wiki/service.go
@@ -118,12 +118,12 @@ func (s *Service) Update(ctx context.Context, wikiID int, option core.RequestOpt
 	validTypes := []core.APIParamOptionType{core.ParamName, core.ParamContent, core.ParamMailNotify}
 	options := append([]core.RequestOption{option}, opts...)
 
-	if !core.HasRequiredOption(options, []core.APIParamOptionType{core.ParamName, core.ParamContent}) {
-		return nil, core.NewValidationError("requires an option to modify wiki content or name (WithName or WithContent)")
-	}
-
 	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
 		return nil, err
+	}
+
+	if !form.Has("name") && !form.Has("content") {
+		return nil, core.NewValidationError("requires an option to modify wiki content or name (WithName or WithContent)")
 	}
 
 	spath := path.Join("wikis", strconv.Itoa(wikiID))


### PR DESCRIPTION
## Summary

Replace the `core.HasRequiredOption` call in `Wiki.Update` with a `form.Has` check after `ApplyOptions`. Since `HasRequiredOption` was only used in this one place, remove it from the `core` package as well.

## Changes

- `internal/wiki/service.go`: Move the required-option check to after `ApplyOptions`, using `form.Has("name") && form.Has("content")` to verify that at least one content-modifying option was set
- `internal/core/option.go`: Remove `HasRequiredOption` function