### PR TITLE
docs: add Example functions for package-level, NewClient, and OptionServices

### DIFF
--- a/example_option_test.go
+++ b/example_option_test.go
@@ -1,0 +1,255 @@
+package backlog_test
+
+import (
+	"context"
+	"fmt"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+// ExampleWikiOptionService demonstrates filtering and updating a wiki page using multiple options.
+func ExampleWikiOptionService() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.Wiki.MinimumJSON)),
+	)
+
+	wiki, _ := c.Wiki.Update(
+		context.Background(),
+		34,
+		c.Wiki.Option.WithName("Minimum Wiki Page"),
+		c.Wiki.Option.WithContent("Updated content."),
+	)
+	fmt.Printf("ID: %d, Name: %s\n", wiki.ID, wiki.Name)
+	// Output:
+	// ID: 34, Name: Minimum Wiki Page
+}
+
+// ExampleIssueOptionService demonstrates filtering issues using multiple options.
+func ExampleIssueOptionService() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.Issue.ListJSON)),
+	)
+
+	issues, _ := c.Issue.All(
+		context.Background(),
+		c.Issue.Option.WithProjectIDs([]int{10}),
+		c.Issue.Option.WithKeyword("first"),
+		c.Issue.Option.WithCount(50),
+	)
+	fmt.Printf("Count: %d, ID: %d, Summary: %s\n", len(issues), issues[0].ID, issues[0].Summary)
+	// Output:
+	// Count: 2, ID: 1, Summary: First issue
+}
+
+// ExampleIssueCommentOptionService demonstrates fetching comments with count and order options.
+func ExampleIssueCommentOptionService() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.Comment.ListJSON)),
+	)
+
+	comments, _ := c.Issue.Comment.All(
+		context.Background(),
+		"PRJ-1",
+		c.Issue.Comment.Option.WithCount(20),
+		c.Issue.Comment.Option.WithOrder(backlog.OrderDesc),
+	)
+	fmt.Printf("Count: %d, ID: %d, Content: %s\n", len(comments), comments[0].ID, comments[0].Content)
+	// Output:
+	// Count: 2, ID: 1, Content: This is a comment.
+}
+
+// ExampleProjectOptionService demonstrates listing all projects including archived ones.
+func ExampleProjectOptionService() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.Project.ListJSON)),
+	)
+
+	projects, _ := c.Project.All(
+		context.Background(),
+		c.Project.Option.WithAll(true),
+		c.Project.Option.WithArchived(false),
+	)
+	fmt.Printf("Count: %d, ProjectKey: %s\n", len(projects), projects[0].ProjectKey)
+	// Output:
+	// Count: 2, ProjectKey: TEST
+}
+
+// ExampleUserOptionService demonstrates updating a user's name and role type.
+func ExampleUserOptionService() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.User.SingleJSON)),
+	)
+
+	user, _ := c.User.Update(
+		context.Background(),
+		1,
+		c.User.Option.WithName("admin"),
+		c.User.Option.WithRoleType(backlog.RoleAdministrator),
+	)
+	fmt.Printf("ID: %d, UserID: %s\n", user.ID, user.UserID)
+	// Output:
+	// ID: 1, UserID: admin
+}
+
+// ExampleUserRecentlyViewedOptionService demonstrates listing recently viewed issues with count and order.
+func ExampleUserRecentlyViewedOptionService() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.RecentlyViewed.IssueListJSON)),
+	)
+
+	issues, _ := c.User.RecentlyViewed.ListIssues(
+		context.Background(),
+		c.User.RecentlyViewed.Option.WithCount(20),
+		c.User.RecentlyViewed.Option.WithOrder(backlog.OrderDesc),
+	)
+	fmt.Printf("IssueKey: %s\n", issues[0].IssueKey)
+	// Output:
+	// IssueKey: TEST-1
+}
+
+// ExampleUserStarOptionService demonstrates listing received stars with count and order.
+func ExampleUserStarOptionService() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.Star.ListJSON)),
+	)
+
+	stars, _ := c.User.Star.List(
+		context.Background(),
+		1,
+		c.User.Star.Option.WithCount(20),
+		c.User.Star.Option.WithOrder(backlog.OrderDesc),
+	)
+	fmt.Printf("ID: %d, Title: %s\n", stars[0].ID, stars[0].Title)
+	// Output:
+	// ID: 10, Title: [TEST-1] first issue
+}
+
+// ExamplePullRequestOptionService demonstrates filtering pull requests by status and assignee.
+func ExamplePullRequestOptionService() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.PullRequest.ListJSON)),
+	)
+
+	prs, _ := c.PullRequest.All(
+		context.Background(),
+		"TEST",
+		"myrepo",
+		c.PullRequest.Option.WithStatusIDs([]int{1}),
+		c.PullRequest.Option.WithCount(50),
+	)
+	fmt.Printf("Count: %d, ID: %d, Summary: %s\n", len(prs), prs[0].ID, prs[0].Summary)
+	// Output:
+	// Count: 2, ID: 2, Summary: test PR
+}
+
+// ExamplePullRequestCommentOptionService demonstrates fetching pull request comments with count and order.
+func ExamplePullRequestCommentOptionService() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.Comment.ListJSON)),
+	)
+
+	comments, _ := c.PullRequest.Comment.All(
+		context.Background(),
+		"TEST",
+		"myrepo",
+		1,
+		c.PullRequest.Comment.Option.WithCount(20),
+		c.PullRequest.Comment.Option.WithOrder(backlog.OrderDesc),
+	)
+	fmt.Printf("Count: %d, ID: %d, Content: %s\n", len(comments), comments[0].ID, comments[0].Content)
+	// Output:
+	// Count: 2, ID: 1, Content: This is a comment.
+}
+
+// ExampleStarOptionService demonstrates adding a star to an issue.
+func ExampleStarOptionService() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerNoContent),
+	)
+
+	err := c.Star.Add(context.Background(), c.Star.Option.WithIssueID(1))
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output:
+	// ok
+}
+
+// ExampleActivityOptionService_spaceWithOptions demonstrates filtering space activities by type and count.
+func ExampleActivityOptionService_spaceWithOptions() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.Activity.ListJSON)),
+	)
+
+	activities, _ := c.Space.Activity.List(
+		context.Background(),
+		c.Space.Activity.Option.WithActivityTypeIDs([]int{1, 2}),
+		c.Space.Activity.Option.WithCount(20),
+	)
+	fmt.Printf("ID: %d, Type: %d\n", activities[0].ID, activities[0].Type)
+	// Output:
+	// ID: 3153, Type: 2
+}
+
+// ExampleActivityOptionService_projectWithOptions demonstrates filtering project activities by type and order.
+func ExampleActivityOptionService_projectWithOptions() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.Activity.ListJSON)),
+	)
+
+	activities, _ := c.Project.Activity.List(
+		context.Background(),
+		"MYPROJECT",
+		c.Project.Activity.Option.WithActivityTypeIDs([]int{1, 2}),
+		c.Project.Activity.Option.WithOrder(backlog.OrderDesc),
+	)
+	fmt.Printf("ID: %d, Type: %d\n", activities[0].ID, activities[0].Type)
+	// Output:
+	// ID: 3153, Type: 2
+}
+
+// ExampleActivityOptionService_userWithOptions demonstrates filtering user activities by type and count.
+func ExampleActivityOptionService_userWithOptions() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.Activity.ListJSON)),
+	)
+
+	activities, _ := c.User.Activity.List(
+		context.Background(),
+		1,
+		c.User.Activity.Option.WithActivityTypeIDs([]int{1, 2}),
+		c.User.Activity.Option.WithCount(20),
+	)
+	fmt.Printf("ID: %d, Type: %d\n", activities[0].ID, activities[0].Type)
+	// Output:
+	// ID: 3153, Type: 2
+}

--- a/example_option_test.go
+++ b/example_option_test.go
@@ -114,7 +114,7 @@ func ExampleProjectOptionService() {
 	)
 	fmt.Printf("Count: %d, ProjectKey: %s\n", len(projects), projects[0].ProjectKey)
 	// Output:
-	// Count: 2, ProjectKey: TEST
+	// Count: 3, ProjectKey: TEST
 }
 
 // ExampleUserOptionService demonstrates updating a user's name and role type.

--- a/example_option_test.go
+++ b/example_option_test.go
@@ -8,12 +8,46 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 )
 
-// ExampleWikiOptionService demonstrates filtering and updating a wiki page using multiple options.
+var (
+	// WikiOptionService
+	doerWikiOption = newMockDoer(fixture.Wiki.MinimumJSON)
+
+	// IssueOptionService
+	doerIssueOption = newMockDoer(fixture.Issue.ListJSON)
+
+	// IssueCommentOptionService
+	doerIssueCommentOption = newMockDoer(fixture.Comment.ListJSON)
+
+	// ProjectOptionService
+	doerProjectOption = newMockDoer(fixture.Project.ListJSON)
+
+	// UserOptionService
+	doerUserOption = newMockDoer(fixture.User.SingleJSON)
+
+	// UserRecentlyViewedOptionService
+	doerUserRecentlyViewedOption = newMockDoer(fixture.RecentlyViewed.IssueListJSON)
+
+	// UserStarOptionService
+	doerUserStarOption = newMockDoer(fixture.Star.ListJSON)
+
+	// PullRequestOptionService
+	doerPullRequestOption = newMockDoer(fixture.PullRequest.ListJSON)
+
+	// PullRequestCommentOptionService
+	doerPullRequestCommentOption = newMockDoer(fixture.Comment.ListJSON)
+
+	// ActivityOptionService
+	doerActivityOptionSpace   = newMockDoer(fixture.Activity.ListJSON)
+	doerActivityOptionProject = newMockDoer(fixture.Activity.ListJSON)
+	doerActivityOptionUser    = newMockDoer(fixture.Activity.ListJSON)
+)
+
+// ExampleWikiOptionService demonstrates updating a wiki page using multiple options.
 func ExampleWikiOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.Wiki.MinimumJSON)),
+		backlog.WithDoer(doerWikiOption),
 	)
 
 	wiki, _ := c.Wiki.Update(
@@ -32,7 +66,7 @@ func ExampleIssueOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.Issue.ListJSON)),
+		backlog.WithDoer(doerIssueOption),
 	)
 
 	issues, _ := c.Issue.All(
@@ -51,7 +85,7 @@ func ExampleIssueCommentOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.Comment.ListJSON)),
+		backlog.WithDoer(doerIssueCommentOption),
 	)
 
 	comments, _ := c.Issue.Comment.All(
@@ -70,7 +104,7 @@ func ExampleProjectOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.Project.ListJSON)),
+		backlog.WithDoer(doerProjectOption),
 	)
 
 	projects, _ := c.Project.All(
@@ -88,7 +122,7 @@ func ExampleUserOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.User.SingleJSON)),
+		backlog.WithDoer(doerUserOption),
 	)
 
 	user, _ := c.User.Update(
@@ -107,7 +141,7 @@ func ExampleUserRecentlyViewedOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.RecentlyViewed.IssueListJSON)),
+		backlog.WithDoer(doerUserRecentlyViewedOption),
 	)
 
 	issues, _ := c.User.RecentlyViewed.ListIssues(
@@ -125,7 +159,7 @@ func ExampleUserStarOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.Star.ListJSON)),
+		backlog.WithDoer(doerUserStarOption),
 	)
 
 	stars, _ := c.User.Star.List(
@@ -139,12 +173,12 @@ func ExampleUserStarOptionService() {
 	// ID: 10, Title: [TEST-1] first issue
 }
 
-// ExamplePullRequestOptionService demonstrates filtering pull requests by status and assignee.
+// ExamplePullRequestOptionService demonstrates filtering pull requests by status and count.
 func ExamplePullRequestOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.PullRequest.ListJSON)),
+		backlog.WithDoer(doerPullRequestOption),
 	)
 
 	prs, _ := c.PullRequest.All(
@@ -164,7 +198,7 @@ func ExamplePullRequestCommentOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.Comment.ListJSON)),
+		backlog.WithDoer(doerPullRequestCommentOption),
 	)
 
 	comments, _ := c.PullRequest.Comment.All(
@@ -203,7 +237,7 @@ func ExampleActivityOptionService_spaceWithOptions() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.Activity.ListJSON)),
+		backlog.WithDoer(doerActivityOptionSpace),
 	)
 
 	activities, _ := c.Space.Activity.List(
@@ -221,7 +255,7 @@ func ExampleActivityOptionService_projectWithOptions() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.Activity.ListJSON)),
+		backlog.WithDoer(doerActivityOptionProject),
 	)
 
 	activities, _ := c.Project.Activity.List(
@@ -240,7 +274,7 @@ func ExampleActivityOptionService_userWithOptions() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.Activity.ListJSON)),
+		backlog.WithDoer(doerActivityOptionUser),
 	)
 
 	activities, _ := c.User.Activity.List(

--- a/example_test.go
+++ b/example_test.go
@@ -3,6 +3,7 @@ package backlog_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
@@ -11,7 +12,6 @@ import (
 var (
 	doerExample            = newMockDoer(fixture.Wiki.ListJSON)
 	doerExampleWithOptions = newMockDoer(fixture.Wiki.ListJSON)
-	doerNewClientWithDoer  = newMockDoer(fixture.Wiki.ListJSON)
 )
 
 // Example demonstrates basic usage: creating a client and listing wiki pages.
@@ -62,12 +62,13 @@ func ExampleNewClient() {
 }
 
 // ExampleNewClient_withDoer demonstrates injecting a custom HTTP client.
-// This is useful for testing, as you can provide a mock implementation.
+// This is useful for configuring timeouts, transport settings, or providing
+// a mock implementation during testing.
 func ExampleNewClient_withDoer() {
 	c, err := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerNewClientWithDoer),
+		backlog.WithDoer(http.DefaultClient),
 	)
 	if err != nil {
 		fmt.Println("error:", err)

--- a/example_test.go
+++ b/example_test.go
@@ -8,12 +8,18 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 )
 
+var (
+	doerExample            = newMockDoer(fixture.Wiki.ListJSON)
+	doerExampleWithOptions = newMockDoer(fixture.Wiki.ListJSON)
+	doerNewClientWithDoer  = newMockDoer(fixture.Wiki.ListJSON)
+)
+
 // Example demonstrates basic usage: creating a client and listing wiki pages.
 func Example() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.Wiki.ListJSON)),
+		backlog.WithDoer(doerExample),
 	)
 
 	wikis, _ := c.Wiki.All(context.Background(), "MYPROJECT")
@@ -27,7 +33,7 @@ func Example_withOptions() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(newMockDoer(fixture.Wiki.ListJSON)),
+		backlog.WithDoer(doerExampleWithOptions),
 	)
 
 	wikis, _ := c.Wiki.All(
@@ -58,12 +64,10 @@ func ExampleNewClient() {
 // ExampleNewClient_withDoer demonstrates injecting a custom HTTP client.
 // This is useful for testing, as you can provide a mock implementation.
 func ExampleNewClient_withDoer() {
-	doer := newMockDoer(fixture.Wiki.ListJSON)
-
 	c, err := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doer),
+		backlog.WithDoer(doerNewClientWithDoer),
 	)
 	if err != nil {
 		fmt.Println("error:", err)

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,75 @@
+package backlog_test
+
+import (
+	"context"
+	"fmt"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+// Example demonstrates basic usage: creating a client and listing wiki pages.
+func Example() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.Wiki.ListJSON)),
+	)
+
+	wikis, _ := c.Wiki.All(context.Background(), "MYPROJECT")
+	fmt.Printf("ID: %d, Name: %s\n", wikis[0].ID, wikis[0].Name)
+	// Output:
+	// ID: 112, Name: test1
+}
+
+// Example_withOptions demonstrates using option methods to filter results.
+func Example_withOptions() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(newMockDoer(fixture.Wiki.ListJSON)),
+	)
+
+	wikis, _ := c.Wiki.All(
+		context.Background(),
+		"MYPROJECT",
+		c.Wiki.Option.WithKeyword("test"),
+	)
+	fmt.Printf("ID: %d, Name: %s\n", wikis[0].ID, wikis[0].Name)
+	// Output:
+	// ID: 112, Name: test1
+}
+
+// ExampleNewClient demonstrates basic client initialization.
+func ExampleNewClient() {
+	c, err := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(c != nil)
+	// Output:
+	// true
+}
+
+// ExampleNewClient_withDoer demonstrates injecting a custom HTTP client.
+// This is useful for testing, as you can provide a mock implementation.
+func ExampleNewClient_withDoer() {
+	doer := newMockDoer(fixture.Wiki.ListJSON)
+
+	c, err := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doer),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(c != nil)
+	// Output:
+	// true
+}


### PR DESCRIPTION
## Summary

Add missing Example functions to improve godoc documentation coverage, as specified in #252.

## Changes

- Add `example_test.go` with package-level and `NewClient` Examples:
  - `Example` — basic usage: `NewClient` → `Wiki.All`
  - `Example_withOptions` — usage with `WithKeyword` option
  - `ExampleNewClient` — basic client initialization
  - `ExampleNewClient_withDoer` — custom Doer injection pattern

- Add `example_option_test.go` with one `ExampleXxxOptionService` per OptionService type, each showing a representative use case combining multiple options:
  - `ExampleWikiOptionService` — `Wiki.Update` with `WithName` + `WithContent`
  - `ExampleIssueOptionService` — `Issue.All` with `WithProjectIDs` + `WithKeyword` + `WithCount`
  - `ExampleIssueCommentOptionService` — `Issue.Comment.All` with `WithCount` + `WithOrder`
  - `ExampleProjectOptionService` — `Project.All` with `WithAll` + `WithArchived`
  - `ExampleUserOptionService` — `User.Update` with `WithName` + `WithRoleType`
  - `ExampleUserRecentlyViewedOptionService` — `User.RecentlyViewed.ListIssues` with `WithCount` + `WithOrder`
  - `ExampleUserStarOptionService` — `User.Star.List` with `WithCount` + `WithOrder`
  - `ExamplePullRequestOptionService` — `PullRequest.All` with `WithStatusIDs` + `WithCount`
  - `ExamplePullRequestCommentOptionService` — `PullRequest.Comment.All` with `WithCount` + `WithOrder`
  - `ExampleStarOptionService` — `Star.Add` with `WithIssueID`
  - `ExampleActivityOptionService_spaceWithOptions` — via `c.Space.Activity.Option`
  - `ExampleActivityOptionService_projectWithOptions` — via `c.Project.Activity.Option`
  - `ExampleActivityOptionService_userWithOptions` — via `c.User.Activity.Option`

Closes #252