### PR TITLE
fix: replace internal/model types in public option method signatures

### DIFF
--- a/option.go
+++ b/option.go
@@ -46,8 +46,8 @@ func (s *ActivityOptionService) WithCount(count int) RequestOption {
 }
 
 // WithOrder sets the sort order of results.
-func (s *ActivityOptionService) WithOrder(order model.Order) RequestOption {
-	return s.base.WithOrder(order)
+func (s *ActivityOptionService) WithOrder(order Order) RequestOption {
+	return s.base.WithOrder(model.Order(order))
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/option_test.go
+++ b/option_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/model"
 )
 
 func TestActivityOptionService(t *testing.T) {
@@ -62,14 +61,14 @@ func TestActivityOptionService(t *testing.T) {
 			wantValue string
 		}{
 			"with-query-order-asc": {
-				option:    o.WithOrder(model.OrderAsc),
+				option:    o.WithOrder(backlog.OrderAsc),
 				key:       core.ParamOrder.Value(),
-				wantValue: string(model.OrderAsc),
+				wantValue: string(backlog.OrderAsc),
 			},
 			"with-query-order-desc": {
-				option:    o.WithOrder(model.OrderDesc),
+				option:    o.WithOrder(backlog.OrderDesc),
 				key:       core.ParamOrder.Value(),
-				wantValue: string(model.OrderDesc),
+				wantValue: string(backlog.OrderDesc),
 			},
 		}
 
@@ -106,7 +105,7 @@ func TestActivityOptionService(t *testing.T) {
 				query := url.Values{}
 				err := tc.option.Set(query)
 				require.NoError(t, err)
-
+			
 				expected := make([]string, len(tc.wantValue))
 				for i, v := range tc.wantValue {
 					expected[i] = strconv.Itoa(v)

--- a/option_test.go
+++ b/option_test.go
@@ -105,7 +105,7 @@ func TestActivityOptionService(t *testing.T) {
 				query := url.Values{}
 				err := tc.option.Set(query)
 				require.NoError(t, err)
-			
+
 				expected := make([]string, len(tc.wantValue))
 				for i, v := range tc.wantValue {
 					expected[i] = strconv.Itoa(v)

--- a/user.go
+++ b/user.go
@@ -303,8 +303,8 @@ func (s *UserOptionService) WithPassword(password string) RequestOption {
 }
 
 // WithRoleType sets the role type of a user.
-func (s *UserOptionService) WithRoleType(role model.Role) RequestOption {
-	return s.base.WithRoleType(role)
+func (s *UserOptionService) WithRoleType(role Role) RequestOption {
+	return s.base.WithRoleType(model.Role(role))
 }
 
 // WithSendMail sets whether to send a mail notification.

--- a/user_test.go
+++ b/user_test.go
@@ -261,11 +261,6 @@ func TestUserOptionService(t *testing.T) {
 				key:       core.ParamUserID.Value(),
 				wantValue: 1,
 			},
-			"with-form-role-type": {
-				option:    o.WithRoleType(2),
-				key:       core.ParamRoleType.Value(),
-				wantValue: 2,
-			},
 		}
 
 		for name, tc := range cases {
@@ -276,6 +271,32 @@ func TestUserOptionService(t *testing.T) {
 				err := tc.option.Set(form)
 				require.NoError(t, err)
 				assert.Equal(t, strconv.Itoa(tc.wantValue), form.Get(tc.key))
+			})
+		}
+	})
+
+	// --- Enum options ---------------------------------------------------------------
+	t.Run("enum-options", func(t *testing.T) {
+		cases := map[string]struct {
+			option    backlog.RequestOption
+			key       string
+			wantValue backlog.Role
+		}{
+			"with-form-role-type": {
+				option:    o.WithRoleType(backlog.RoleNormalUser),
+				key:       core.ParamRoleType.Value(),
+				wantValue: backlog.RoleNormalUser,
+			},
+		}
+
+		for name, tc := range cases {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				form := url.Values{}
+				err := tc.option.Set(form)
+				require.NoError(t, err)
+				assert.Equal(t, strconv.Itoa(int(tc.wantValue)), form.Get(tc.key))
 			})
 		}
 	})


### PR DESCRIPTION
## Summary

Two option methods in the public API were accepting `internal/model` types in their signatures, making them impossible to call from outside the module. The tests also failed to catch this because untyped integer/string constants are assignable to named types.

## Changes

- `ActivityOptionService.WithOrder`: parameter type `model.Order` → `Order`; internally casts with `model.Order(order)`
- `UserOptionService.WithRoleType`: parameter type `model.Role` → `Role`; internally casts with `model.Role(role)`
- `option.go`: remove now-unused `internal/model` import
- `option_test.go`: update `WithOrder` call sites from `model.OrderAsc`/`model.OrderDesc` to `backlog.OrderAsc`/`backlog.OrderDesc`; remove unused `internal/model` import
- `user_test.go`: replace untyped int literal `2` in `WithRoleType` test with `backlog.RoleNormalUser`; move case to enum-options section with `wantValue` typed as `backlog.Role`