### PR TITLE
fix: replace model.Format with public Format type in WithTextFormattingRule

### DIFF
--- a/project.go
+++ b/project.go
@@ -161,8 +161,8 @@ func (s *ProjectOptionService) WithSubtaskingEnabled(enabled bool) RequestOption
 }
 
 // WithTextFormattingRule sets the text formatting rule.
-func (s *ProjectOptionService) WithTextFormattingRule(format model.Format) RequestOption {
-	return s.base.WithTextFormattingRule(format)
+func (s *ProjectOptionService) WithTextFormattingRule(format Format) RequestOption {
+	return s.base.WithTextFormattingRule(model.Format(format))
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/project_test.go
+++ b/project_test.go
@@ -11,7 +11,6 @@ import (
 
 	backlog "github.com/nattokin/go-backlog"
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
@@ -208,7 +207,7 @@ func TestProjectOptionService(t *testing.T) {
 			wantKey: core.ParamSubtaskingEnabled.Value(),
 		},
 		"WithTextFormattingRule": {
-			option:  s.WithTextFormattingRule(model.FormatBacklog),
+			option:  s.WithTextFormattingRule(backlog.FormatBacklog),
 			wantKey: core.ParamTextFormattingRule.Value(),
 		},
 	}


### PR DESCRIPTION
## Summary

`ProjectOptionService.WithTextFormattingRule` was accepting `model.Format` (an `internal/model` type) in its signature, making it impossible to call from outside the module. The test also failed to catch this because `model.FormatBacklog` was referenced directly from the test file.

## Changes

- `project.go`: `WithTextFormattingRule` parameter type `model.Format` → `Format`; internally casts with `model.Format(format)`
- `project_test.go`: replace `model.FormatBacklog` with `backlog.FormatBacklog`; remove unused `internal/model` import