### PR TITLE
docs: add example tests for file download endpoints

### DIFF
--- a/example_issue_test.go
+++ b/example_issue_test.go
@@ -19,8 +19,9 @@ var (
 	doerIssueParticipants = newMockDoer(fixture.User.ListJSON)
 
 	// IssueAttachmentService
-	doerIssueAttachmentList   = newMockDoer(fixture.Attachment.ListJSON)
-	doerIssueAttachmentRemove = newMockDoer(fixture.Attachment.SingleJSON)
+	doerIssueAttachmentList     = newMockDoer(fixture.Attachment.ListJSON)
+	doerIssueAttachmentDownload = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
+	doerIssueAttachmentRemove   = newMockDoer(fixture.Attachment.SingleJSON)
 
 	// IssueCommentService
 	doerIssueCommentAll           = newMockDoer(fixture.Comment.ListJSON)
@@ -140,6 +141,19 @@ func ExampleIssueAttachmentService_List() {
 	fmt.Printf("ID: %d, Name: %s\n", attachments[0].ID, attachments[0].Name)
 	// Output:
 	// ID: 2, Name: A.png
+}
+
+func ExampleIssueAttachmentService_Download() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerIssueAttachmentDownload),
+	)
+
+	file, _ := c.Issue.Attachment.Download(context.Background(), "TEST-1", 2)
+	fmt.Printf("ContentType: %s, FileName: %s\n", file.ContentType, file.Filename)
+	// Output:
+	// ContentType: image/png, FileName: A.png
 }
 
 func ExampleIssueAttachmentService_Remove() {

--- a/example_project_test.go
+++ b/example_project_test.go
@@ -16,12 +16,14 @@ var (
 	doerProjectUpdate    = newMockDoer(fixture.Project.SingleJSON)
 	doerProjectDelete    = newMockDoer(fixture.Project.SingleJSON)
 	doerProjectDiskUsage = newMockDoer(fixture.Project.DiskUsageJSON)
+	doerProjectIcon      = newMockBinaryDoer("image/png", "test.png", []byte("PNG"))
 
 	// ProjectActivityService
 	doerProjectActivityList = newMockDoer(fixture.Activity.ListJSON)
 
 	// ProjectSharedFileService
-	doerProjectSharedFileList = newMockDoer(fixture.SharedFile.ListJSON)
+	doerProjectSharedFileList    = newMockDoer(fixture.SharedFile.ListJSON)
+	doerProjectSharedFileGetFile = newMockBinaryDoer("image/png", "shared.png", []byte("PNG"))
 
 	// ProjectCategoryService
 	doerProjectCategoryAll    = newMockDoer(fixture.Category.ListJSON)
@@ -151,6 +153,19 @@ func ExampleProjectService_DiskUsage() {
 	fmt.Printf("ProjectID: %d, Issue: %d\n", usage.ProjectID, usage.Issue)
 	// Output:
 	// ProjectID: 1, Issue: 11931
+}
+
+func ExampleProjectService_Icon() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectIcon),
+	)
+
+	icon, _ := c.Project.Icon(context.Background(), "TEST")
+	fmt.Printf("ContentType: %s, FileName: %s\n", icon.ContentType, icon.Filename)
+	// Output:
+	// ContentType: image/png, FileName: test.png
 }
 
 func ExampleProjectActivityService_List() {
@@ -379,6 +394,19 @@ func ExampleProjectSharedFileService_List() {
 	fmt.Printf("ID: %d, Name: %s\n", files[0].ID, files[0].Name)
 	// Output:
 	// ID: 454403, Name: 01_buz.png
+}
+
+func ExampleProjectSharedFileService_GetFile() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerProjectSharedFileGetFile),
+	)
+
+	file, _ := c.Project.SharedFile.GetFile(context.Background(), "TEST", 1)
+	fmt.Printf("ContentType: %s, FileName: %s\n", file.ContentType, file.Filename)
+	// Output:
+	// ContentType: image/png, FileName: shared.png
 }
 
 func ExampleProjectUserService_All() {

--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -23,8 +23,9 @@ var (
 	doerPullRequestCommentUpdate = newMockDoer(fixture.Comment.SingleJSON)
 
 	// PullRequestAttachmentService
-	doerPullRequestAttachmentList   = newMockDoer(fixture.Attachment.ListJSON)
-	doerPullRequestAttachmentRemove = newMockDoer(fixture.Attachment.SingleJSON)
+	doerPullRequestAttachmentList     = newMockDoer(fixture.Attachment.ListJSON)
+	doerPullRequestAttachmentDownload = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
+	doerPullRequestAttachmentRemove   = newMockDoer(fixture.Attachment.SingleJSON)
 )
 
 func ExamplePullRequestService_All() {
@@ -103,6 +104,19 @@ func ExamplePullRequestAttachmentService_List() {
 	fmt.Printf("ID: %d, Name: %s\n", attachments[0].ID, attachments[0].Name)
 	// Output:
 	// ID: 2, Name: A.png
+}
+
+func ExamplePullRequestAttachmentService_Download() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerPullRequestAttachmentDownload),
+	)
+
+	file, _ := c.PullRequest.Attachment.Download(context.Background(), "TEST", "myrepo", 1, 2)
+	fmt.Printf("ContentType: %s, FileName: %s\n", file.ContentType, file.Filename)
+	// Output:
+	// ContentType: image/png, FileName: A.png
 }
 
 func ExamplePullRequestAttachmentService_Remove() {

--- a/example_user_test.go
+++ b/example_user_test.go
@@ -16,6 +16,7 @@ var (
 	doerUserAdd    = newMockDoer(fixture.User.SingleJSON)
 	doerUserUpdate = newMockDoer(fixture.User.SingleJSON)
 	doerUserDelete = newMockDoer(fixture.User.SingleJSON)
+	doerUserIcon   = newMockBinaryDoer("image/png", "icon.png", []byte("PNG"))
 
 	// UserActivityService
 	doerUserActivityList = newMockDoer(fixture.Activity.ListJSON)
@@ -119,6 +120,19 @@ func ExampleUserService_Delete() {
 	fmt.Printf("ID: %d, UserID: %s\n", user.ID, user.UserID)
 	// Output:
 	// ID: 1, UserID: admin
+}
+
+func ExampleUserService_Icon() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerUserIcon),
+	)
+
+	icon, _ := c.User.Icon(context.Background(), 1)
+	fmt.Printf("ContentType: %s, FileName: %s\n", icon.ContentType, icon.Filename)
+	// Output:
+	// ContentType: image/png, FileName: icon.png
 }
 
 func ExampleUserActivityService_List() {

--- a/example_wiki_test.go
+++ b/example_wiki_test.go
@@ -18,9 +18,10 @@ var (
 	doerWikiDelete = newMockDoer(fixture.Wiki.MinimumJSON)
 
 	// WikiAttachmentService
-	doerWikiAttachmentAttach = newMockDoer(fixture.Attachment.ListJSON)
-	doerWikiAttachmentList   = newMockDoer(fixture.Attachment.ListJSON)
-	doerWikiAttachmentRemove = newMockDoer(fixture.Attachment.SingleJSON)
+	doerWikiAttachmentAttach   = newMockDoer(fixture.Attachment.ListJSON)
+	doerWikiAttachmentList     = newMockDoer(fixture.Attachment.ListJSON)
+	doerWikiAttachmentDownload = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
+	doerWikiAttachmentRemove   = newMockDoer(fixture.Attachment.SingleJSON)
 
 	// WikiHistoryService
 	doerWikiHistoryList = newMockDoer(fixture.WikiHistory.ListJSON)
@@ -140,6 +141,19 @@ func ExampleWikiAttachmentService_List() {
 	fmt.Printf("ID: %d, Name: %s\n", attachments[0].ID, attachments[0].Name)
 	// Output:
 	// ID: 2, Name: A.png
+}
+
+func ExampleWikiAttachmentService_Download() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerWikiAttachmentDownload),
+	)
+
+	file, _ := c.Wiki.Attachment.Download(context.Background(), 34, 2)
+	fmt.Printf("ContentType: %s, FileName: %s\n", file.ContentType, file.Filename)
+	// Output:
+	// ContentType: image/png, FileName: A.png
 }
 
 func ExampleWikiAttachmentService_Remove() {

--- a/mock_test.go
+++ b/mock_test.go
@@ -27,6 +27,23 @@ func newMockDoer(body string) *mockDoer {
 	}
 }
 
+// newMockBinaryDoer returns a mockDoer that always responds with HTTP 200
+// and the given binary body, filename, and Content-Type.
+func newMockBinaryDoer(contentType, filename string, body []byte) *mockDoer {
+	return &mockDoer{
+		do: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type":        []string{contentType},
+					"Content-Disposition": []string{"attachment; filename=" + filename},
+				},
+				Body: io.NopCloser(bytes.NewReader(body)),
+			}, nil
+		},
+	}
+}
+
 // doerNoContent is a mockDoer that always responds with HTTP 204 No Content.
 var doerNoContent = &mockDoer{
 	do: func(_ *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Title

docs: add example tests for file download endpoints

## Description

## Summary

Add Example tests for binary download APIs across services.

This PR introduces reusable binary response mocks via newMockBinaryDoer and adds Example coverage for attachment, shared file, and icon download methods.

## Changes

### Test Utilities

- Add newMockBinaryDoer
  - supports binary response bodies
  - sets Content-Type
  - sets Content-Disposition with filename support

### Added Example Tests

#### IssueAttachmentService

- ExampleIssueAttachmentService_Download

#### ProjectService

- ExampleProjectService_Icon

#### ProjectSharedFileService

- ExampleProjectSharedFileService_GetFile

#### PullRequestAttachmentService

- ExamplePullRequestAttachmentService_Download

#### UserService

- ExampleUserService_Icon

#### WikiAttachmentService

- ExampleWikiAttachmentService_Download

Closes: #236