### PR TITLE
fix: add WithAttachmentIDs option to PullRequestService.Add

### DIFF
--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -184,6 +184,22 @@ func ExamplePullRequestCommentService_Update() {
 	// ID: 1, Content: This is a comment.
 }
 
+func ExamplePullRequestCommentOptionService_WithAttachmentIDs() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerPullRequestCommentAdd),
+	)
+
+	comment, _ := c.PullRequest.Comment.Add(
+		context.Background(), "TEST", "myrepo", 1, "This is a comment.",
+		c.PullRequest.Comment.Option.WithAttachmentIDs([]int{1, 2}),
+	)
+	fmt.Printf("ID: %d, Content: %s\n", comment.ID, comment.Content)
+	// Output:
+	// ID: 1, Content: This is a comment.
+}
+
 func ExamplePullRequestStarService_Add() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",

--- a/internal/comment/service.go
+++ b/internal/comment/service.go
@@ -307,6 +307,7 @@ func (s *PullRequestService) All(ctx context.Context, projectIDOrKey string, rep
 //
 // This method supports options:
 //   - WithNotifiedUserIDs
+//   - WithAttachmentIDs
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-pull-request-comment
 func (s *PullRequestService) Add(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, content string, opts ...core.RequestOption) (*model.Comment, error) {
@@ -325,6 +326,7 @@ func (s *PullRequestService) Add(ctx context.Context, projectIDOrKey string, rep
 	validTypes := []core.APIParamOptionType{
 		core.ParamContent,
 		core.ParamNotifiedUserIDs,
+		core.ParamAttachmentIDs,
 	}
 	options := append(
 		[]core.RequestOption{option.WithContent(content)},

--- a/internal/comment/service_pullrequest_test.go
+++ b/internal/comment/service_pullrequest_test.go
@@ -201,6 +201,20 @@ func TestPullRequestCommentService_Add(t *testing.T) {
 			},
 			wantID: 1,
 		},
+		"success-with-attachmentIDs": {
+			projectIDOrKey: "PRJ",
+			repoIDOrName:   "repo",
+			prNumber:       1,
+			content:        "Attaching files.",
+			opts:           []core.RequestOption{o.WithAttachmentIDs([]int{10, 11})},
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/PRJ/git/repositories/repo/pullRequests/1/comments", spath)
+				assert.Equal(t, "Attaching files.", form.Get("content"))
+				assert.Equal(t, []string{"10", "11"}, form["attachmentId[]"])
+				return mock.NewCreatedJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			wantID: 1,
+		},
 		"error-empty-projectIDOrKey": {
 			projectIDOrKey: "",
 			repoIDOrName:   "repo",

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -220,6 +220,11 @@ type PullRequestCommentOptionService struct {
 	base *core.OptionService
 }
 
+// WithAttachmentIDs returns an option to set multiple `attachmentId[]` parameters.
+func (s *PullRequestCommentOptionService) WithAttachmentIDs(ids []int) RequestOption {
+	return s.base.WithAttachmentIDs(ids)
+}
+
 // WithCount sets the number of comments to retrieve (1-100).
 func (s *PullRequestCommentOptionService) WithCount(count int) RequestOption {
 	return s.base.WithCount(count)

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -186,6 +186,7 @@ func (s *PullRequestCommentService) All(ctx context.Context, projectIDOrKey stri
 // This method supports options returned by methods in "*Client.PullRequest.Comment.Option",
 // such as:
 //   - WithNotifiedUserIDs
+//   - WithAttachmentIDs
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-pull-request-comment
 func (s *PullRequestCommentService) Add(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, content string, opts ...RequestOption) (*Comment, error) {

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -566,6 +566,7 @@ func TestPullRequestCommentOptionService(t *testing.T) {
 		option  backlog.RequestOption
 		wantKey string
 	}{
+		"WithAttachmentIDs":   {option: s.WithAttachmentIDs([]int{1}), wantKey: core.ParamAttachmentIDs.Value()},
 		"WithCount":           {option: s.WithCount(20), wantKey: core.ParamCount.Value()},
 		"WithMaxID":           {option: s.WithMaxID(100), wantKey: core.ParamMaxID.Value()},
 		"WithMinID":           {option: s.WithMinID(1), wantKey: core.ParamMinID.Value()},


### PR DESCRIPTION
## Summary

`comment.PullRequestService.Add` was missing `core.ParamAttachmentIDs` in its `validTypes`, and `PullRequestCommentOptionService` was missing `WithAttachmentIDs`, despite the Backlog API accepting `attachmentId[]` for this endpoint.

## Changes

- Add `core.ParamAttachmentIDs` to `validTypes` in `comment.PullRequestService.Add`
- Update doc comment to list `WithAttachmentIDs` as a supported option
- Add `success-with-attachmentIDs` test case to `TestPullRequestCommentService_Add`
- Add `WithAttachmentIDs` to `PullRequestCommentOptionService`
- Add `ExamplePullRequestCommentOptionService_WithAttachmentIDs` example test

Closes #282