### PR TITLE
refactor: merge internal/history into internal/wiki

### DIFF
--- a/internal/wiki/service_history.go
+++ b/internal/wiki/service_history.go
@@ -1,4 +1,4 @@
-package history
+package wiki
 
 import (
 	"context"
@@ -11,19 +11,15 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// ──────────────────────────────────────────────────────────────
-//  WikiService
-// ──────────────────────────────────────────────────────────────
-
-// WikiService handles communication with the wiki history-related methods of the Backlog API.
-type WikiService struct {
+// HistorySevice handles communication with the wiki history-related methods of the Backlog API.
+type HistorySevice struct {
 	method *core.Method
 }
 
 // List returns the version history of a wiki page.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-history/
-func (s *WikiService) List(ctx context.Context, wikiID int) ([]*model.WikiHistory, error) {
+func (s *HistorySevice) List(ctx context.Context, wikiID int) ([]*model.WikiHistory, error) {
 	if err := validate.ValidateWikiID(wikiID); err != nil {
 		return nil, err
 	}
@@ -43,10 +39,10 @@ func (s *WikiService) List(ctx context.Context, wikiID int) ([]*model.WikiHistor
 }
 
 // ──────────────────────────────────────────────────────────────
-//  Constructor
+//  Constructors
 // ──────────────────────────────────────────────────────────────
 
-// NewWikiService creates and returns a new history WikiService.
-func NewWikiService(method *core.Method) *WikiService {
-	return &WikiService{method: method}
+// NewHistoryService creates and returns a new history WikiService.
+func NewHistoryService(method *core.Method) *HistorySevice {
+	return &HistorySevice{method: method}
 }

--- a/internal/wiki/service_history_test.go
+++ b/internal/wiki/service_history_test.go
@@ -1,4 +1,4 @@
-package history_test
+package wiki_test
 
 import (
 	"context"
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/nattokin/go-backlog/internal/history"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
+	"github.com/nattokin/go-backlog/internal/wiki"
 )
 
 func TestWikiHistoryService_List(t *testing.T) {
@@ -67,7 +67,7 @@ func TestWikiHistoryService_List(t *testing.T) {
 
 			method := mock.NewMethod(t)
 			method.Get = tc.mockGetFn
-			s := history.NewWikiService(method)
+			s := wiki.NewHistoryService(method)
 
 			entries, err := s.List(context.Background(), tc.wikiID)
 
@@ -89,25 +89,4 @@ func TestWikiHistoryService_List(t *testing.T) {
 			}
 		})
 	}
-}
-
-func Test_WikiHistoryService_contextPropagation(t *testing.T) {
-	type ctxKey struct{}
-	sentinel := &struct{}{}
-	ctx := context.WithValue(context.Background(), ctxKey{}, sentinel)
-
-	makeMockFn := func(t *testing.T) func(context.Context, string, url.Values) (*http.Response, error) {
-		return func(got context.Context, _ string, _ url.Values) (*http.Response, error) {
-			assert.Same(t, sentinel, got.Value(ctxKey{}))
-			return nil, errors.New("stop")
-		}
-	}
-
-	t.Run("WikiService.List", func(t *testing.T) {
-		t.Parallel()
-		m := mock.NewMethod(t)
-		m.Get = makeMockFn(t)
-		s := history.NewWikiService(m)
-		s.List(ctx, 1) //nolint:errcheck
-	})
 }

--- a/internal/wiki/service_test.go
+++ b/internal/wiki/service_test.go
@@ -741,35 +741,40 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"WikiService.All", func(t *testing.T, m *core.Method) {
+		{"Service.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.All(ctx, "TEST") //nolint:errcheck
 		}},
-		{"WikiService.Count", func(t *testing.T, m *core.Method) {
+		{"Service.Count", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Count(ctx, "TEST") //nolint:errcheck
 		}},
-		{"WikiService.One", func(t *testing.T, m *core.Method) {
+		{"Service.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.One(ctx, 1) //nolint:errcheck
 		}},
-		{"WikiService.Create", func(t *testing.T, m *core.Method) {
+		{"Service.Create", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Create(ctx, 1, "name", "content") //nolint:errcheck
 		}},
-		{"WikiService.Update", func(t *testing.T, m *core.Method) {
+		{"Service.Update", func(t *testing.T, m *core.Method) {
 			m.Patch = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
 		}},
-		{"WikiService.Delete", func(t *testing.T, m *core.Method) {
+		{"Service.Delete", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.Delete(ctx, 1) //nolint:errcheck
+		}},
+		{"HistoryService.List", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := wiki.NewHistoryService(m)
+			s.List(ctx, 1) //nolint:errcheck
 		}},
 	}
 

--- a/wiki.go
+++ b/wiki.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nattokin/go-backlog/internal/attachment"
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/history"
 	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/sharedfile"
 	"github.com/nattokin/go-backlog/internal/star"
@@ -169,7 +168,7 @@ func (s *WikiAttachmentService) Download(ctx context.Context, wikiID, attachment
 
 // WikiHistoryService handles communication with the wiki history-related methods of the Backlog API.
 type WikiHistoryService struct {
-	base *history.WikiService
+	base *wiki.HistorySevice
 }
 
 // List returns the version history of a wiki page.
@@ -298,7 +297,7 @@ func newWikiAttachmentService(method *core.Method) *WikiAttachmentService {
 
 func newWikiHistoryService(method *core.Method) *WikiHistoryService {
 	return &WikiHistoryService{
-		base: history.NewWikiService(method),
+		base: wiki.NewHistoryService(method),
 	}
 }
 


### PR DESCRIPTION
## Summary

Remove the `internal/history` package and move `history.WikiService` into `internal/wiki` as `wiki.HistoryService`. The package existed solely for a single service tied to wiki, so it does not warrant a dedicated package.

## Changes

- Add `HistoryService` to `internal/wiki`
- Remove `internal/history` package
- Update root package to use `wiki.HistoryService`

Part of #281