### PR TITLE
refactor: relocate star domain wrappers to user and wiki packages

### DIFF
--- a/internal/star/service.go
+++ b/internal/star/service.go
@@ -3,17 +3,11 @@ package star
 import (
 	"context"
 	"net/url"
-	"path"
 	"strconv"
 
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/validate"
 )
-
-// ──────────────────────────────────────────────────────────────
-//  Service
-// ──────────────────────────────────────────────────────────────
 
 // Service handles communication with the star-related methods of the Backlog API.
 type Service struct {
@@ -69,119 +63,10 @@ func (s *Service) Remove(ctx context.Context, id int) error {
 }
 
 // ──────────────────────────────────────────────────────────────
-//  UserService
-// ──────────────────────────────────────────────────────────────
-
-// UserService handles communication with the user star-related methods of the Backlog API.
-type UserService struct {
-	method *core.Method
-}
-
-// List returns a list of stars received by the user with the given ID.
-//
-// This method supports options returned by methods in "*Client.User.Star.Option",
-// such as:
-//   - WithCount
-//   - WithMaxID
-//   - WithMinID
-//   - WithOrder
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-received-star-list
-func (s *UserService) List(ctx context.Context, userID int, opts ...core.RequestOption) ([]*model.Star, error) {
-	if err := validate.ValidateUserID(userID); err != nil {
-		return nil, err
-	}
-
-	query := url.Values{}
-	validOptionKeys := []core.APIParamOptionType{core.ParamMinID, core.ParamMaxID, core.ParamCount, core.ParamOrder}
-	if err := core.ApplyOptions(query, validOptionKeys, opts...); err != nil {
-		return nil, err
-	}
-
-	spath := path.Join("users", strconv.Itoa(userID), "stars")
-	resp, err := s.method.Get(ctx, spath, query)
-	if err != nil {
-		return nil, err
-	}
-
-	v := []*model.Star{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return v, nil
-}
-
-// Count returns the number of stars received by the user with the given ID.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-user-received-stars
-func (s *UserService) Count(ctx context.Context, userID int) (int, error) {
-	if err := validate.ValidateUserID(userID); err != nil {
-		return 0, err
-	}
-
-	spath := path.Join("users", strconv.Itoa(userID), "stars", "count")
-	resp, err := s.method.Get(ctx, spath, nil)
-	if err != nil {
-		return 0, err
-	}
-
-	var v struct {
-		Count int `json:"count"`
-	}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return 0, err
-	}
-
-	return v.Count, nil
-}
-
-// ──────────────────────────────────────────────────────────────
-//  WikiService
-// ──────────────────────────────────────────────────────────────
-
-// WikiService handles communication with the wiki star-related methods of the Backlog API.
-type WikiService struct {
-	method *core.Method
-}
-
-// List returns a list of stars on the wiki page with the given ID.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-star
-func (s *WikiService) List(ctx context.Context, wikiID int) ([]*model.Star, error) {
-	if err := validate.ValidateWikiID(wikiID); err != nil {
-		return nil, err
-	}
-
-	spath := path.Join("wikis", strconv.Itoa(wikiID), "stars")
-	resp, err := s.method.Get(ctx, spath, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	v := []*model.Star{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return v, nil
-}
-
-// ──────────────────────────────────────────────────────────────
 //  Constructor
 // ──────────────────────────────────────────────────────────────
 
 // NewService creates and returns a new star Service.
 func NewService(method *core.Method) *Service {
 	return &Service{method: method}
-}
-
-// NewUserService creates and returns a new star UserService.
-func NewUserService(method *core.Method) *UserService {
-	return &UserService{method: method}
-}
-
-// NewWikiService creates and returns a new star WikiService.
-func NewWikiService(method *core.Method) *WikiService {
-	return &WikiService{method: method}
 }

--- a/internal/star/service_test.go
+++ b/internal/star/service_test.go
@@ -176,13 +176,13 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"StarService.Add", func(t *testing.T, m *core.Method) {
+		{"Service.Add", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
 			o := &core.OptionService{}
 			s := star.NewService(m)
 			s.Add(ctx, o.WithIssueID(1)) //nolint:errcheck
 		}},
-		{"StarService.Remove", func(t *testing.T, m *core.Method) {
+		{"Service.Remove", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)
 			s := star.NewService(m)
 			s.Remove(ctx, 1) //nolint:errcheck

--- a/internal/star/service_test.go
+++ b/internal/star/service_test.go
@@ -187,21 +187,6 @@ func Test_contextPropagation(t *testing.T) {
 			s := star.NewService(m)
 			s.Remove(ctx, 1) //nolint:errcheck
 		}},
-		{"UserStarService.List", func(t *testing.T, m *core.Method) {
-			m.Get = makeMockFn(t)
-			s := star.NewUserService(m)
-			s.List(ctx, 1) //nolint:errcheck
-		}},
-		{"UserStarService.Count", func(t *testing.T, m *core.Method) {
-			m.Get = makeMockFn(t)
-			s := star.NewUserService(m)
-			s.Count(ctx, 1) //nolint:errcheck
-		}},
-		{"WikiStarService.List", func(t *testing.T, m *core.Method) {
-			m.Get = makeMockFn(t)
-			s := star.NewWikiService(m)
-			s.List(ctx, 34) //nolint:errcheck
-		}},
 	}
 
 	for _, tc := range cases {

--- a/internal/user/service_star.go
+++ b/internal/user/service_star.go
@@ -1,0 +1,89 @@
+package user
+
+import (
+	"context"
+	"net/url"
+	"path"
+	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/validate"
+)
+
+// ──────────────────────────────────────────────────────────────
+//  UserService
+// ──────────────────────────────────────────────────────────────
+
+// StarService handles communication with the user star-related methods of the Backlog API.
+type StarService struct {
+	method *core.Method
+}
+
+// List returns a list of stars received by the user with the given ID.
+//
+// This method supports options returned by methods in "*Client.User.Star.Option",
+// such as:
+//   - WithCount
+//   - WithMaxID
+//   - WithMinID
+//   - WithOrder
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-received-star-list
+func (s *StarService) List(ctx context.Context, userID int, opts ...core.RequestOption) ([]*model.Star, error) {
+	if err := validate.ValidateUserID(userID); err != nil {
+		return nil, err
+	}
+
+	query := url.Values{}
+	validOptionKeys := []core.APIParamOptionType{core.ParamMinID, core.ParamMaxID, core.ParamCount, core.ParamOrder}
+	if err := core.ApplyOptions(query, validOptionKeys, opts...); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("users", strconv.Itoa(userID), "stars")
+	resp, err := s.method.Get(ctx, spath, query)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.Star{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Count returns the number of stars received by the user with the given ID.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-user-received-stars
+func (s *StarService) Count(ctx context.Context, userID int) (int, error) {
+	if err := validate.ValidateUserID(userID); err != nil {
+		return 0, err
+	}
+
+	spath := path.Join("users", strconv.Itoa(userID), "stars", "count")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	var v struct {
+		Count int `json:"count"`
+	}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return 0, err
+	}
+
+	return v.Count, nil
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructor
+// ──────────────────────────────────────────────────────────────
+
+// NewStarService creates and returns a new user StarService.
+func NewStarService(method *core.Method) *StarService {
+	return &StarService{method: method}
+}

--- a/internal/user/service_star_test.go
+++ b/internal/user/service_star_test.go
@@ -1,4 +1,4 @@
-package star_test
+package user_test
 
 import (
 	"context"
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/star"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
+	"github.com/nattokin/go-backlog/internal/user"
 )
 
 func TestUserStarService_List(t *testing.T) {
@@ -78,7 +78,7 @@ func TestUserStarService_List(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := star.NewUserService(method)
+			s := user.NewStarService(method)
 			got, err := s.List(context.Background(), tc.userID, tc.opts...)
 
 			if tc.wantErr {
@@ -137,7 +137,7 @@ func TestUserStarService_Count(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := star.NewUserService(method)
+			s := user.NewStarService(method)
 			got, err := s.Count(context.Background(), tc.userID)
 
 			if tc.wantErr {

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -704,70 +704,80 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"UserService.All", func(t *testing.T, m *core.Method) {
+		{"Service.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := user.NewService(m)
 			s.All(ctx) //nolint:errcheck
 		}},
-		{"UserService.One", func(t *testing.T, m *core.Method) {
+		{"Service.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := user.NewService(m)
 			s.One(ctx, 1) //nolint:errcheck
 		}},
-		{"UserService.Own", func(t *testing.T, m *core.Method) {
+		{"Service.Own", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := user.NewService(m)
 			s.Own(ctx) //nolint:errcheck
 		}},
-		{"UserService.Add", func(t *testing.T, m *core.Method) {
+		{"Service.Add", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
 			s := user.NewService(m)
 			s.Add(ctx, "u", "p", "n", "m@m.com", model.RoleAdministrator) //nolint:errcheck
 		}},
-		{"UserService.Update", func(t *testing.T, m *core.Method) {
+		{"Service.Update", func(t *testing.T, m *core.Method) {
 			m.Patch = makeMockFn(t)
 			s := user.NewService(m)
 			s.Update(ctx, 1, o.WithName("n")) //nolint:errcheck
 		}},
-		{"UserService.Delete", func(t *testing.T, m *core.Method) {
+		{"Service.Delete", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)
 			s := user.NewService(m)
 			s.Delete(ctx, 1) //nolint:errcheck
 		}},
-		{"UserService.Icon", func(t *testing.T, m *core.Method) {
+		{"Service.Icon", func(t *testing.T, m *core.Method) {
 			m.Download = makeMockFn(t)
 			s := user.NewService(m)
 			s.Icon(ctx, 1) //nolint:errcheck
 		}},
-		{"ProjectUserService.All", func(t *testing.T, m *core.Method) {
+		{"ProjectService.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.All(ctx, "TEST", false) //nolint:errcheck
 		}},
-		{"ProjectUserService.Add", func(t *testing.T, m *core.Method) {
+		{"ProjectService.Add", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.Add(ctx, "TEST", 1) //nolint:errcheck
 		}},
-		{"ProjectUserService.Delete", func(t *testing.T, m *core.Method) {
+		{"ProjectService.Delete", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.Delete(ctx, "TEST", 1) //nolint:errcheck
 		}},
-		{"ProjectUserService.AddAdmin", func(t *testing.T, m *core.Method) {
+		{"ProjectService.AddAdmin", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.AddAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},
-		{"ProjectUserService.AdminAll", func(t *testing.T, m *core.Method) {
+		{"ProjectService.AdminAll", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.AdminAll(ctx, "TEST") //nolint:errcheck
 		}},
-		{"ProjectUserService.DeleteAdmin", func(t *testing.T, m *core.Method) {
+		{"ProjectService.DeleteAdmin", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)
 			s := user.NewProjectService(m)
 			s.DeleteAdmin(ctx, "TEST", 1) //nolint:errcheck
+		}},
+		{"StarService.List", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := user.NewStarService(m)
+			s.List(ctx, 1) //nolint:errcheck
+		}},
+		{"StarService.Count", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := user.NewStarService(m)
+			s.Count(ctx, 1) //nolint:errcheck
 		}},
 	}
 

--- a/internal/wiki/service_star.go
+++ b/internal/wiki/service_star.go
@@ -1,0 +1,47 @@
+package wiki
+
+import (
+	"context"
+	"path"
+	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/validate"
+)
+
+// StarService handles communication with the wiki star-related methods of the Backlog API.
+type StarService struct {
+	method *core.Method
+}
+
+// List returns a list of stars on the wiki page with the given ID.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-star
+func (s *StarService) List(ctx context.Context, wikiID int) ([]*model.Star, error) {
+	if err := validate.ValidateWikiID(wikiID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("wikis", strconv.Itoa(wikiID), "stars")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.Star{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructor
+// ──────────────────────────────────────────────────────────────
+
+// NewStarService creates and returns a new wiki StarService.
+func NewStarService(method *core.Method) *StarService {
+	return &StarService{method: method}
+}

--- a/internal/wiki/service_star_test.go
+++ b/internal/wiki/service_star_test.go
@@ -1,4 +1,4 @@
-package star_test
+package wiki_test
 
 import (
 	"context"
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/nattokin/go-backlog/internal/star"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
+	"github.com/nattokin/go-backlog/internal/wiki"
 )
 
 func TestWikiStarService_List(t *testing.T) {
@@ -60,7 +60,7 @@ func TestWikiStarService_List(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := star.NewWikiService(method)
+			s := wiki.NewStarService(method)
 			got, err := s.List(context.Background(), tc.wikiID)
 
 			if tc.wantErr {

--- a/internal/wiki/service_test.go
+++ b/internal/wiki/service_test.go
@@ -796,6 +796,11 @@ func Test_contextPropagation(t *testing.T) {
 			s := wiki.NewHistoryService(m)
 			s.List(ctx, 1) //nolint:errcheck
 		}},
+		{"StarService.List", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := wiki.NewStarService(m)
+			s.List(ctx, 34) //nolint:errcheck
+		}},
 	}
 
 	for _, tc := range cases {

--- a/user.go
+++ b/user.go
@@ -7,7 +7,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/recentlyviewed"
-	"github.com/nattokin/go-backlog/internal/star"
 	"github.com/nattokin/go-backlog/internal/user"
 )
 
@@ -228,7 +227,7 @@ func (s *UserRecentlyViewedOptionService) WithOrder(order Order) RequestOption {
 
 // UserStarService handles communication with the user star-related methods of the Backlog API.
 type UserStarService struct {
-	base *star.UserService
+	base *user.StarService
 
 	Option *UserStarOptionService
 }
@@ -358,7 +357,7 @@ func newUserRecentlyViewedService(method *core.Method, option *core.OptionServic
 
 func newUserStarService(method *core.Method, option *core.OptionService) *UserStarService {
 	return &UserStarService{
-		base:   star.NewUserService(method),
+		base:   user.NewStarService(method),
 		Option: newUserStarOptionService(option),
 	}
 }

--- a/wiki.go
+++ b/wiki.go
@@ -7,7 +7,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/sharedfile"
-	"github.com/nattokin/go-backlog/internal/star"
 	"github.com/nattokin/go-backlog/internal/wiki"
 )
 
@@ -217,7 +216,7 @@ func (s *WikiSharedFileService) Unlink(ctx context.Context, wikiID, fileID int) 
 
 // WikiStarService handles communication with the wiki star-related methods of the Backlog API.
 type WikiStarService struct {
-	base *star.WikiService
+	base *wiki.StarService
 	star *StarService
 }
 
@@ -308,7 +307,7 @@ func newWikiSharedFileService(method *core.Method) *WikiSharedFileService {
 
 func newWikiStarService(method *core.Method, option *core.OptionService) *WikiStarService {
 	return &WikiStarService{
-		base: star.NewWikiService(method),
+		base: wiki.NewStarService(method),
 		star: newStarService(method, option),
 	}
 }


### PR DESCRIPTION
## Summary

Implements the `internal/star` portion of #281.

`star.Service` (Add/Remove) remains unchanged as it is exposed as `Client.Star` in the root package. The domain-specific wrappers `star.UserService` and `star.WikiService` are moved to their owning packages.

## Changes

### `internal/star`

- `star.UserService` removed; replaced by `user.StarService`
- `star.WikiService` removed; replaced by `wiki.StarService`
- `star.Service` (Add/Remove) and its constructor remain unchanged

### New domain wrappers

| Package | Struct | Methods |
|---|---|---|
| `internal/user` | `StarService` | `List` |
| `internal/wiki` | `StarService` | `List` |

### Root package

Updated `UserStarService` and `WikiStarService` to use the new domain wrapper types. Removed direct `internal/star` imports from `user.go` and `wiki.go` where applicable.

Part of #281