### PR TITLE
refactor: comment services into issue and pull request specific packages

### DIFF
--- a/internal/comment/service.go
+++ b/internal/comment/service.go
@@ -3,27 +3,19 @@ package comment
 import (
 	"context"
 	"net/url"
-	"path"
-	"strconv"
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
-	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// IssueService handles communication with the issue comment-related methods of the Backlog API.
-type IssueService struct {
+// Service holds shared HTTP logic for comment-related Backlog API endpoints.
+// It is spath-agnostic: callers supply the full sub-path and are responsible
+// for validation and path construction.
+type Service struct {
 	method *core.Method
 }
 
-// All returns a list of comments on an issue.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-comment-list
-func (s *IssueService) All(ctx context.Context, issueIDOrKey string, opts ...core.RequestOption) ([]*model.Comment, error) {
-	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
-		return nil, err
-	}
-
+func (s *Service) All(ctx context.Context, spath string, opts ...core.RequestOption) ([]*model.Comment, error) {
 	query := url.Values{}
 	validTypes := []core.APIParamOptionType{
 		core.ParamMinID,
@@ -35,7 +27,6 @@ func (s *IssueService) All(ctx context.Context, issueIDOrKey string, opts ...cor
 		return nil, err
 	}
 
-	spath := path.Join("issues", issueIDOrKey, "comments")
 	resp, err := s.method.Get(ctx, spath, query)
 	if err != nil {
 		return nil, err
@@ -49,14 +40,7 @@ func (s *IssueService) All(ctx context.Context, issueIDOrKey string, opts ...cor
 	return v, nil
 }
 
-// Add adds a comment to an issue.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-comment
-func (s *IssueService) Add(ctx context.Context, issueIDOrKey string, content string, opts ...core.RequestOption) (*model.Comment, error) {
-	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
-		return nil, err
-	}
-
+func (s *Service) Add(ctx context.Context, spath, content string, opts ...core.RequestOption) (*model.Comment, error) {
 	option := &core.OptionService{}
 	form := url.Values{}
 	validTypes := []core.APIParamOptionType{
@@ -72,7 +56,6 @@ func (s *IssueService) Add(ctx context.Context, issueIDOrKey string, content str
 		return nil, err
 	}
 
-	spath := path.Join("issues", issueIDOrKey, "comments")
 	resp, err := s.method.Post(ctx, spath, form)
 	if err != nil {
 		return nil, err
@@ -86,15 +69,7 @@ func (s *IssueService) Add(ctx context.Context, issueIDOrKey string, content str
 	return &v, nil
 }
 
-// Count returns the number of comments on an issue.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-comment
-func (s *IssueService) Count(ctx context.Context, issueIDOrKey string) (int, error) {
-	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
-		return 0, err
-	}
-
-	spath := path.Join("issues", issueIDOrKey, "comments", "count")
+func (s *Service) Count(ctx context.Context, spath string) (int, error) {
 	resp, err := s.method.Get(ctx, spath, nil)
 	if err != nil {
 		return 0, err
@@ -108,18 +83,7 @@ func (s *IssueService) Count(ctx context.Context, issueIDOrKey string) (int, err
 	return v["count"], nil
 }
 
-// One returns information about a specific comment.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-comment
-func (s *IssueService) One(ctx context.Context, issueIDOrKey string, commentID int) (*model.Comment, error) {
-	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidateCommentID(commentID); err != nil {
-		return nil, err
-	}
-
-	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID))
+func (s *Service) One(ctx context.Context, spath string) (*model.Comment, error) {
 	resp, err := s.method.Get(ctx, spath, nil)
 	if err != nil {
 		return nil, err
@@ -133,42 +97,7 @@ func (s *IssueService) One(ctx context.Context, issueIDOrKey string, commentID i
 	return &v, nil
 }
 
-// Delete deletes a comment from an issue.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-comment
-func (s *IssueService) Delete(ctx context.Context, issueIDOrKey string, commentID int) (*model.Comment, error) {
-	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidateCommentID(commentID); err != nil {
-		return nil, err
-	}
-
-	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID))
-	resp, err := s.method.Delete(ctx, spath, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	v := model.Comment{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return &v, nil
-}
-
-// Update updates a comment on an issue.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-comment
-func (s *IssueService) Update(ctx context.Context, issueIDOrKey string, commentID int, content string) (*model.Comment, error) {
-	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidateCommentID(commentID); err != nil {
-		return nil, err
-	}
-
+func (s *Service) Update(ctx context.Context, spath, content string) (*model.Comment, error) {
 	option := (&core.OptionService{}).WithContent(content)
 	if err := option.Check(); err != nil {
 		return nil, err
@@ -176,233 +105,6 @@ func (s *IssueService) Update(ctx context.Context, issueIDOrKey string, commentI
 	form := url.Values{}
 	option.Set(form)
 
-	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID))
-	resp, err := s.method.Patch(ctx, spath, form)
-	if err != nil {
-		return nil, err
-	}
-
-	v := model.Comment{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return &v, nil
-}
-
-// Notifications returns a list of notifications on a comment.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-comment-notifications
-func (s *IssueService) Notifications(ctx context.Context, issueIDOrKey string, commentID int) ([]*model.Notification, error) {
-	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidateCommentID(commentID); err != nil {
-		return nil, err
-	}
-
-	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID), "notifications")
-	resp, err := s.method.Get(ctx, spath, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	v := []*model.Notification{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return v, nil
-}
-
-// Notify sends notifications for a comment.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-comment-notification
-func (s *IssueService) Notify(ctx context.Context, issueIDOrKey string, commentID int, userIDs []int) (*model.Comment, error) {
-	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidateCommentID(commentID); err != nil {
-		return nil, err
-	}
-
-	option := &core.OptionService{}
-	form := url.Values{}
-	validTypes := []core.APIParamOptionType{
-		core.ParamNotifiedUserIDs,
-	}
-	if err := core.ApplyOptions(form, validTypes, option.WithNotifiedUserIDs(userIDs)); err != nil {
-		return nil, err
-	}
-
-	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID), "notifications")
-	resp, err := s.method.Post(ctx, spath, form)
-	if err != nil {
-		return nil, err
-	}
-
-	v := model.Comment{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return &v, nil
-}
-
-// ──────────────────────────────────────────────────────────────
-//  PullRequestService
-// ──────────────────────────────────────────────────────────────
-
-// PullRequestService handles communication with the pull request comment-related methods of the Backlog API.
-type PullRequestService struct {
-	method *core.Method
-}
-
-// All returns a list of comments on a pull request.
-//
-// This method supports options:
-//   - WithMinID
-//   - WithMaxID
-//   - WithCount
-//   - WithOrder
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-comment
-func (s *PullRequestService) All(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, opts ...core.RequestOption) ([]*model.Comment, error) {
-	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidatePRNumber(prNumber); err != nil {
-		return nil, err
-	}
-
-	query := url.Values{}
-	validTypes := []core.APIParamOptionType{
-		core.ParamMinID,
-		core.ParamMaxID,
-		core.ParamCount,
-		core.ParamOrder,
-	}
-	if err := core.ApplyOptions(query, validTypes, opts...); err != nil {
-		return nil, err
-	}
-
-	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber), "comments")
-	resp, err := s.method.Get(ctx, spath, query)
-	if err != nil {
-		return nil, err
-	}
-
-	v := []*model.Comment{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return v, nil
-}
-
-// Add adds a comment to a pull request.
-//
-// This method supports options:
-//   - WithNotifiedUserIDs
-//   - WithAttachmentIDs
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-pull-request-comment
-func (s *PullRequestService) Add(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, content string, opts ...core.RequestOption) (*model.Comment, error) {
-	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidatePRNumber(prNumber); err != nil {
-		return nil, err
-	}
-
-	option := &core.OptionService{}
-	form := url.Values{}
-	validTypes := []core.APIParamOptionType{
-		core.ParamContent,
-		core.ParamNotifiedUserIDs,
-		core.ParamAttachmentIDs,
-	}
-	options := append(
-		[]core.RequestOption{option.WithContent(content)},
-		opts...,
-	)
-	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
-		return nil, err
-	}
-
-	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber), "comments")
-	resp, err := s.method.Post(ctx, spath, form)
-	if err != nil {
-		return nil, err
-	}
-
-	v := model.Comment{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return &v, nil
-}
-
-// Count returns the number of comments on a pull request.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-number-of-pull-request-comments
-func (s *PullRequestService) Count(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int) (int, error) {
-	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
-		return 0, err
-	}
-	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
-		return 0, err
-	}
-	if err := validate.ValidatePRNumber(prNumber); err != nil {
-		return 0, err
-	}
-
-	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber), "comments", "count")
-	resp, err := s.method.Get(ctx, spath, nil)
-	if err != nil {
-		return 0, err
-	}
-
-	v := map[string]int{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return 0, err
-	}
-
-	return v["count"], nil
-}
-
-// Update updates a comment on a pull request.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-pull-request-comment-information
-func (s *PullRequestService) Update(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, commentID int, content string) (*model.Comment, error) {
-	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidatePRNumber(prNumber); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidateCommentID(commentID); err != nil {
-		return nil, err
-	}
-
-	option := (&core.OptionService{}).WithContent(content)
-	if err := option.Check(); err != nil {
-		return nil, err
-	}
-	form := url.Values{}
-	option.Set(form)
-
-	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber), "comments", strconv.Itoa(commentID))
 	resp, err := s.method.Patch(ctx, spath, form)
 	if err != nil {
 		return nil, err
@@ -417,15 +119,10 @@ func (s *PullRequestService) Update(ctx context.Context, projectIDOrKey string, 
 }
 
 // ──────────────────────────────────────────────────────────────
-//  Constructors
+//  Constructor
 // ──────────────────────────────────────────────────────────────
 
-// NewIssueService creates and returns a new comment IssueService.
-func NewIssueService(method *core.Method) *IssueService {
-	return &IssueService{method: method}
-}
-
-// NewPullRequestService creates and returns a new comment PullRequestService.
-func NewPullRequestService(method *core.Method) *PullRequestService {
-	return &PullRequestService{method: method}
+// NewService creates and returns a new comment Service.
+func NewService(method *core.Method) *Service {
+	return &Service{method: method}
 }

--- a/internal/issue/service_comment.go
+++ b/internal/issue/service_comment.go
@@ -1,0 +1,181 @@
+package issue
+
+import (
+	"context"
+	"net/url"
+	"path"
+	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/comment"
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/validate"
+)
+
+// CommentService handles communication with the issue comment-related methods of the Backlog API.
+type CommentService struct {
+	base   *comment.Service
+	method *core.Method
+}
+
+// All returns a list of comments on an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-comment-list
+func (s *CommentService) All(ctx context.Context, issueIDOrKey string, opts ...core.RequestOption) ([]*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments")
+	return s.base.All(ctx, spath, opts...)
+}
+
+// Add adds a comment to an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-comment
+func (s *CommentService) Add(ctx context.Context, issueIDOrKey string, content string, opts ...core.RequestOption) (*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments")
+	return s.base.Add(ctx, spath, content, opts...)
+}
+
+// Count returns the number of comments on an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-comment
+func (s *CommentService) Count(ctx context.Context, issueIDOrKey string) (int, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return 0, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", "count")
+	return s.base.Count(ctx, spath)
+}
+
+// One returns information about a specific comment.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-comment
+func (s *CommentService) One(ctx context.Context, issueIDOrKey string, commentID int) (*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID))
+	return s.base.One(ctx, spath)
+}
+
+// Delete deletes a comment from an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-comment
+func (s *CommentService) Delete(ctx context.Context, issueIDOrKey string, commentID int) (*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID))
+	resp, err := s.method.Delete(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Comment{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Update updates a comment on an issue.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-comment
+func (s *CommentService) Update(ctx context.Context, issueIDOrKey string, commentID int, content string) (*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID))
+	return s.base.Update(ctx, spath, content)
+}
+
+// Notifications returns a list of notifications on a comment.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-comment-notifications
+func (s *CommentService) Notifications(ctx context.Context, issueIDOrKey string, commentID int) ([]*model.Notification, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID), "notifications")
+	resp, err := s.method.Get(ctx, spath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.Notification{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Notify sends notifications for a comment.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-comment-notification
+func (s *CommentService) Notify(ctx context.Context, issueIDOrKey string, commentID int, userIDs []int) (*model.Comment, error) {
+	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	option := &core.OptionService{}
+	form := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamNotifiedUserIDs,
+	}
+	if err := core.ApplyOptions(form, validTypes, option.WithNotifiedUserIDs(userIDs)); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("issues", issueIDOrKey, "comments", strconv.Itoa(commentID), "notifications")
+	resp, err := s.method.Post(ctx, spath, form)
+	if err != nil {
+		return nil, err
+	}
+
+	v := model.Comment{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
+// NewCommentService creates and returns a new issue CommentService.
+func NewCommentService(method *core.Method) *CommentService {
+	return &CommentService{
+		base:   comment.NewService(method),
+		method: method,
+	}
+}

--- a/internal/issue/service_comment_test.go
+++ b/internal/issue/service_comment_test.go
@@ -1,4 +1,4 @@
-package comment_test
+package issue_test
 
 import (
 	"context"
@@ -11,13 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/nattokin/go-backlog/internal/comment"
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/issue"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestIssueCommentService_All(t *testing.T) {
+func TestCommentService_All(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -111,7 +111,7 @@ func TestIssueCommentService_All(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := comment.NewIssueService(method)
+			s := issue.NewCommentService(method)
 
 			got, err := s.All(context.Background(), tc.issueIDOrKey, tc.opts...)
 
@@ -132,7 +132,7 @@ func TestIssueCommentService_All(t *testing.T) {
 	}
 }
 
-func TestIssueCommentService_Add(t *testing.T) {
+func TestCommentService_Add(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -215,7 +215,7 @@ func TestIssueCommentService_Add(t *testing.T) {
 				method.Post = tc.mockPostFn
 			}
 
-			s := comment.NewIssueService(method)
+			s := issue.NewCommentService(method)
 
 			got, err := s.Add(context.Background(), tc.issueIDOrKey, tc.content, tc.opts...)
 
@@ -233,7 +233,7 @@ func TestIssueCommentService_Add(t *testing.T) {
 	}
 }
 
-func TestIssueCommentService_Count(t *testing.T) {
+func TestCommentService_Count(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
 
@@ -283,7 +283,7 @@ func TestIssueCommentService_Count(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := comment.NewIssueService(method)
+			s := issue.NewCommentService(method)
 
 			count, err := s.Count(context.Background(), tc.issueIDOrKey)
 
@@ -300,7 +300,7 @@ func TestIssueCommentService_Count(t *testing.T) {
 	}
 }
 
-func TestIssueCommentService_One(t *testing.T) {
+func TestCommentService_One(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
 		commentID    int
@@ -356,7 +356,7 @@ func TestIssueCommentService_One(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := comment.NewIssueService(method)
+			s := issue.NewCommentService(method)
 
 			got, err := s.One(context.Background(), tc.issueIDOrKey, tc.commentID)
 
@@ -374,7 +374,7 @@ func TestIssueCommentService_One(t *testing.T) {
 	}
 }
 
-func TestIssueCommentService_Delete(t *testing.T) {
+func TestCommentService_Delete(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
 		commentID    int
@@ -430,7 +430,7 @@ func TestIssueCommentService_Delete(t *testing.T) {
 				method.Delete = tc.mockDeleteFn
 			}
 
-			s := comment.NewIssueService(method)
+			s := issue.NewCommentService(method)
 
 			got, err := s.Delete(context.Background(), tc.issueIDOrKey, tc.commentID)
 
@@ -448,7 +448,7 @@ func TestIssueCommentService_Delete(t *testing.T) {
 	}
 }
 
-func TestIssueCommentService_Update(t *testing.T) {
+func TestCommentService_Update(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
 		commentID    int
@@ -517,7 +517,7 @@ func TestIssueCommentService_Update(t *testing.T) {
 				method.Patch = tc.mockPatchFn
 			}
 
-			s := comment.NewIssueService(method)
+			s := issue.NewCommentService(method)
 
 			got, err := s.Update(context.Background(), tc.issueIDOrKey, tc.commentID, tc.content)
 
@@ -535,7 +535,7 @@ func TestIssueCommentService_Update(t *testing.T) {
 	}
 }
 
-func TestIssueCommentService_Notifications(t *testing.T) {
+func TestCommentService_Notifications(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
 		commentID    int
@@ -591,7 +591,7 @@ func TestIssueCommentService_Notifications(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := comment.NewIssueService(method)
+			s := issue.NewCommentService(method)
 
 			got, err := s.Notifications(context.Background(), tc.issueIDOrKey, tc.commentID)
 
@@ -608,7 +608,7 @@ func TestIssueCommentService_Notifications(t *testing.T) {
 	}
 }
 
-func TestIssueCommentService_Notify(t *testing.T) {
+func TestCommentService_Notify(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
 		commentID    int
@@ -677,7 +677,7 @@ func TestIssueCommentService_Notify(t *testing.T) {
 				method.Post = tc.mockPostFn
 			}
 
-			s := comment.NewIssueService(method)
+			s := issue.NewCommentService(method)
 
 			got, err := s.Notify(context.Background(), tc.issueIDOrKey, tc.commentID, tc.userIDs)
 

--- a/internal/issue/service_test.go
+++ b/internal/issue/service_test.go
@@ -822,6 +822,46 @@ func Test_contextPropagation(t *testing.T) {
 			s := issue.NewAttachmentService(m)
 			s.Download(ctx, "TEST-1", 1) //nolint:errcheck
 		}},
+		{"CommentService.All", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := issue.NewCommentService(m)
+			s.All(ctx, "ISSUE-1") //nolint:errcheck
+		}},
+		{"CommentService.Add", func(t *testing.T, m *core.Method) {
+			m.Post = makeMockFn(t)
+			s := issue.NewCommentService(m)
+			s.Add(ctx, "ISSUE-1", "comment") //nolint:errcheck
+		}},
+		{"CommentService.Count", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := issue.NewCommentService(m)
+			s.Count(ctx, "ISSUE-1") //nolint:errcheck
+		}},
+		{"CommentService.One", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := issue.NewCommentService(m)
+			s.One(ctx, "ISSUE-1", 1) //nolint:errcheck
+		}},
+		{"CommentService.Delete", func(t *testing.T, m *core.Method) {
+			m.Delete = makeMockFn(t)
+			s := issue.NewCommentService(m)
+			s.Delete(ctx, "ISSUE-1", 1) //nolint:errcheck
+		}},
+		{"CommentService.Update", func(t *testing.T, m *core.Method) {
+			m.Patch = makeMockFn(t)
+			s := issue.NewCommentService(m)
+			s.Update(ctx, "ISSUE-1", 1, "content") //nolint:errcheck
+		}},
+		{"CommentService.Notifications", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := issue.NewCommentService(m)
+			s.Notifications(ctx, "ISSUE-1", 1) //nolint:errcheck
+		}},
+		{"CommentService.Notify", func(t *testing.T, m *core.Method) {
+			m.Post = makeMockFn(t)
+			s := issue.NewCommentService(m)
+			s.Notify(ctx, "ISSUE-1", 1, []int{1, 2}) //nolint:errcheck
+		}},
 		{"SharedFileService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := issue.NewSharedFileService(m)

--- a/internal/pullrequest/service_comment.go
+++ b/internal/pullrequest/service_comment.go
@@ -1,0 +1,120 @@
+package pullrequest
+
+import (
+	"context"
+	"path"
+	"strconv"
+
+	"github.com/nattokin/go-backlog/internal/comment"
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/validate"
+)
+
+// CommentService handles communication with the pull request comment-related methods of the Backlog API.
+type CommentService struct {
+	base   *comment.Service
+	method *core.Method
+}
+
+// All returns a list of comments on a pull request.
+//
+// This method supports options:
+//   - WithMinID
+//   - WithMaxID
+//   - WithCount
+//   - WithOrder
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-comment
+func (s *CommentService) All(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, opts ...core.RequestOption) ([]*model.Comment, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidatePRNumber(prNumber); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber), "comments")
+	return s.base.All(ctx, spath, opts...)
+}
+
+// Add adds a comment to a pull request.
+//
+// This method supports options:
+//   - WithNotifiedUserIDs
+//   - WithAttachmentIDs
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-pull-request-comment
+func (s *CommentService) Add(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, content string, opts ...core.RequestOption) (*model.Comment, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidatePRNumber(prNumber); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber), "comments")
+	return s.base.Add(ctx, spath, content, opts...)
+}
+
+// Count returns the number of comments on a pull request.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-number-of-pull-request-comments
+func (s *CommentService) Count(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int) (int, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return 0, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return 0, err
+	}
+	if err := validate.ValidatePRNumber(prNumber); err != nil {
+		return 0, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber), "comments", "count")
+	return s.base.Count(ctx, spath)
+}
+
+// TODO
+// func (s *CommentService) One(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int) (*model.Comment, error) {
+// 	return nil, nil
+// }
+
+// Update updates a comment on a pull request.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-pull-request-comment-information
+func (s *CommentService) Update(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, commentID int, content string) (*model.Comment, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidatePRNumber(prNumber); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber), "comments", strconv.Itoa(commentID))
+	return s.base.Update(ctx, spath, content)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
+// NewCommentService creates and returns a new pullrequest CommentService.
+func NewCommentService(method *core.Method) *CommentService {
+	return &CommentService{
+		base:   comment.NewService(method),
+		method: method,
+	}
+}

--- a/internal/pullrequest/service_comment.go
+++ b/internal/pullrequest/service_comment.go
@@ -13,8 +13,7 @@ import (
 
 // CommentService handles communication with the pull request comment-related methods of the Backlog API.
 type CommentService struct {
-	base   *comment.Service
-	method *core.Method
+	base *comment.Service
 }
 
 // All returns a list of comments on a pull request.
@@ -114,7 +113,6 @@ func (s *CommentService) Update(ctx context.Context, projectIDOrKey string, repo
 // NewCommentService creates and returns a new pullrequest CommentService.
 func NewCommentService(method *core.Method) *CommentService {
 	return &CommentService{
-		base:   comment.NewService(method),
-		method: method,
+		base: comment.NewService(method),
 	}
 }

--- a/internal/pullrequest/service_comment_test.go
+++ b/internal/pullrequest/service_comment_test.go
@@ -1,4 +1,4 @@
-package comment_test
+package pullrequest_test
 
 import (
 	"context"
@@ -11,13 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/nattokin/go-backlog/internal/comment"
 	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/pullrequest"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestPullRequestCommentService_All(t *testing.T) {
+func TestCommentService_All(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -139,7 +139,7 @@ func TestPullRequestCommentService_All(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := comment.NewPullRequestService(method)
+			s := pullrequest.NewCommentService(method)
 
 			got, err := s.All(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.prNumber, tc.opts...)
 
@@ -160,7 +160,7 @@ func TestPullRequestCommentService_All(t *testing.T) {
 	}
 }
 
-func TestPullRequestCommentService_Add(t *testing.T) {
+func TestCommentService_Add(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -296,7 +296,7 @@ func TestPullRequestCommentService_Add(t *testing.T) {
 				method.Post = tc.mockPostFn
 			}
 
-			s := comment.NewPullRequestService(method)
+			s := pullrequest.NewCommentService(method)
 
 			got, err := s.Add(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.prNumber, tc.content, tc.opts...)
 
@@ -314,7 +314,7 @@ func TestPullRequestCommentService_Add(t *testing.T) {
 	}
 }
 
-func TestPullRequestCommentService_Count(t *testing.T) {
+func TestCommentService_Count(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 		repoIDOrName   string
@@ -394,7 +394,7 @@ func TestPullRequestCommentService_Count(t *testing.T) {
 				method.Get = tc.mockGetFn
 			}
 
-			s := comment.NewPullRequestService(method)
+			s := pullrequest.NewCommentService(method)
 
 			count, err := s.Count(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.prNumber)
 
@@ -411,7 +411,7 @@ func TestPullRequestCommentService_Count(t *testing.T) {
 	}
 }
 
-func TestPullRequestCommentService_Update(t *testing.T) {
+func TestCommentService_Update(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 		repoIDOrName   string
@@ -526,7 +526,7 @@ func TestPullRequestCommentService_Update(t *testing.T) {
 				method.Patch = tc.mockPatchFn
 			}
 
-			s := comment.NewPullRequestService(method)
+			s := pullrequest.NewCommentService(method)
 
 			got, err := s.Update(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.prNumber, tc.commentID, tc.content)
 

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -698,6 +698,26 @@ func Test_contextPropagation(t *testing.T) {
 			s := pullrequest.NewAttachmentService(m)
 			s.Download(ctx, "TEST", "repo", 1, 1) //nolint:errcheck
 		}},
+		{"CommentService.All", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := pullrequest.NewCommentService(m)
+			s.All(ctx, "PRJ-1", "REPO-1", 1) //nolint:errcheck
+		}},
+		{"CommentService.Add", func(t *testing.T, m *core.Method) {
+			m.Post = makeMockFn(t)
+			s := pullrequest.NewCommentService(m)
+			s.Add(ctx, "PRJ-1", "REPO-1", 1, "comment") //nolint:errcheck
+		}},
+		{"CommentService.Count", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := pullrequest.NewCommentService(m)
+			s.Count(ctx, "PRJ-1", "REPO-1", 1) //nolint:errcheck
+		}},
+		{"CommentService.Update", func(t *testing.T, m *core.Method) {
+			m.Patch = makeMockFn(t)
+			s := pullrequest.NewCommentService(m)
+			s.Update(ctx, "PRJ-1", "REPO-1", 1, 1, "content") //nolint:errcheck
+		}},
 	}
 
 	for _, tc := range cases {

--- a/issue.go
+++ b/issue.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/nattokin/go-backlog/internal/comment"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/issue"
 	"github.com/nattokin/go-backlog/internal/model"
@@ -249,7 +248,7 @@ func (s *IssueAttachmentService) Download(ctx context.Context, issueIDOrKey stri
 
 // IssueCommentService handles communication with the issue comment-related methods of the Backlog API.
 type IssueCommentService struct {
-	base   *comment.IssueService
+	base   *issue.CommentService
 	Option *IssueCommentOptionService
 }
 
@@ -677,7 +676,7 @@ func newIssueAttachmentService(method *core.Method) *IssueAttachmentService {
 
 func newIssueCommentService(method *core.Method, option *core.OptionService) *IssueCommentService {
 	return &IssueCommentService{
-		base:   comment.NewIssueService(method),
+		base:   issue.NewCommentService(method),
 		Option: &IssueCommentOptionService{base: option},
 	}
 }

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/nattokin/go-backlog/internal/comment"
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/pullrequest"
@@ -161,7 +160,7 @@ func (s *PullRequestAttachmentService) Download(ctx context.Context, projectIDOr
 
 // PullRequestCommentService handles communication with the pull request comment-related methods of the Backlog API.
 type PullRequestCommentService struct {
-	base   *comment.PullRequestService
+	base   *pullrequest.CommentService
 	Option *PullRequestCommentOptionService
 }
 
@@ -369,7 +368,7 @@ func newPullRequestAttachmentService(method *core.Method) *PullRequestAttachment
 
 func newPullRequestCommentService(method *core.Method, option *core.OptionService) *PullRequestCommentService {
 	return &PullRequestCommentService{
-		base:   comment.NewPullRequestService(method),
+		base:   pullrequest.NewCommentService(method),
 		Option: &PullRequestCommentOptionService{base: option},
 	}
 }


### PR DESCRIPTION
This PR restructures the comment service implementation by extracting shared HTTP logic into a reusable internal comment.Service and moving issue/pull request specific APIs into their respective packages.

## Changes

* Added generic internal/comment.Service
    * Handles shared comment API operations
    * Accepts fully constructed sub-paths (spath)
    * Removes resource-specific validation and path construction responsibilities
* Added internal/issue.CommentService
    * Encapsulates issue comment endpoint validation and path generation
    * Delegates shared operations to comment.Service
* Added internal/pullrequest.CommentService
    * Encapsulates pull request comment endpoint validation and path generation
    * Delegates shared operations to comment.Service
* Moved and renamed tests
    * internal/comment/service_issue_test.go
        → internal/issue/service_comment_test.go
    * internal/comment/service_pullrequest_test.go
        → internal/pullrequest/service_comment_test.go
* Updated public service wiring
    * IssueCommentService now uses issue.CommentService
    * PullRequestCommentService now uses pullrequest.CommentService

## Notes

* Shared methods such as All, Add, Count, and Update are now centralized in comment.Service
* Resource-specific operations remain in their dedicated packages
* Added TODO placeholder for pull request comment One endpoint implementation

Part of #281 