### PR TITLE
feat: implement CommentService.One for pull requests

### DIFF
--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -20,6 +20,7 @@ var (
 	doerPullRequestCommentAll    = newMockDoer(fixture.Comment.ListJSON)
 	doerPullRequestCommentAdd    = newMockDoer(fixture.Comment.SingleJSON)
 	doerPullRequestCommentCount  = newMockDoer(`{"count":2}`)
+	doerPullRequestCommentOne    = newMockDoer(fixture.Comment.SingleJSON)
 	doerPullRequestCommentUpdate = newMockDoer(fixture.Comment.SingleJSON)
 
 	// PullRequestAttachmentService
@@ -169,6 +170,19 @@ func ExamplePullRequestCommentService_Count() {
 	fmt.Printf("Count: %d\n", count)
 	// Output:
 	// Count: 2
+}
+
+func ExamplePullRequestCommentService_One() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerPullRequestCommentOne),
+	)
+
+	comment, _ := c.PullRequest.Comment.One(context.Background(), "TEST", "myrepo", 1, 1)
+	fmt.Printf("ID: %d, Content: %s\n", comment.ID, comment.Content)
+	// Output:
+	// ID: 1, Content: This is a comment.
 }
 
 func ExamplePullRequestCommentService_Update() {

--- a/internal/pullrequest/service_comment.go
+++ b/internal/pullrequest/service_comment.go
@@ -80,10 +80,26 @@ func (s *CommentService) Count(ctx context.Context, projectIDOrKey string, repoI
 	return s.base.Count(ctx, spath)
 }
 
-// TODO
-// func (s *CommentService) One(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int) (*model.Comment, error) {
-// 	return nil, nil
-// }
+// One returns information about a specific comment on a pull request.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-comment
+func (s *CommentService) One(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, commentID int) (*model.Comment, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidatePRNumber(prNumber); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateCommentID(commentID); err != nil {
+		return nil, err
+	}
+
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber), "comments", strconv.Itoa(commentID))
+	return s.base.One(ctx, spath)
+}
 
 // Update updates a comment on a pull request.
 //

--- a/internal/pullrequest/service_comment_test.go
+++ b/internal/pullrequest/service_comment_test.go
@@ -411,6 +411,120 @@ func TestCommentService_Count(t *testing.T) {
 	}
 }
 
+func TestCommentService_One(t *testing.T) {
+	cases := map[string]struct {
+		projectIDOrKey string
+		repoIDOrName   string
+		prNumber       int
+		commentID      int
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantID      int
+	}{
+		"success": {
+			projectIDOrKey: "PRJ",
+			repoIDOrName:   "repo",
+			prNumber:       1,
+			commentID:      42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "projects/PRJ/git/repositories/repo/pullRequests/1/comments/42", spath)
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			wantID: 1,
+		},
+		"error-empty-projectIDOrKey": {
+			projectIDOrKey: "",
+			repoIDOrName:   "repo",
+			prNumber:       1,
+			commentID:      1,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-zero-projectIDOrKey": {
+			projectIDOrKey: "0",
+			repoIDOrName:   "repo",
+			prNumber:       1,
+			commentID:      1,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-empty-repoIDOrName": {
+			projectIDOrKey: "PRJ",
+			repoIDOrName:   "",
+			prNumber:       1,
+			commentID:      1,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-zero-repoIDOrName": {
+			projectIDOrKey: "PRJ",
+			repoIDOrName:   "0",
+			prNumber:       1,
+			commentID:      1,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-invalid-prNumber": {
+			projectIDOrKey: "PRJ",
+			repoIDOrName:   "repo",
+			prNumber:       0,
+			commentID:      1,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-invalid-commentID": {
+			projectIDOrKey: "PRJ",
+			repoIDOrName:   "repo",
+			prNumber:       1,
+			commentID:      0,
+			wantErrType:    &core.ValidationError{},
+		},
+		"error-client-network": {
+			projectIDOrKey: "PRJ",
+			repoIDOrName:   "repo",
+			prNumber:       1,
+			commentID:      42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			projectIDOrKey: "PRJ",
+			repoIDOrName:   "repo",
+			prNumber:       1,
+			commentID:      42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := pullrequest.NewCommentService(method)
+
+			got, err := s.One(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.prNumber, tc.commentID)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}
+
 func TestCommentService_Update(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string

--- a/internal/pullrequest/service_test.go
+++ b/internal/pullrequest/service_test.go
@@ -713,6 +713,11 @@ func Test_contextPropagation(t *testing.T) {
 			s := pullrequest.NewCommentService(m)
 			s.Count(ctx, "PRJ-1", "REPO-1", 1) //nolint:errcheck
 		}},
+		{"CommentService.One", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := pullrequest.NewCommentService(m)
+			s.One(ctx, "PRJ-1", "REPO-1", 1, 1) //nolint:errcheck
+		}},
 		{"CommentService.Update", func(t *testing.T, m *core.Method) {
 			m.Patch = makeMockFn(t)
 			s := pullrequest.NewCommentService(m)

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -200,6 +200,14 @@ func (s *PullRequestCommentService) Count(ctx context.Context, projectIDOrKey st
 	return count, convertError(err)
 }
 
+// One returns information about a specific comment on a pull request.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-comment
+func (s *PullRequestCommentService) One(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, commentID int) (*Comment, error) {
+	v, err := s.base.One(ctx, projectIDOrKey, repositoryIDOrName, prNumber, commentID)
+	return commentFromModel(v), convertError(err)
+}
+
 // Update updates a comment on a pull request.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-pull-request-comment-information

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -422,6 +422,28 @@ func TestPullRequestCommentService(t *testing.T) {
 				assert.True(t, errors.As(err, &target))
 			},
 		},
+		"One": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1/comments/42", req.URL.Path)
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.PullRequest.Comment.One(ctx, "TEST", "repo", 1, 42)
+				require.NoError(t, err)
+				assert.Equal(t, 1, got.ID)
+				assert.Equal(t, "This is a comment.", got.Content)
+			},
+		},
+		"One/error": {
+			doFunc: newNotFoundDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.PullRequest.Comment.One(ctx, "TEST", "repo", 1, 42)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.True(t, errors.As(err, &target))
+			},
+		},
 		"Update": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodPatch, req.Method)


### PR DESCRIPTION
## Summary

Implements the missing `CommentService.One` method in `internal/pullrequest/service_comment.go`, which retrieves a single comment on a pull request. This endpoint existed in the Backlog API but was left as a `// TODO` stub.

## Changes

- Remove `TODO` stub; implement `CommentService.One` with full validation (`projectIDOrKey`, `repoIDOrName`, `prNumber`, `commentID`) and delegate to `comment.Service.One`
- Add `TestCommentService_One` covering success, all validation error cases, network error, and invalid JSON response