### PR TITLE
refactor!: move UserRecentlyViewedService to Client.RecentlyViewed

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 - [Get Number of Pull Request Comments](https://developer.nulab.com/docs/backlog/api/2/get-number-of-pull-request-comments/) - Returns the number of comments on a pull request.
 - [Update Pull Request Comment Information](https://developer.nulab.com/docs/backlog/api/2/update-pull-request-comment-information/) - Updates a comment on a pull request.
 
+### Client.[RecentlyViewed](https://pkg.go.dev/github.com/nattokin/go-backlog#RecentlyViewedService)
+
+- [Get Recently Viewed Issues](https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-issues) - Returns a list of recently viewed issues.
+- [Get Recently Viewed Projects](https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-projects) - Returns a list of recently viewed projects.
+- [Get Recently Viewed Wikis](https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-wikis/) - Returns a list of recently viewed wiki pages.
+- [Add Recently Viewed Issue](https://developer.nulab.com/docs/backlog/api/2/add-recently-viewed-issue/) - Adds an issue to recently viewed list.
+- [Add Recently Viewed Wiki](https://developer.nulab.com/docs/backlog/api/2/add-recently-viewed-wiki/) - Adds a wiki to recently viewed list.
+
 ### Client.[Repository](https://pkg.go.dev/github.com/nattokin/go-backlog#RepositoryService)
 
 - [Get List of Git Repositories](https://developer.nulab.com/docs/backlog/api/2/get-list-of-git-repositories/) - Returns a list of Git repositories in a project.
@@ -214,14 +222,6 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 ### Client.User.[Activity](https://pkg.go.dev/github.com/nattokin/go-backlog#UserActivityService)
 
 - [Get User Recent Updates](https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates) - Returns a user's recent updates.
-
-### Client.User.[RecentlyViewed](https://pkg.go.dev/github.com/nattokin/go-backlog#UserRecentlyViewedService)
-
-- [Get Recently Viewed Issues](https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-issues) - Returns a list of recently viewed issues.
-- [Get Recently Viewed Projects](https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-projects) - Returns a list of recently viewed projects.
-- [Get Recently Viewed Wikis](https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-wikis/) - Returns a list of recently viewed wiki pages.
-- [Add Recently Viewed Issue](https://developer.nulab.com/docs/backlog/api/2/add-recently-viewed-issue/) - Adds an issue to recently viewed list.
-- [Add Recently Viewed Wiki](https://developer.nulab.com/docs/backlog/api/2/add-recently-viewed-wiki/) - Adds a wiki to recently viewed list.
 
 ### Client.[Wiki](https://pkg.go.dev/github.com/nattokin/go-backlog#WikiService)
 

--- a/client.go
+++ b/client.go
@@ -27,14 +27,15 @@ type Client struct {
 	core *core.Client
 
 	// Service endpoints
-	Issue       *IssueService
-	Project     *ProjectService
-	PullRequest *PullRequestService
-	Repository  *RepositoryService
-	Space       *SpaceService
-	Star        *StarService
-	User        *UserService
-	Wiki        *WikiService
+	Issue          *IssueService
+	Project        *ProjectService
+	PullRequest    *PullRequestService
+	RecentlyViewed *RecentlyViewedService
+	Repository     *RepositoryService
+	Space          *SpaceService
+	Star           *StarService
+	User           *UserService
+	Wiki           *WikiService
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -78,6 +79,8 @@ func initServices(c *Client) {
 	c.Project = newProjectService(c.core.Method, baseOptionService)
 
 	c.PullRequest = newPullRequestService(c.core.Method, baseOptionService)
+
+	c.RecentlyViewed = newRecentlyViewedService(c.core.Method, baseOptionService)
 
 	c.Repository = newRepositoryService(c.core.Method)
 

--- a/example_option_test.go
+++ b/example_option_test.go
@@ -117,6 +117,24 @@ func ExampleProjectOptionService() {
 	// Count: 3, ProjectKey: TEST
 }
 
+// ExampleUserRecentlyViewedOptionService demonstrates listing recently viewed issues with count and order.
+func ExampleRecentlyViewedOptionService() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerUserRecentlyViewedOption),
+	)
+
+	issues, _ := c.RecentlyViewed.ListIssues(
+		context.Background(),
+		c.RecentlyViewed.Option.WithCount(20),
+		c.RecentlyViewed.Option.WithOrder(backlog.OrderDesc),
+	)
+	fmt.Printf("IssueKey: %s\n", issues[0].IssueKey)
+	// Output:
+	// IssueKey: TEST-1
+}
+
 // ExampleUserOptionService demonstrates updating a user's name and role type.
 func ExampleUserOptionService() {
 	c, _ := backlog.NewClient(
@@ -134,24 +152,6 @@ func ExampleUserOptionService() {
 	fmt.Printf("ID: %d, UserID: %s\n", user.ID, user.UserID)
 	// Output:
 	// ID: 1, UserID: admin
-}
-
-// ExampleUserRecentlyViewedOptionService demonstrates listing recently viewed issues with count and order.
-func ExampleUserRecentlyViewedOptionService() {
-	c, _ := backlog.NewClient(
-		"https://example.backlog.com",
-		"token",
-		backlog.WithDoer(doerUserRecentlyViewedOption),
-	)
-
-	issues, _ := c.User.RecentlyViewed.ListIssues(
-		context.Background(),
-		c.User.RecentlyViewed.Option.WithCount(20),
-		c.User.RecentlyViewed.Option.WithOrder(backlog.OrderDesc),
-	)
-	fmt.Printf("IssueKey: %s\n", issues[0].IssueKey)
-	// Output:
-	// IssueKey: TEST-1
 }
 
 // ExampleUserStarOptionService demonstrates listing received stars with count and order.

--- a/example_recentlyviewed_test.go
+++ b/example_recentlyviewed_test.go
@@ -1,0 +1,82 @@
+package backlog_test
+
+import (
+	"context"
+	"fmt"
+
+	backlog "github.com/nattokin/go-backlog"
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+var (
+	doerRecentlyViewedListIssues   = newMockDoer(fixture.RecentlyViewed.IssueListJSON)
+	doerRecentlyViewedAddIssue     = newMockDoer(fixture.RecentlyViewed.IssueSingleJSON)
+	doerRecentlyViewedListProjects = newMockDoer(fixture.RecentlyViewed.ProjectListJSON)
+	doerRecentlyViewedListWikis    = newMockDoer(fixture.RecentlyViewed.WikiListJSON)
+	doerRecentlyViewedAddWiki      = newMockDoer(fixture.RecentlyViewed.WikiSingleJSON)
+)
+
+func ExampleRecentlyViewedService_ListIssues() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerRecentlyViewedListIssues),
+	)
+
+	issues, _ := c.RecentlyViewed.ListIssues(context.Background())
+	fmt.Printf("IssueKey: %s\n", issues[0].IssueKey)
+	// Output:
+	// IssueKey: TEST-1
+}
+
+func ExampleRecentlyViewedService_AddIssue() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerRecentlyViewedAddIssue),
+	)
+
+	issue, _ := c.RecentlyViewed.AddIssue(context.Background(), 1)
+	fmt.Printf("IssueKey: %s\n", issue.IssueKey)
+	// Output:
+	// IssueKey: TEST-1
+}
+
+func ExampleRecentlyViewedService_ListProjects() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerRecentlyViewedListProjects),
+	)
+
+	projects, _ := c.RecentlyViewed.ListProjects(context.Background())
+	fmt.Printf("ProjectKey: %s\n", projects[0].ProjectKey)
+	// Output:
+	// ProjectKey: TEST
+}
+
+func ExampleRecentlyViewedService_ListWikis() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerRecentlyViewedListWikis),
+	)
+
+	wikis, _ := c.RecentlyViewed.ListWikis(context.Background())
+	fmt.Printf("Name: %s\n", wikis[0].Name)
+	// Output:
+	// Name: Home
+}
+
+func ExampleRecentlyViewedService_AddWiki() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerRecentlyViewedAddWiki),
+	)
+
+	wiki, _ := c.RecentlyViewed.AddWiki(context.Background(), 10)
+	fmt.Printf("Name: %s\n", wiki.Name)
+	// Output:
+	// Name: Home
+}

--- a/example_user_test.go
+++ b/example_user_test.go
@@ -21,13 +21,6 @@ var (
 	// UserActivityService
 	doerUserActivityList = newMockDoer(fixture.Activity.ListJSON)
 
-	// UserRecentlyViewedService
-	doerRecentlyViewedListIssues   = newMockDoer(fixture.RecentlyViewed.IssueListJSON)
-	doerRecentlyViewedAddIssue     = newMockDoer(fixture.RecentlyViewed.IssueSingleJSON)
-	doerRecentlyViewedListProjects = newMockDoer(fixture.RecentlyViewed.ProjectListJSON)
-	doerRecentlyViewedListWikis    = newMockDoer(fixture.RecentlyViewed.WikiListJSON)
-	doerRecentlyViewedAddWiki      = newMockDoer(fixture.RecentlyViewed.WikiSingleJSON)
-
 	// UserStarService
 	doerUserStarCount = newMockDoer(fixture.Star.CountJSON)
 	doerUserStarList  = newMockDoer(fixture.Star.ListJSON)
@@ -146,71 +139,6 @@ func ExampleUserActivityService_List() {
 	fmt.Printf("ID: %d, Type: %d\n", activities[0].ID, activities[0].Type)
 	// Output:
 	// ID: 3153, Type: 2
-}
-
-func ExampleUserRecentlyViewedService_ListIssues() {
-	c, _ := backlog.NewClient(
-		"https://example.backlog.com",
-		"token",
-		backlog.WithDoer(doerRecentlyViewedListIssues),
-	)
-
-	issues, _ := c.User.RecentlyViewed.ListIssues(context.Background())
-	fmt.Printf("IssueKey: %s\n", issues[0].IssueKey)
-	// Output:
-	// IssueKey: TEST-1
-}
-
-func ExampleUserRecentlyViewedService_AddIssue() {
-	c, _ := backlog.NewClient(
-		"https://example.backlog.com",
-		"token",
-		backlog.WithDoer(doerRecentlyViewedAddIssue),
-	)
-
-	issue, _ := c.User.RecentlyViewed.AddIssue(context.Background(), 1)
-	fmt.Printf("IssueKey: %s\n", issue.IssueKey)
-	// Output:
-	// IssueKey: TEST-1
-}
-
-func ExampleUserRecentlyViewedService_ListProjects() {
-	c, _ := backlog.NewClient(
-		"https://example.backlog.com",
-		"token",
-		backlog.WithDoer(doerRecentlyViewedListProjects),
-	)
-
-	projects, _ := c.User.RecentlyViewed.ListProjects(context.Background())
-	fmt.Printf("ProjectKey: %s\n", projects[0].ProjectKey)
-	// Output:
-	// ProjectKey: TEST
-}
-
-func ExampleUserRecentlyViewedService_ListWikis() {
-	c, _ := backlog.NewClient(
-		"https://example.backlog.com",
-		"token",
-		backlog.WithDoer(doerRecentlyViewedListWikis),
-	)
-
-	wikis, _ := c.User.RecentlyViewed.ListWikis(context.Background())
-	fmt.Printf("Name: %s\n", wikis[0].Name)
-	// Output:
-	// Name: Home
-}
-
-func ExampleUserRecentlyViewedService_AddWiki() {
-	c, _ := backlog.NewClient(
-		"https://example.backlog.com",
-		"token",
-		backlog.WithDoer(doerRecentlyViewedAddWiki),
-	)
-
-	wiki, _ := c.User.RecentlyViewed.AddWiki(context.Background(), 10)
-	fmt.Printf("Name: %s\n", wiki.Name)
-	// Output:
-	// Name: Home
 }
 
 func ExampleUserStarService_Count() {

--- a/internal/recentlyviewed/service.go
+++ b/internal/recentlyviewed/service.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Service handles communication with the recently-viewed methods of the Backlog API.
-// All endpoints are scoped to the authenticated user (myself), so no userID argument is needed.
+// All endpoints are scoped to the authenticated user (myself).
 type Service struct {
 	method *core.Method
 }
@@ -147,6 +147,10 @@ func (s *Service) AddWiki(ctx context.Context, wikiID int) (*model.Wiki, error) 
 
 	return v, nil
 }
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
 
 // NewService creates and returns a new recently viewed Service.
 func NewService(method *core.Method) *Service {

--- a/recentlyviewed.go
+++ b/recentlyviewed.go
@@ -1,0 +1,121 @@
+package backlog
+
+import (
+	"context"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/model"
+	"github.com/nattokin/go-backlog/internal/recentlyviewed"
+)
+
+// ──────────────────────────────────────────────────────────────
+//  UserRecentlyViewedService
+// ──────────────────────────────────────────────────────────────
+
+// RecentlyViewedService handles communication with the recently-viewed methods of the Backlog API.
+// All endpoints are scoped to the authenticated user (myself), so no userID argument is needed.
+type RecentlyViewedService struct {
+	base *recentlyviewed.Service
+
+	Option *RecentlyViewedOptionService
+}
+
+// ListIssues returns a list of issues recently viewed by the authenticated user.
+//
+// This method supports options returned by methods in "*Client.User.RecentlyViewed.Option",
+// such as:
+//   - WithCount
+//   - WithOffset
+//   - WithOrder
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-issues
+func (s *RecentlyViewedService) ListIssues(ctx context.Context, opts ...RequestOption) ([]*Issue, error) {
+	v, err := s.base.ListIssues(ctx, toCoreOptions(opts)...)
+	return issuesFromModel(v), convertError(err)
+}
+
+// AddIssue adds an issue to the recently viewed list of the authenticated user.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-recently-viewed-issue
+func (s *RecentlyViewedService) AddIssue(ctx context.Context, issueID int) (*Issue, error) {
+	v, err := s.base.AddIssue(ctx, issueID)
+	return issueFromModel(v), convertError(err)
+}
+
+// ListProjects returns a list of projects recently viewed by the authenticated user.
+//
+// This method supports options returned by methods in "*Client.User.RecentlyViewed.Option",
+// such as:
+//   - WithCount
+//   - WithOffset
+//   - WithOrder
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-projects
+func (s *RecentlyViewedService) ListProjects(ctx context.Context, opts ...RequestOption) ([]*Project, error) {
+	v, err := s.base.ListProjects(ctx, toCoreOptions(opts)...)
+	return projectsFromModel(v), convertError(err)
+}
+
+// ListWikis returns a list of Wiki pages recently viewed by the authenticated user.
+//
+// This method supports options returned by methods in "*Client.User.RecentlyViewed.Option",
+// such as:
+//   - WithCount
+//   - WithOffset
+//   - WithOrder
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-wikis
+func (s *RecentlyViewedService) ListWikis(ctx context.Context, opts ...RequestOption) ([]*Wiki, error) {
+	v, err := s.base.ListWikis(ctx, toCoreOptions(opts)...)
+	return wikisFromModel(v), convertError(err)
+}
+
+// AddWiki adds a Wiki page to the recently viewed list of the authenticated user.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-recently-viewed-wiki
+func (s *RecentlyViewedService) AddWiki(ctx context.Context, wikiID int) (*Wiki, error) {
+	v, err := s.base.AddWiki(ctx, wikiID)
+	return wikiFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
+//  UserRecentlyViewedOptionService
+// ──────────────────────────────────────────────────────────────
+
+// RecentlyViewedOptionService provides a domain-specific set of option builders
+// for operations within the UserRecentlyViewedService.
+type RecentlyViewedOptionService struct {
+	base *core.OptionService
+}
+
+// WithCount sets the number of results to return (1-100).
+func (s *RecentlyViewedOptionService) WithCount(count int) RequestOption {
+	return s.base.WithCount(count)
+}
+
+// WithOffset sets the number of items to skip.
+func (s *RecentlyViewedOptionService) WithOffset(offset int) RequestOption {
+	return s.base.WithOffset(offset)
+}
+
+// WithOrder sets the sort order of results.
+func (s *RecentlyViewedOptionService) WithOrder(order Order) RequestOption {
+	return s.base.WithOrder(model.Order(order))
+}
+
+// ──────────────────────────────────────────────────────────────
+//  Constructors
+// ──────────────────────────────────────────────────────────────
+
+func newRecentlyViewedService(method *core.Method, option *core.OptionService) *RecentlyViewedService {
+	return &RecentlyViewedService{
+		base:   recentlyviewed.NewService(method),
+		Option: newRecentlyViewedOptionService(option),
+	}
+}
+
+func newRecentlyViewedOptionService(option *core.OptionService) *RecentlyViewedOptionService {
+	return &RecentlyViewedOptionService{
+		base: option,
+	}
+}

--- a/recentlyviewed_test.go
+++ b/recentlyviewed_test.go
@@ -31,7 +31,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.RecentlyViewed.IssueListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.User.RecentlyViewed.ListIssues(ctx)
+				got, err := c.RecentlyViewed.ListIssues(ctx)
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, "TEST-1", got[0].IssueKey)
@@ -46,8 +46,8 @@ func TestUserRecentlyViewedService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.RecentlyViewed.IssueListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				o := c.User.RecentlyViewed.Option
-				got, err := c.User.RecentlyViewed.ListIssues(ctx,
+				o := c.RecentlyViewed.Option
+				got, err := c.RecentlyViewed.ListIssues(ctx,
 					o.WithCount(5),
 					o.WithOffset(10),
 					o.WithOrder(backlog.OrderAsc),
@@ -59,7 +59,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 		"ListIssues/error": {
 			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.User.RecentlyViewed.ListIssues(ctx)
+				_, err := c.RecentlyViewed.ListIssues(ctx)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))
@@ -72,7 +72,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.RecentlyViewed.IssueSingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.User.RecentlyViewed.AddIssue(ctx, 1)
+				got, err := c.RecentlyViewed.AddIssue(ctx, 1)
 				require.NoError(t, err)
 				assert.Equal(t, "TEST-1", got.IssueKey)
 			},
@@ -80,7 +80,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 		"AddIssue/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.User.RecentlyViewed.AddIssue(ctx, 1)
+				_, err := c.RecentlyViewed.AddIssue(ctx, 1)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))
@@ -93,7 +93,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.RecentlyViewed.ProjectListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.User.RecentlyViewed.ListProjects(ctx)
+				got, err := c.RecentlyViewed.ListProjects(ctx)
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, "TEST", got[0].ProjectKey)
@@ -102,7 +102,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 		"ListProjects/error": {
 			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.User.RecentlyViewed.ListProjects(ctx)
+				_, err := c.RecentlyViewed.ListProjects(ctx)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))
@@ -115,7 +115,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.RecentlyViewed.WikiListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.User.RecentlyViewed.ListWikis(ctx)
+				got, err := c.RecentlyViewed.ListWikis(ctx)
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, "Home", got[0].Name)
@@ -124,7 +124,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 		"ListWikis/error": {
 			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.User.RecentlyViewed.ListWikis(ctx)
+				_, err := c.RecentlyViewed.ListWikis(ctx)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))
@@ -137,7 +137,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.RecentlyViewed.WikiSingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.User.RecentlyViewed.AddWiki(ctx, 10)
+				got, err := c.RecentlyViewed.AddWiki(ctx, 10)
 				require.NoError(t, err)
 				assert.Equal(t, "Home", got.Name)
 			},
@@ -145,7 +145,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 		"AddWiki/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.User.RecentlyViewed.AddWiki(ctx, 10)
+				_, err := c.RecentlyViewed.AddWiki(ctx, 10)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))
@@ -167,7 +167,7 @@ func TestUserRecentlyViewedService(t *testing.T) {
 func TestUserRecentlyViewedOptionService(t *testing.T) {
 	c, err := backlog.NewClient("https://example.backlog.com", "token")
 	require.NoError(t, err)
-	o := c.User.RecentlyViewed.Option
+	o := c.RecentlyViewed.Option
 
 	// --- Integer options ------------------------------------------------------------
 	t.Run("integer-options", func(t *testing.T) {

--- a/user.go
+++ b/user.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/model"
-	"github.com/nattokin/go-backlog/internal/recentlyviewed"
 	"github.com/nattokin/go-backlog/internal/user"
 )
 
@@ -27,9 +26,8 @@ type User struct {
 type UserService struct {
 	base *user.Service
 
-	Activity       *UserActivityService
-	RecentlyViewed *UserRecentlyViewedService
-	Star           *UserStarService
+	Activity *UserActivityService
+	Star     *UserStarService
 
 	Option *UserOptionService
 }
@@ -123,101 +121,6 @@ type UserActivityService struct {
 func (s *UserActivityService) List(ctx context.Context, userID int, opts ...RequestOption) ([]*Activity, error) {
 	v, err := s.base.List(ctx, userID, toCoreOptions(opts)...)
 	return activitiesFromModel(v), convertError(err)
-}
-
-// ──────────────────────────────────────────────────────────────
-//  UserRecentlyViewedService
-// ──────────────────────────────────────────────────────────────
-
-// UserRecentlyViewedService handles communication with the recently-viewed methods of the Backlog API.
-// All endpoints are scoped to the authenticated user (myself), so no userID argument is needed.
-type UserRecentlyViewedService struct {
-	base *recentlyviewed.Service
-
-	Option *UserRecentlyViewedOptionService
-}
-
-// ListIssues returns a list of issues recently viewed by the authenticated user.
-//
-// This method supports options returned by methods in "*Client.User.RecentlyViewed.Option",
-// such as:
-//   - WithCount
-//   - WithOffset
-//   - WithOrder
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-issues
-func (s *UserRecentlyViewedService) ListIssues(ctx context.Context, opts ...RequestOption) ([]*Issue, error) {
-	v, err := s.base.ListIssues(ctx, toCoreOptions(opts)...)
-	return issuesFromModel(v), convertError(err)
-}
-
-// AddIssue adds an issue to the recently viewed list of the authenticated user.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-recently-viewed-issue
-func (s *UserRecentlyViewedService) AddIssue(ctx context.Context, issueID int) (*Issue, error) {
-	v, err := s.base.AddIssue(ctx, issueID)
-	return issueFromModel(v), convertError(err)
-}
-
-// ListProjects returns a list of projects recently viewed by the authenticated user.
-//
-// This method supports options returned by methods in "*Client.User.RecentlyViewed.Option",
-// such as:
-//   - WithCount
-//   - WithOffset
-//   - WithOrder
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-projects
-func (s *UserRecentlyViewedService) ListProjects(ctx context.Context, opts ...RequestOption) ([]*Project, error) {
-	v, err := s.base.ListProjects(ctx, toCoreOptions(opts)...)
-	return projectsFromModel(v), convertError(err)
-}
-
-// ListWikis returns a list of Wiki pages recently viewed by the authenticated user.
-//
-// This method supports options returned by methods in "*Client.User.RecentlyViewed.Option",
-// such as:
-//   - WithCount
-//   - WithOffset
-//   - WithOrder
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-recently-viewed-wikis
-func (s *UserRecentlyViewedService) ListWikis(ctx context.Context, opts ...RequestOption) ([]*Wiki, error) {
-	v, err := s.base.ListWikis(ctx, toCoreOptions(opts)...)
-	return wikisFromModel(v), convertError(err)
-}
-
-// AddWiki adds a Wiki page to the recently viewed list of the authenticated user.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-recently-viewed-wiki
-func (s *UserRecentlyViewedService) AddWiki(ctx context.Context, wikiID int) (*Wiki, error) {
-	v, err := s.base.AddWiki(ctx, wikiID)
-	return wikiFromModel(v), convertError(err)
-}
-
-// ──────────────────────────────────────────────────────────────
-//  UserRecentlyViewedOptionService
-// ──────────────────────────────────────────────────────────────
-
-// UserRecentlyViewedOptionService provides a domain-specific set of option builders
-// for operations within the UserRecentlyViewedService.
-type UserRecentlyViewedOptionService struct {
-	base *core.OptionService
-}
-
-// WithCount sets the number of results to return (1-100).
-func (s *UserRecentlyViewedOptionService) WithCount(count int) RequestOption {
-	return s.base.WithCount(count)
-}
-
-// WithOffset sets the number of items to skip.
-func (s *UserRecentlyViewedOptionService) WithOffset(offset int) RequestOption {
-	return s.base.WithOffset(offset)
-}
-
-// WithOrder sets the sort order of results.
-func (s *UserRecentlyViewedOptionService) WithOrder(order Order) RequestOption {
-	return s.base.WithOrder(model.Order(order))
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -332,9 +235,8 @@ func newUserService(method *core.Method, option *core.OptionService) *UserServic
 	return &UserService{
 		base: user.NewService(method),
 
-		Activity:       newUserActivityService(method, option),
-		RecentlyViewed: newUserRecentlyViewedService(method, option),
-		Star:           newUserStarService(method, option),
+		Activity: newUserActivityService(method, option),
+		Star:     newUserStarService(method, option),
 
 		Option: newUserOptionService(option),
 	}
@@ -347,13 +249,6 @@ func newUserActivityService(method *core.Method, option *core.OptionService) *Us
 	}
 }
 
-func newUserRecentlyViewedService(method *core.Method, option *core.OptionService) *UserRecentlyViewedService {
-	return &UserRecentlyViewedService{
-		base:   recentlyviewed.NewService(method),
-		Option: newUserRecentlyViewedOptionService(option),
-	}
-}
-
 func newUserStarService(method *core.Method, option *core.OptionService) *UserStarService {
 	return &UserStarService{
 		base:   user.NewStarService(method),
@@ -363,12 +258,6 @@ func newUserStarService(method *core.Method, option *core.OptionService) *UserSt
 
 func newUserOptionService(option *core.OptionService) *UserOptionService {
 	return &UserOptionService{
-		base: option,
-	}
-}
-
-func newUserRecentlyViewedOptionService(option *core.OptionService) *UserRecentlyViewedOptionService {
-	return &UserRecentlyViewedOptionService{
 		base: option,
 	}
 }


### PR DESCRIPTION
Implements a dedicated RecentlyViewedService at the top-level client scope and removes the redundant User.RecentlyViewed service hierarchy.

## Changes

* Added Client.RecentlyViewed service
* Added RecentlyViewedOptionService
* Moved recently viewed operations from:
    * Client.User.RecentlyViewed
    * to Client.RecentlyViewed
* Added examples for:
    * listing recently viewed issues/projects/wikis
    * adding recently viewed issues/wikis
* Updated option examples to use the new service structure
* Renamed and updated tests to reflect the new API surface
* Removed duplicated UserRecentlyViewedService and related option service implementations
* Improved internal service comments and constructor section organization

## Motivation

The recently viewed endpoints are scoped to the authenticated user (myself) and do not require a user ID. Exposing them under Client.User implied user-specific operations unnecessarily.

This change aligns the public API structure more closely with the Backlog API semantics and simplifies access patterns:

### Before:

```
c.User.RecentlyViewed.ListIssues(ctx)
```

### After:

```
c.RecentlyViewed.ListIssues(ctx)
```

Closes: #284 