### PR TITLE
docs: fix godoc comments across public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,6 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 ### Client.Wiki.[Star](https://pkg.go.dev/github.com/nattokin/go-backlog#WikiStarService)
 
 - [Get Wiki Page Star](https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-star) - Returns stars on a wiki page.
-- [Add Star](https://developer.nulab.com/docs/backlog/api/2/add-star) - Adds a star to a wiki page.
-- [Remove Star](https://developer.nulab.com/docs/backlog/api/2/remove-star) - Removes a star from a wiki page.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 
 ### Client.[Star](https://pkg.go.dev/github.com/nattokin/go-backlog#StarService)
 
-- [Add Star](https://developer.nulab.com/docs/backlog/api/2/add-star) - Add adds a star to a resource.
-- [Remove Star](https://developer.nulab.com/docs/backlog/api/2/remove-star) - Remove removes a star by its ID.
+- [Add Star](https://developer.nulab.com/docs/backlog/api/2/add-star) - Adds a star to a resource.
+- [Remove Star](https://developer.nulab.com/docs/backlog/api/2/remove-star) - Removes a star by its ID.
 
 ### Client.[User](https://pkg.go.dev/github.com/nattokin/go-backlog#UserService)
 
@@ -253,6 +253,8 @@ More examples can be found in the [examples/](examples/) directory and on [pkg.g
 ### Client.Wiki.[Star](https://pkg.go.dev/github.com/nattokin/go-backlog#WikiStarService)
 
 - [Get Wiki Page Star](https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-star) - Returns stars on a wiki page.
+- [Add Star](https://developer.nulab.com/docs/backlog/api/2/add-star) - Adds a star to a wiki page.
+- [Remove Star](https://developer.nulab.com/docs/backlog/api/2/remove-star) - Removes a star from a wiki page.
 
 ## License
 

--- a/client.go
+++ b/client.go
@@ -26,16 +26,24 @@ type Doer interface {
 type Client struct {
 	core *core.Client
 
-	// Service endpoints
-	Issue          *IssueService
-	Project        *ProjectService
-	PullRequest    *PullRequestService
+	// Issue provides access to issue-related API endpoints.
+	Issue *IssueService
+	// Project provides access to project-related API endpoints.
+	Project *ProjectService
+	// PullRequest provides access to pull request-related API endpoints.
+	PullRequest *PullRequestService
+	// RecentlyViewed provides access to recently viewed resource endpoints.
 	RecentlyViewed *RecentlyViewedService
-	Repository     *RepositoryService
-	Space          *SpaceService
-	Star           *StarService
-	User           *UserService
-	Wiki           *WikiService
+	// Repository provides access to Git repository endpoints.
+	Repository *RepositoryService
+	// Space provides access to space-related API endpoints.
+	Space *SpaceService
+	// Star provides access to star-related API endpoints.
+	Star *StarService
+	// User provides access to user-related API endpoints.
+	User *UserService
+	// Wiki provides access to wiki-related API endpoints.
+	Wiki *WikiService
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -43,11 +51,12 @@ type Client struct {
 // ──────────────────────────────────────────────────────────────
 
 // NewClient creates and initializes a Backlog API Client.
-// It requires a baseURL and an API token.
+// It requires a baseURL (e.g. "https://example.backlog.com") and an API token.
 //
-// This function supports options returned by package-level functions,
-// such as:
-//   - WithDoer
+// It returns an [*InternalClientError] if the base URL or token is invalid.
+//
+// Supported options:
+//   - [WithDoer]
 func NewClient(baseURL, token string, opts ...*ClientOption) (*Client, error) {
 	coreOpts := make([]*core.ClientOption, len(opts))
 	for i, o := range opts {

--- a/const.go
+++ b/const.go
@@ -5,7 +5,7 @@ import "fmt"
 // CustomFieldType represents the type identifier of a custom field.
 type CustomFieldType int
 
-// CustomFieldType constants for use with ProjectCustomFieldService.Create.
+// CustomFieldType constants for use with [ProjectCustomFieldService.Create].
 const (
 	CustomFieldTypeText         CustomFieldType = 1
 	CustomFieldTypeSentence     CustomFieldType = 2
@@ -20,7 +20,7 @@ const (
 // Format defines the text formatting rule for the Backlog wiki.
 type Format string
 
-// Format defines the text formatting rule for the Backlog wiki.
+// Available text formatting rules.
 const (
 	FormatMarkdown Format = "markdown"
 	FormatBacklog  Format = "backlog"
@@ -40,7 +40,7 @@ func (f Format) String() string {
 // IssueSort defines the field to sort issue list results by.
 type IssueSort string
 
-// IssueSort defines the field to sort issue list results by.
+// Available sort fields for issue list operations.
 const (
 	IssueSortIssueType      IssueSort = "issueType"
 	IssueSortCategory       IssueSort = "category"
@@ -66,7 +66,7 @@ const (
 // Order defines the sort order (ascending or descending).
 type Order string
 
-// Order defines the sort order (ascending or descending).
+// Available sort orders.
 const (
 	OrderAsc  Order = "asc"
 	OrderDesc Order = "desc"
@@ -86,7 +86,7 @@ func (o Order) String() string {
 // Role defines the type of user role within a project.
 type Role int
 
-// Role defines the type of user role within a project.
+// Available user roles within a project.
 const (
 	_ Role = iota
 	RoleAdministrator

--- a/error.go
+++ b/error.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Error represents one of the individual error entries in a Backlog API response.
-// It is a data structure used for decoding API responses and is not an error itself.
+// It is used as an element of [APIResponseError.Errors] and is not an error itself.
 type Error struct {
 	// Message is the detailed error message from the API.
 	Message  string
@@ -14,6 +14,7 @@ type Error struct {
 }
 
 // APIResponseError represents an error response from the Backlog API.
+// Use [errors.As] to check whether a returned error is an *APIResponseError.
 type APIResponseError struct {
 	core *core.APIResponseError
 }
@@ -37,7 +38,9 @@ func (e *APIResponseError) Errors() []*Error {
 	return out
 }
 
-// InvalidOptionKeyError represents an error for an invalid option key.
+// InvalidOptionKeyError is returned when an option method is called with a key
+// that is not valid for the target service method.
+// Use [errors.As] to check whether a returned error is an *InvalidOptionKeyError.
 type InvalidOptionKeyError struct {
 	core *core.InvalidOptionKeyError
 }
@@ -51,7 +54,9 @@ func (e *InvalidOptionKeyError) InvalidKey() string { return e.core.Invalid }
 // AllowKeys returns the list of allowed option keys.
 func (e *InvalidOptionKeyError) AllowKeys() []string { return e.core.ValidList }
 
-// ValidationError represents an argument validation error.
+// ValidationError is returned when a required argument fails validation
+// (e.g. an empty string where a non-empty value is required).
+// Use [errors.As] to check whether a returned error is a *ValidationError.
 type ValidationError struct {
 	core *core.ValidationError
 }
@@ -60,8 +65,9 @@ type ValidationError struct {
 func (e *ValidationError) Error() string { return e.core.Error() }
 
 // InternalClientError represents client-side configuration or usage errors.
-// It is distinct from API-level errors and indicates issues like missing Token
-// or malformed base URL.
+// It is distinct from API-level errors and indicates issues like a missing token
+// or a malformed base URL.
+// Use [errors.As] to check whether a returned error is an *InternalClientError.
 type InternalClientError struct {
 	core *core.InternalClientError
 }

--- a/models.go
+++ b/models.go
@@ -7,7 +7,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/model"
 )
 
-// Attachment represents an attached file.
+// Attachment represents a file attached to an issue, wiki page, or pull request.
 type Attachment struct {
 	ID          int
 	Name        string
@@ -35,7 +35,7 @@ type ActivityContent struct {
 	Comment     *Comment
 }
 
-// Category represents an category.
+// Category represents a project category.
 type Category struct {
 	ID           int
 	Name         string
@@ -49,7 +49,7 @@ type ChangeLog struct {
 	OriginalValue string
 }
 
-// Comment represents any one comment.
+// Comment represents a comment on an issue or pull request.
 type Comment struct {
 	ID            int
 	Content       string
@@ -73,14 +73,14 @@ type CustomField struct {
 	Items                  []*CustomFieldItem
 }
 
-// CustomFieldItem represents one of Items in CustomField.
+// CustomFieldItem represents one item in a list type [CustomField].
 type CustomFieldItem struct {
 	ID           int
 	Name         string
 	DisplayOrder int
 }
 
-// DiskUsageBase represents base of disk usage.
+// DiskUsageBase represents the disk usage breakdown by storage type.
 type DiskUsageBase struct {
 	Issue      int
 	Wiki       int
@@ -98,7 +98,7 @@ type FileData struct {
 	ContentType string
 }
 
-// Licence represents licence.
+// Licence represents the licence information for a Backlog space.
 type Licence struct {
 	Active                            bool
 	AttachmentLimit                   int
@@ -135,7 +135,7 @@ type Licence struct {
 	WikiAttachmentNumLimit            int
 }
 
-// Notification represents some notification.
+// Notification represents a notification delivered to a user.
 type Notification struct {
 	ID                  int
 	AlreadyRead         bool
@@ -163,7 +163,7 @@ type SharedFile struct {
 	Updated     time.Time
 }
 
-// Star represents any Star.
+// Star represents a star added to an issue, wiki page, or pull request.
 type Star struct {
 	ID        int
 	Comment   string
@@ -182,13 +182,13 @@ type Status struct {
 	DisplayOrder int
 }
 
-// Tag represents one of tags in Wiki.
+// Tag represents a tag attached to a wiki page.
 type Tag struct {
 	ID   int
 	Name string
 }
 
-// Team represents team.
+// Team represents a team within a space.
 type Team struct {
 	ID           int
 	Name         string
@@ -200,7 +200,7 @@ type Team struct {
 	Updated      time.Time
 }
 
-// Version represents any version.
+// Version represents a version or milestone in a project.
 type Version struct {
 	ID             int
 	ProjectID      int
@@ -212,7 +212,7 @@ type Version struct {
 	DisplayOrder   int
 }
 
-// WatchingItem represents an item of watching list.
+// WatchingItem represents an item in a user's watching list.
 type WatchingItem struct {
 	ID                  int
 	ResourceAlreadyRead bool


### PR DESCRIPTION
## Summary

Fix inaccurate, redundant, or missing doc comments across the public API surface, identified by reviewing pkg.go.dev.

## Changes

### `const.go`
- Remove duplicate `const` block comments that repeated the `type` comment verbatim (`Format`, `IssueSort`, `Order`, `Role`)
- Replace duplicates with concise, descriptive summaries ("Available text formatting rules.", etc.)
- Add a doc link to `[ProjectCustomFieldService.Create]` in the `CustomFieldType` constant block comment

### `models.go`
- `Category`: fix "an category" → "a project category"
- `Comment`: fix "any one comment" → "a comment on an issue or pull request"
- `CustomFieldItem`: add reference to `[CustomField]`
- `DiskUsageBase`: fix "base of disk usage" → "disk usage breakdown by storage type"
- `Licence`: fix tautological comment → "licence information for a Backlog space"
- `Notification`: fix "some notification" → "a notification delivered to a user"
- `Star`: fix "any Star" → "a star added to an issue, wiki page, or pull request"
- `Tag`: fix "one of tags in Wiki" → "a tag attached to a wiki page"
- `Team`: fix "represents team" → "a team within a space"
- `Version`: fix "any version" → "a version or milestone in a project"
- `WatchingItem`: fix "an item of watching list" → "an item in a user's watching list"
- `Attachment`: clarify "attached to an issue, wiki page, or pull request"

### `error.go`
- `Error`: clarify it is used as an element of `[APIResponseError.Errors]`, not an error itself
- `APIResponseError`, `InvalidOptionKeyError`, `ValidationError`, `InternalClientError`: add `errors.As` usage hint to each type comment
- `InvalidOptionKeyError`: improve description to reflect when the error is returned
- `ValidationError`: improve description to reflect when the error is returned

### `client.go`
- `Client` struct fields: add per-field doc comments (`// Issue provides access to ...`)
- `NewClient`: clarify `baseURL` format with an example, add `[*InternalClientError]` error return note, rewrite options list using `[WithDoer]` doc link

### `README.md`
- `Client.Star`: fix "Add adds a star" / "Remove removes a star" (method name leaked into description)