### PR TITLE
docs: unify comment style in internal/user

### DIFF
--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -1,3 +1,4 @@
+// Package user implements the Backlog User API service.
 package user
 
 import (
@@ -11,6 +12,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// getUser is a shared helper that fetches a single user from the given spath.
 func getUser(ctx context.Context, m *core.Method, spath string) (*model.User, error) {
 	resp, err := m.Get(ctx, spath, nil)
 	if err != nil {
@@ -29,6 +31,9 @@ type Service struct {
 	method *core.Method
 }
 
+// All returns a list of all users in the space.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-list
 func (s *Service) All(ctx context.Context) ([]*model.User, error) {
 	resp, err := s.method.Get(ctx, "users", nil)
 	if err != nil {
@@ -43,6 +48,9 @@ func (s *Service) All(ctx context.Context) ([]*model.User, error) {
 	return v, nil
 }
 
+// One returns a single user by ID.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user
 func (s *Service) One(ctx context.Context, id int) (*model.User, error) {
 	if err := validate.ValidateUserID(id); err != nil {
 		return nil, err
@@ -52,10 +60,16 @@ func (s *Service) One(ctx context.Context, id int) (*model.User, error) {
 	return getUser(ctx, s.method, spath)
 }
 
+// Own returns the currently authenticated user.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-own-user
 func (s *Service) Own(ctx context.Context) (*model.User, error) {
 	return getUser(ctx, s.method, "users/myself")
 }
 
+// Add adds a new user to the space.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-user
 func (s *Service) Add(ctx context.Context, userID, password, name, mailAddress string, roleType model.Role) (*model.User, error) {
 	if userID == "" {
 		return nil, core.NewValidationError("userID must not be empty")
@@ -89,6 +103,9 @@ func (s *Service) Add(ctx context.Context, userID, password, name, mailAddress s
 	return &v, nil
 }
 
+// Update updates an existing user.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-user
 func (s *Service) Update(ctx context.Context, id int, option core.RequestOption, opts ...core.RequestOption) (*model.User, error) {
 	baseOpt := &core.OptionService{}
 	form := url.Values{}
@@ -111,9 +128,11 @@ func (s *Service) Update(ctx context.Context, id int, option core.RequestOption,
 	}
 
 	return &v, nil
-
 }
 
+// Delete deletes a user by ID.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-user
 func (s *Service) Delete(ctx context.Context, id int) (*model.User, error) {
 	if err := validate.ValidateUserID(id); err != nil {
 		return nil, err
@@ -133,6 +152,10 @@ func (s *Service) Delete(ctx context.Context, id int) (*model.User, error) {
 	return &v, nil
 }
 
+// Icon downloads the icon image of the user.
+// The caller is responsible for closing FileData.Body after use.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-icon
 func (s *Service) Icon(ctx context.Context, id int) (*model.FileData, error) {
 	if err := validate.ValidateUserID(id); err != nil {
 		return nil, err
@@ -146,10 +169,6 @@ func (s *Service) Icon(ctx context.Context, id int) (*model.FileData, error) {
 
 	return core.DownloadResponse(resp)
 }
-
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
 
 func NewService(method *core.Method) *Service {
 	return &Service{

--- a/internal/user/service_activity.go
+++ b/internal/user/service_activity.go
@@ -11,11 +11,16 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// ActivityService handles user activity-related Backlog API calls.
+// It delegates HTTP operations to the shared activity.Service.
 type ActivityService struct {
 	base   *activity.Service
 	method *core.Method
 }
 
+// List returns a list of activities for the user.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates
 func (s *ActivityService) List(ctx context.Context, userID int, opts ...core.RequestOption) ([]*model.Activity, error) {
 	if err := validate.ValidateUserID(userID); err != nil {
 		return nil, err
@@ -24,10 +29,6 @@ func (s *ActivityService) List(ctx context.Context, userID int, opts ...core.Req
 	spath := path.Join("users", strconv.Itoa(userID), "activities")
 	return s.base.List(ctx, spath, opts...)
 }
-
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
 
 func NewActivityService(method *core.Method) *ActivityService {
 	return &ActivityService{

--- a/internal/user/service_star.go
+++ b/internal/user/service_star.go
@@ -11,23 +11,12 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// ──────────────────────────────────────────────────────────────
-//  UserService
-// ──────────────────────────────────────────────────────────────
-
-// StarService handles communication with the user star-related methods of the Backlog API.
+// StarService handles user star-related Backlog API calls.
 type StarService struct {
 	method *core.Method
 }
 
-// List returns a list of stars received by the user with the given ID.
-//
-// This method supports options returned by methods in "*Client.User.Star.Option",
-// such as:
-//   - WithCount
-//   - WithMaxID
-//   - WithMinID
-//   - WithOrder
+// List returns a list of stars received by the user.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-received-star-list
 func (s *StarService) List(ctx context.Context, userID int, opts ...core.RequestOption) ([]*model.Star, error) {
@@ -55,7 +44,7 @@ func (s *StarService) List(ctx context.Context, userID int, opts ...core.Request
 	return v, nil
 }
 
-// Count returns the number of stars received by the user with the given ID.
+// Count returns the number of stars received by the user.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-user-received-stars
 func (s *StarService) Count(ctx context.Context, userID int) (int, error) {
@@ -79,11 +68,6 @@ func (s *StarService) Count(ctx context.Context, userID int) (int, error) {
 	return v.Count, nil
 }
 
-// ──────────────────────────────────────────────────────────────
-//  Constructor
-// ──────────────────────────────────────────────────────────────
-
-// NewStarService creates and returns a new user StarService.
 func NewStarService(method *core.Method) *StarService {
 	return &StarService{method: method}
 }


### PR DESCRIPTION
## Summary

Unify comment style across `internal/user` as part of the broader effort to standardize comments throughout all `internal` packages.

## Changes

- Add package-level doc comment to `service.go`
- Add `// Backlog API docs:` URL comments to all methods in `service.go` and `service_activity.go` (were missing)
- Add struct comment to `ActivityService` (was missing)
- Add a brief inline comment to `getUser` to clarify its role as a shared helper
- Remove decorative section dividers (`// ──────...`) from all files
- Remove constructor comments — self-evident from the function name
- Remove the supported-options list from `StarService.List` — valid option keys are already enforced by `ApplyOptions` and visible in the implementation