### PR TITLE
docs: unify comment style in internal/space

### DIFF
--- a/internal/space/service.go
+++ b/internal/space/service.go
@@ -1,3 +1,4 @@
+// Package space implements the Backlog Space API service.
 package space
 
 import (
@@ -8,6 +9,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/model"
 )
 
+// Service handles space-related Backlog API calls.
 type Service struct {
 	method *core.Method
 }
@@ -88,10 +90,6 @@ func (s *Service) UpdateNotification(ctx context.Context, content string) (*mode
 
 	return &v, nil
 }
-
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
 
 func NewService(method *core.Method) *Service {
 	return &Service{

--- a/internal/space/service_activity.go
+++ b/internal/space/service_activity.go
@@ -11,11 +11,16 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// ActivityService handles space activity-related Backlog API calls.
+// It delegates list operations to the shared activity.Service.
 type ActivityService struct {
 	base   *activity.Service
 	method *core.Method
 }
 
+// List returns a list of activities in the space.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-space-activities
 func (s *ActivityService) List(ctx context.Context, opts ...core.RequestOption) ([]*model.Activity, error) {
 	return s.base.List(ctx, "space/activities", opts...)
 }
@@ -41,10 +46,6 @@ func (s *ActivityService) Get(ctx context.Context, activityID int) (*model.Activ
 
 	return &v, nil
 }
-
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
 
 func NewActivityService(method *core.Method) *ActivityService {
 	return &ActivityService{

--- a/internal/space/service_attachment.go
+++ b/internal/space/service_attachment.go
@@ -9,14 +9,13 @@ import (
 )
 
 // AttachmentService handles attachment-related Backlog API calls for a space.
-// It delegates all HTTP operations to the shared attachment.Service.
 type AttachmentService struct {
 	method *core.Method
 }
 
-// Upload uploads any file to the space.
-//
+// Upload uploads a file to the space.
 // The file name must not be empty.
+// The caller is responsible for closing the reader after use.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/post-attachment-file
 func (s *AttachmentService) Upload(ctx context.Context, fileName string, r io.Reader) (*model.Attachment, error) {
@@ -31,14 +30,8 @@ func (s *AttachmentService) Upload(ctx context.Context, fileName string, r io.Re
 	}
 
 	return &v, nil
-
 }
 
-// ──────────────────────────────────────────────────────────────
-//  Constructor
-// ──────────────────────────────────────────────────────────────
-
-// NewAttachmentService creates and returns a new space AttachmentService.
 func NewAttachmentService(method *core.Method) *AttachmentService {
 	return &AttachmentService{method: method}
 }


### PR DESCRIPTION
## Summary

Unify comment style across `internal/space` as part of the broader effort to standardize comments throughout all `internal` packages.

## Changes

- Add package-level doc comment to `service.go`
- Add struct comment to `Service` and `ActivityService` (were missing)
- Add `// Backlog API docs:` URL comment to `ActivityService.List` (was missing)
- Add caller-responsibility note to `AttachmentService.Upload` (reader is not closed internally)
- Remove decorative section dividers (`// ──────...`) from all files
- Remove constructor comments — self-evident from the function name
- Remove redundant delegation note from `AttachmentService` struct comment