### PR TITLE
docs: unify comment style in internal/repository

### DIFF
--- a/internal/repository/service.go
+++ b/internal/repository/service.go
@@ -1,3 +1,4 @@
+// Package repository implements the Backlog Git Repository API service.
 package repository
 
 import (
@@ -10,6 +11,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// Service handles git repository-related Backlog API calls.
 type Service struct {
 	method *core.Method
 }
@@ -36,7 +38,7 @@ func (s *Service) All(ctx context.Context, projectIDOrKey string) ([]*model.Repo
 	return v, nil
 }
 
-// One returns information about a specific Git repository.
+// One returns a specific Git repository.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-git-repository
 func (s *Service) One(ctx context.Context, projectIDOrKey string, repoIDOrName string) (*model.Repository, error) {
@@ -60,10 +62,6 @@ func (s *Service) One(ctx context.Context, projectIDOrKey string, repoIDOrName s
 
 	return &v, nil
 }
-
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
 
 func NewService(method *core.Method) *Service {
 	return &Service{


### PR DESCRIPTION
## Summary

Unify comment style across `internal/repository` as part of the broader effort to standardize comments throughout all `internal` packages.

## Changes

- Add package-level doc comment
- Add struct comment to `Service` (was missing)
- Tighten `One` method comment (removed "information about a specific" boilerplate)
- Remove decorative section divider (`// ──────...`)
- Remove constructor comment — self-evident from the function name