### PR TITLE
docs: unify comment style in internal/pullrequest

### DIFF
--- a/internal/pullrequest/service.go
+++ b/internal/pullrequest/service.go
@@ -1,3 +1,4 @@
+// Package pullrequest implements the Backlog Pull Request API service.
 package pullrequest
 
 import (
@@ -11,6 +12,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// Service handles pull request-related Backlog API calls.
 type Service struct {
 	method *core.Method
 }
@@ -208,10 +210,6 @@ func (s *Service) Update(ctx context.Context, projectIDOrKey string, repoIDOrNam
 
 	return &v, nil
 }
-
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
 
 func NewService(method *core.Method) *Service {
 	return &Service{

--- a/internal/pullrequest/service_attachment.go
+++ b/internal/pullrequest/service_attachment.go
@@ -18,7 +18,7 @@ type AttachmentService struct {
 	base *attachment.Service
 }
 
-// List returns a list of all attachments in the pull request.
+// List returns a list of attachments on the pull request.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-pull-request-attachment
 func (s *AttachmentService) List(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int) ([]*model.Attachment, error) {
@@ -36,7 +36,7 @@ func (s *AttachmentService) List(ctx context.Context, projectIDOrKey string, rep
 	return s.base.List(ctx, spath)
 }
 
-// Remove removes a file attached to the pull request.
+// Remove removes an attachment from the pull request.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-pull-request-attachments
 func (s *AttachmentService) Remove(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*model.Attachment, error) {
@@ -57,7 +57,7 @@ func (s *AttachmentService) Remove(ctx context.Context, projectIDOrKey string, r
 	return s.base.Remove(ctx, spath)
 }
 
-// Download downloads a file attached to the pull request.
+// Download downloads an attachment from the pull request.
 // The caller is responsible for closing FileData.Body after use.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/download-pull-request-attachment
@@ -79,11 +79,6 @@ func (s *AttachmentService) Download(ctx context.Context, projectIDOrKey string,
 	return s.base.Download(ctx, spath)
 }
 
-// ──────────────────────────────────────────────────────────────
-//  Constructor
-// ──────────────────────────────────────────────────────────────
-
-// NewAttachmentService creates and returns a new pullrequest AttachmentService.
 func NewAttachmentService(method *core.Method) *AttachmentService {
 	return &AttachmentService{base: attachment.NewService(method)}
 }

--- a/internal/pullrequest/service_comment.go
+++ b/internal/pullrequest/service_comment.go
@@ -11,18 +11,14 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// CommentService handles communication with the pull request comment-related methods of the Backlog API.
+// CommentService handles pull request comment-related Backlog API calls.
+// It delegates all HTTP operations to the shared comment.Service and is
+// responsible only for validation and spath construction.
 type CommentService struct {
 	base *comment.Service
 }
 
 // All returns a list of comments on a pull request.
-//
-// This method supports options:
-//   - WithMinID
-//   - WithMaxID
-//   - WithCount
-//   - WithOrder
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-comment
 func (s *CommentService) All(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, opts ...core.RequestOption) ([]*model.Comment, error) {
@@ -41,10 +37,6 @@ func (s *CommentService) All(ctx context.Context, projectIDOrKey string, repoIDO
 }
 
 // Add adds a comment to a pull request.
-//
-// This method supports options:
-//   - WithNotifiedUserIDs
-//   - WithAttachmentIDs
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-pull-request-comment
 func (s *CommentService) Add(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, content string, opts ...core.RequestOption) (*model.Comment, error) {
@@ -80,7 +72,7 @@ func (s *CommentService) Count(ctx context.Context, projectIDOrKey string, repoI
 	return s.base.Count(ctx, spath)
 }
 
-// One returns information about a specific comment on a pull request.
+// One returns a single comment on a pull request.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-comment
 func (s *CommentService) One(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, commentID int) (*model.Comment, error) {
@@ -122,11 +114,6 @@ func (s *CommentService) Update(ctx context.Context, projectIDOrKey string, repo
 	return s.base.Update(ctx, spath, content)
 }
 
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
-
-// NewCommentService creates and returns a new pullrequest CommentService.
 func NewCommentService(method *core.Method) *CommentService {
 	return &CommentService{
 		base: comment.NewService(method),


### PR DESCRIPTION
## Summary

Unify comment style across `internal/pullrequest` as part of the broader effort to standardize comments throughout all `internal` packages.

## Changes

- Add package-level doc comment to `service.go`
- Add struct comment to `Service` (was missing)
- Expand `CommentService` struct comment to include delegation note (consistent with `AttachmentService`)
- Remove supported-options lists from `CommentService.All` and `CommentService.Add` — valid option keys are enforced by `ApplyOptions` and visible in the implementation
- Tighten `CommentService.One` method comment (removed "information about a specific" boilerplate)
- Remove decorative section dividers (`// ──────...`) from all files
- Remove constructor comments — self-evident from the function name