### PR TITLE
docs: unify comment style in internal/project

### DIFF
--- a/internal/project/service.go
+++ b/internal/project/service.go
@@ -1,3 +1,4 @@
+// Package project implements the Backlog Project API service.
 package project
 
 import (
@@ -11,10 +12,14 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// Service handles project-related Backlog API calls.
 type Service struct {
 	method *core.Method
 }
 
+// All returns a list of projects in the space.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-list
 func (s *Service) All(ctx context.Context, opts ...core.RequestOption) ([]*model.Project, error) {
 
 	query := url.Values{}
@@ -36,6 +41,9 @@ func (s *Service) All(ctx context.Context, opts ...core.RequestOption) ([]*model
 	return v, nil
 }
 
+// One returns a single project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project
 func (s *Service) One(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -55,6 +63,9 @@ func (s *Service) One(ctx context.Context, projectIDOrKey string) (*model.Projec
 	return &v, nil
 }
 
+// Create creates a new project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-project
 func (s *Service) Create(ctx context.Context, key, name string, opts ...core.RequestOption) (*model.Project, error) {
 	option := &core.OptionService{}
 
@@ -78,6 +89,9 @@ func (s *Service) Create(ctx context.Context, key, name string, opts ...core.Req
 	return &v, nil
 }
 
+// Update updates a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-project
 func (s *Service) Update(ctx context.Context, projectIDOrKey string, option core.RequestOption, opts ...core.RequestOption) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -107,6 +121,9 @@ func (s *Service) Update(ctx context.Context, projectIDOrKey string, option core
 	return &v, nil
 }
 
+// Delete deletes a project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-project
 func (s *Service) Delete(ctx context.Context, projectIDOrKey string) (*model.Project, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -149,6 +166,7 @@ func (s *Service) DiskUsage(ctx context.Context, projectIDOrKey string) (*model.
 }
 
 // Icon returns the icon image of a project.
+// The caller is responsible for closing FileData.Body after use.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-icon
 func (s *Service) Icon(ctx context.Context, projectIDOrKey string) (*model.FileData, error) {
@@ -165,11 +183,7 @@ func (s *Service) Icon(ctx context.Context, projectIDOrKey string) (*model.FileD
 	return core.DownloadResponse(resp)
 }
 
-// ──────────────────────────────────────────────────────────────
-//  CategoryService
-// ──────────────────────────────────────────────────────────────
-
-// CategoryService handles communication with the category-related methods of the Backlog API.
+// CategoryService handles category-related Backlog API calls for a project.
 type CategoryService struct {
 	method *core.Method
 }
@@ -282,11 +296,7 @@ func (s *CategoryService) Delete(ctx context.Context, projectIDOrKey string, cat
 	return &v, nil
 }
 
-// ──────────────────────────────────────────────────────────────
-//  IssueTypeService
-// ──────────────────────────────────────────────────────────────
-
-// IssueTypeService handles communication with the issue-type-related methods of the Backlog API.
+// IssueTypeService handles issue type-related Backlog API calls for a project.
 type IssueTypeService struct {
 	method *core.Method
 }
@@ -376,6 +386,7 @@ func (s *IssueTypeService) Update(ctx context.Context, projectIDOrKey string, is
 }
 
 // Delete deletes an issue type from a project.
+// substituteIssueTypeID specifies the issue type to migrate existing issues to.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-issue-type
 func (s *IssueTypeService) Delete(ctx context.Context, projectIDOrKey string, issueTypeID, substituteIssueTypeID int) (*model.IssueType, error) {
@@ -406,11 +417,7 @@ func (s *IssueTypeService) Delete(ctx context.Context, projectIDOrKey string, is
 	return &v, nil
 }
 
-// ──────────────────────────────────────────────────────────────
-//  StatusService
-// ──────────────────────────────────────────────────────────────
-
-// StatusService handles communication with the status-related methods of the Backlog API.
+// StatusService handles status-related Backlog API calls for a project.
 type StatusService struct {
 	method *core.Method
 }
@@ -506,6 +513,7 @@ func (s *StatusService) Update(ctx context.Context, projectIDOrKey string, statu
 }
 
 // Delete deletes a status from a project.
+// substituteStatusID specifies the status to migrate existing issues to.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-status
 func (s *StatusService) Delete(ctx context.Context, projectIDOrKey string, statusID, substituteStatusID int) (*model.Status, error) {
@@ -570,10 +578,6 @@ func (s *StatusService) UpdateOrder(ctx context.Context, projectIDOrKey string, 
 
 	return v, nil
 }
-
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
 
 func NewService(method *core.Method) *Service {
 	return &Service{

--- a/internal/project/service_activity.go
+++ b/internal/project/service_activity.go
@@ -10,11 +10,16 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// ActivityService handles project activity-related Backlog API calls.
+// It delegates HTTP operations to the shared activity.Service.
 type ActivityService struct {
 	base   *activity.Service
 	method *core.Method
 }
 
+// List returns a list of activities in the project.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates
 func (s *ActivityService) List(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Activity, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
@@ -23,10 +28,6 @@ func (s *ActivityService) List(ctx context.Context, projectIDOrKey string, opts 
 	spath := path.Join("projects", projectIDOrKey, "activities")
 	return s.base.List(ctx, spath, opts...)
 }
-
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
 
 func NewActivityService(method *core.Method) *ActivityService {
 	return &ActivityService{

--- a/internal/project/service_customfield.go
+++ b/internal/project/service_customfield.go
@@ -11,12 +11,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// ──────────────────────────────────────────────────────────────
-//  CustomFieldService
-// ──────────────────────────────────────────────────────────────
-
-// CustomFieldService handles communication with the custom-field-related
-// methods of the Backlog API.
+// CustomFieldService handles custom field-related Backlog API calls for a project.
 type CustomFieldService struct {
 	method *core.Method
 }
@@ -44,36 +39,6 @@ func (s *CustomFieldService) All(ctx context.Context, projectIDOrKey string) ([]
 }
 
 // Create adds a new custom field to a project.
-//
-// fieldType specifies the custom field type. Use the model.CustomFieldType constants:
-//   - model.CustomFieldTypeText
-//   - model.CustomFieldTypeSentence
-//   - model.CustomFieldTypeNumber
-//   - model.CustomFieldTypeDate
-//   - model.CustomFieldTypeSingleList
-//   - model.CustomFieldTypeMultipleList
-//   - model.CustomFieldTypeCheckbox
-//   - model.CustomFieldTypeRadio
-//
-// Common options (all types):
-//   - WithDescription
-//   - WithRequired
-//   - WithApplicableIssueTypeIDs
-//
-// Number type (CustomFieldTypeNumber) additional options:
-//   - WithMin, WithMax, WithInitialValue (float64)
-//   - WithUnit
-//
-// Date type (CustomFieldTypeDate) additional options:
-//   - WithInitialDateMin, WithInitialDateMax ("yyyy-MM-dd")
-//   - WithInitialValueType (1: today, 2: today+N, 3: specified date)
-//   - WithInitialShift (days, when initialValueType=2)
-//   - WithInitialDate ("yyyy-MM-dd", when initialValueType=3)
-//
-// List type (CustomFieldTypeSingleList/MultipleList/Checkbox/Radio) additional options:
-//   - WithItems
-//   - WithAllowInput
-//   - WithAllowAddItem
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-custom-field
 func (s *CustomFieldService) Create(ctx context.Context, projectIDOrKey string, fieldType model.CustomFieldType, name string, opts ...core.RequestOption) (*model.CustomField, error) {
@@ -116,12 +81,6 @@ func (s *CustomFieldService) Create(ctx context.Context, projectIDOrKey string, 
 }
 
 // Update updates a custom field in a project.
-//
-// At least one option must be provided. Supported options:
-//   - WithName
-//   - WithDescription
-//   - WithRequired
-//   - WithApplicableIssueTypeIDs
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-custom-field
 func (s *CustomFieldService) Update(ctx context.Context, projectIDOrKey string, customFieldID int, option core.RequestOption, opts ...core.RequestOption) (*model.CustomField, error) {
@@ -275,10 +234,6 @@ func (s *CustomFieldService) DeleteListItem(ctx context.Context, projectIDOrKey 
 
 	return &v, nil
 }
-
-// ──────────────────────────────────────────────────────────────
-//  Constructor
-// ──────────────────────────────────────────────────────────────
 
 func NewCustomFieldService(method *core.Method) *CustomFieldService {
 	return &CustomFieldService{method: method}

--- a/internal/project/service_sharedfile.go
+++ b/internal/project/service_sharedfile.go
@@ -10,8 +10,9 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// SharedFileService handles communication with the project shared-file-related methods of the Backlog API.
-// Kept here because GetFile is project-specific and does not fit the shared spath-agnostic pattern.
+// SharedFileService handles project shared-file-related Backlog API calls.
+// Kept separate from internal/sharedfile because GetFile is project-specific
+// and does not fit the spath-agnostic pattern used by that package.
 type SharedFileService struct {
 	method *core.Method
 }
@@ -39,6 +40,7 @@ func (s *SharedFileService) List(ctx context.Context, projectIDOrKey string) ([]
 }
 
 // GetFile downloads a shared file from the project.
+// The caller is responsible for closing FileData.Body after use.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-file
 func (s *SharedFileService) GetFile(ctx context.Context, projectIDOrKey string, sharedFileID int) (*model.FileData, error) {
@@ -58,7 +60,6 @@ func (s *SharedFileService) GetFile(ctx context.Context, projectIDOrKey string, 
 	return core.DownloadResponse(resp)
 }
 
-// NewSharedFileService creates and returns a new project SharedFileService.
 func NewSharedFileService(method *core.Method) *SharedFileService {
 	return &SharedFileService{method: method}
 }

--- a/internal/project/service_user.go
+++ b/internal/project/service_user.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// getUserList is a shared helper that fetches a list of users from the given spath.
 func getUserList(ctx context.Context, m *core.Method, spath string, query url.Values) ([]*model.User, error) {
 	resp, err := m.Get(ctx, spath, query)
 	if err != nil {
@@ -25,6 +26,7 @@ func getUserList(ctx context.Context, m *core.Method, spath string, query url.Va
 	return v, nil
 }
 
+// addUser is a shared helper that adds a user by ID via POST to the given spath.
 func addUser(ctx context.Context, m *core.Method, spath string, userID int) (*model.User, error) {
 	form := url.Values{}
 	form.Set("userId", strconv.Itoa(userID))
@@ -42,6 +44,7 @@ func addUser(ctx context.Context, m *core.Method, spath string, userID int) (*mo
 	return &v, nil
 }
 
+// deleteUser is a shared helper that removes a user by ID via DELETE to the given spath.
 func deleteUser(ctx context.Context, m *core.Method, spath string, userID int) (*model.User, error) {
 	form := url.Values{}
 	form.Set("userId", strconv.Itoa(userID))
@@ -59,7 +62,7 @@ func deleteUser(ctx context.Context, m *core.Method, spath string, userID int) (
 	return &v, nil
 }
 
-// UserService handles communication with the project user-related methods of the Backlog API.
+// UserService handles project user-related Backlog API calls.
 type UserService struct {
 	method *core.Method
 }
@@ -155,7 +158,6 @@ func (s *UserService) DeleteAdmin(ctx context.Context, projectIDOrKey string, us
 	return deleteUser(ctx, s.method, spath, userID)
 }
 
-// NewUserService creates and returns a new project UserService.
 func NewUserService(method *core.Method) *UserService {
 	return &UserService{method: method}
 }

--- a/internal/project/service_webhook.go
+++ b/internal/project/service_webhook.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// WebhookService handles communication with the webhook related methods of the Backlog API.
+// WebhookService handles webhook-related Backlog API calls for a project.
 type WebhookService struct {
 	method *core.Method
 }
@@ -89,7 +89,7 @@ func (s *WebhookService) Add(ctx context.Context, projectIDOrKey, name, hookURL 
 	return v, nil
 }
 
-// Get returns information about a specific webhook.
+// Get returns a single webhook.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-webhook/
 func (s *WebhookService) Get(ctx context.Context, projectIDOrKey string, webhookID int) (*model.Webhook, error) {
@@ -184,11 +184,6 @@ func (s *WebhookService) Delete(ctx context.Context, projectIDOrKey string, webh
 	return v, nil
 }
 
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
-
-// NewWebhookService creates and returns a new webhook WebhookService.
 func NewWebhookService(method *core.Method) *WebhookService {
 	return &WebhookService{method: method}
 }


### PR DESCRIPTION
## Summary

Unify comment style across `internal/project` as part of the broader effort to standardize comments throughout all `internal` packages.

## Changes

### service.go
- Add package-level doc comment
- Add struct comments to `Service`, `CategoryService`, `IssueTypeService`, `StatusService` (were missing)
- Add `// Backlog API docs:` URL comments to `All`, `One`, `Create`, `Update`, `Delete` on `Service` (were missing)
- Add caller-responsibility note to `Service.Icon` (FileData.Body)
- Add `substituteIssueTypeID` / `substituteStatusID` purpose notes to `IssueTypeService.Delete` and `StatusService.Delete`
- Remove decorative section dividers (`// ──────...`) from all service type blocks
- Remove constructor comments — self-evident from the function name

### service_activity.go
- Add struct comment and `// Backlog API docs:` URL to `ActivityService.List` (were missing)
- Remove decorative section divider and constructor comment

### service_customfield.go
- Remove decorative section divider and constructor comment
- Remove `fieldType` enum listing and per-type option listing from `CustomFieldService.Create` — implementation already groups params by type via inline comments
- Remove "At least one option must be provided" note from `CustomFieldService.Update` — enforced at the option level

### service_sharedfile.go
- Rephrase struct comment to better explain the design reason for not using `internal/sharedfile`
- Add caller-responsibility note to `GetFile` (FileData.Body)
- Remove constructor comment

### service_user.go
- Add brief inline comments to `getUserList`, `addUser`, `deleteUser` helpers
- Remove constructor comment

### service_webhook.go
- Tighten `WebhookService.Get` comment (removed "information about a specific" boilerplate)
- Remove decorative section divider and constructor comment