### PR TITLE
docs: unify comment style in internal/comment

### DIFF
--- a/internal/comment/service.go
+++ b/internal/comment/service.go
@@ -1,3 +1,4 @@
+// Package comment implements shared HTTP logic for comment-related Backlog API endpoints.
 package comment
 
 import (
@@ -118,11 +119,6 @@ func (s *Service) Update(ctx context.Context, spath, content string) (*model.Com
 	return &v, nil
 }
 
-// ──────────────────────────────────────────────────────────────
-//  Constructor
-// ──────────────────────────────────────────────────────────────
-
-// NewService creates and returns a new comment Service.
 func NewService(method *core.Method) *Service {
 	return &Service{method: method}
 }


### PR DESCRIPTION
## Summary

Unify comment style across `internal/comment` as part of the broader effort to standardize comments throughout all `internal` packages.

## Changes

- Add package-level doc comment
- Remove decorative section divider (`// ──────...`)
- Remove constructor comment — self-evident from the function name
- Retain the "spath-agnostic" note on the struct — documents the non-obvious design constraint shared across all callers