### PR TITLE
docs: unify comment style in internal/attachment

### DIFF
--- a/internal/attachment/service.go
+++ b/internal/attachment/service.go
@@ -1,3 +1,4 @@
+// Package attachment implements shared HTTP logic for attachment-related Backlog API endpoints.
 package attachment
 
 import (
@@ -14,7 +15,6 @@ type Service struct {
 	method *core.Method
 }
 
-// List returns the list of attachments at spath.
 func (s *Service) List(ctx context.Context, spath string) ([]*model.Attachment, error) {
 	resp, err := s.method.Get(ctx, spath, nil)
 	if err != nil {
@@ -29,7 +29,6 @@ func (s *Service) List(ctx context.Context, spath string) ([]*model.Attachment, 
 	return v, nil
 }
 
-// Remove deletes the attachment at spath and returns the deleted attachment.
 func (s *Service) Remove(ctx context.Context, spath string) (*model.Attachment, error) {
 	resp, err := s.method.Delete(ctx, spath, nil)
 	if err != nil {
@@ -45,6 +44,7 @@ func (s *Service) Remove(ctx context.Context, spath string) (*model.Attachment, 
 }
 
 // Download streams the attachment at spath.
+// The caller is responsible for closing FileData.Body after use.
 func (s *Service) Download(ctx context.Context, spath string) (*model.FileData, error) {
 	resp, err := s.method.Download(ctx, spath, nil)
 	if err != nil {
@@ -54,11 +54,6 @@ func (s *Service) Download(ctx context.Context, spath string) (*model.FileData, 
 	return core.DownloadResponse(resp)
 }
 
-// ──────────────────────────────────────────────────────────────
-//  Constructor
-// ──────────────────────────────────────────────────────────────
-
-// NewService creates and returns a new attachment Service.
 func NewService(method *core.Method) *Service {
 	return &Service{method: method}
 }


### PR DESCRIPTION
## Summary

Unify comment style across `internal/attachment` as part of the broader effort to standardize comments throughout all `internal` packages.

## Changes

- Add package-level doc comment
- Remove per-method comments on `List` and `Remove` — names are self-explanatory and the spath contract is described on the struct
- Add caller-responsibility note to `Download` (FileData.Body must be closed by caller)
- Remove decorative section divider (`// ──────...`)
- Remove constructor comment — self-evident from the function name
- Retain the "spath-agnostic" note on the struct — documents the non-obvious design constraint shared across all callers