### PR TITLE
docs: unify comment style in internal/activity

### DIFF
--- a/internal/activity/service.go
+++ b/internal/activity/service.go
@@ -1,3 +1,4 @@
+// Package activity implements shared HTTP logic for activity-related Backlog API endpoints.
 package activity
 
 import (
@@ -34,10 +35,6 @@ func (s *Service) List(ctx context.Context, spath string, opts ...core.RequestOp
 
 	return v, nil
 }
-
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
 
 func NewService(method *core.Method) *Service {
 	return &Service{


### PR DESCRIPTION
## Summary

Unify comment style across `internal/activity` as part of the broader effort to standardize comments throughout all `internal` packages.

## Changes

- Add package-level doc comment
- Remove decorative section divider (`// ──────...`)
- Remove constructor comment — self-evident from the function name
- Retain the "spath-agnostic" note on the struct — documents the non-obvious design constraint shared across all callers