### PR TITLE
docs: unify comment style in internal/issue

### DIFF
--- a/internal/issue/service.go
+++ b/internal/issue/service.go
@@ -1,3 +1,4 @@
+// Package issue implements the Backlog Issue API service.
 package issue
 
 import (
@@ -11,6 +12,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// Service handles issue-related Backlog API calls.
 type Service struct {
 	method *core.Method
 }
@@ -284,10 +286,6 @@ func (s *Service) Participants(ctx context.Context, issueIDOrKey string) ([]*mod
 
 	return v, nil
 }
-
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
 
 func NewService(method *core.Method) *Service {
 	return &Service{

--- a/internal/issue/service_attachment.go
+++ b/internal/issue/service_attachment.go
@@ -18,7 +18,7 @@ type AttachmentService struct {
 	base *attachment.Service
 }
 
-// List returns a list of all attachments in the issue.
+// List returns a list of attachments on the issue.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-issue-attachments
 func (s *AttachmentService) List(ctx context.Context, issueIDOrKey string) ([]*model.Attachment, error) {
@@ -30,7 +30,7 @@ func (s *AttachmentService) List(ctx context.Context, issueIDOrKey string) ([]*m
 	return s.base.List(ctx, spath)
 }
 
-// Remove removes a file attached to the issue.
+// Remove removes an attachment from the issue.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-issue-attachment
 func (s *AttachmentService) Remove(ctx context.Context, issueIDOrKey string, attachmentID int) (*model.Attachment, error) {
@@ -45,7 +45,7 @@ func (s *AttachmentService) Remove(ctx context.Context, issueIDOrKey string, att
 	return s.base.Remove(ctx, spath)
 }
 
-// Download downloads a file attached to the issue.
+// Download downloads an attachment from the issue.
 // The caller is responsible for closing FileData.Body after use.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-attachment
@@ -61,11 +61,6 @@ func (s *AttachmentService) Download(ctx context.Context, issueIDOrKey string, a
 	return s.base.Download(ctx, spath)
 }
 
-// ──────────────────────────────────────────────────────────────
-//  Constructor
-// ──────────────────────────────────────────────────────────────
-
-// NewAttachmentService creates and returns a new issue AttachmentService.
 func NewAttachmentService(method *core.Method) *AttachmentService {
 	return &AttachmentService{base: attachment.NewService(method)}
 }

--- a/internal/issue/service_comment.go
+++ b/internal/issue/service_comment.go
@@ -12,7 +12,9 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// CommentService handles communication with the issue comment-related methods of the Backlog API.
+// CommentService handles issue comment-related Backlog API calls.
+// It delegates HTTP operations to the shared comment.Service and is
+// responsible only for validation and spath construction.
 type CommentService struct {
 	base   *comment.Service
 	method *core.Method
@@ -54,7 +56,7 @@ func (s *CommentService) Count(ctx context.Context, issueIDOrKey string) (int, e
 	return s.base.Count(ctx, spath)
 }
 
-// One returns information about a specific comment.
+// One returns a single comment on an issue.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-comment
 func (s *CommentService) One(ctx context.Context, issueIDOrKey string, commentID int) (*model.Comment, error) {
@@ -168,11 +170,6 @@ func (s *CommentService) Notify(ctx context.Context, issueIDOrKey string, commen
 	return &v, nil
 }
 
-// ──────────────────────────────────────────────────────────────
-//  Constructors
-// ──────────────────────────────────────────────────────────────
-
-// NewCommentService creates and returns a new issue CommentService.
 func NewCommentService(method *core.Method) *CommentService {
 	return &CommentService{
 		base:   comment.NewService(method),

--- a/internal/issue/service_sharedfile.go
+++ b/internal/issue/service_sharedfile.go
@@ -57,11 +57,6 @@ func (s *SharedFileService) Unlink(ctx context.Context, issueIDOrKey string, fil
 	return s.base.Unlink(ctx, spath)
 }
 
-// ──────────────────────────────────────────────────────────────
-//  Constructor
-// ──────────────────────────────────────────────────────────────
-
-// NewSharedFileService creates and returns a new issue SharedFileService.
 func NewSharedFileService(method *core.Method) *SharedFileService {
 	return &SharedFileService{base: sharedfile.NewService(method)}
 }


### PR DESCRIPTION
## Summary

Unify comment style across `internal/issue` as part of the broader effort to standardize comments throughout all `internal` packages.

## Changes

### service.go
- Add package-level doc comment
- Add struct comment to `Service` (was missing)
- Remove decorative section divider (`// ──────...`)
- Remove constructor comment — self-evident from the function name

### service_attachment.go
- Tighten method comments (`List`, `Remove`, `Download`) to match the style used in `internal/pullrequest`
- Remove decorative section divider and constructor comment

### service_comment.go
- Expand `CommentService` struct comment to include delegation note (consistent with `internal/pullrequest`)
- Tighten `One` method comment (removed "information about a specific" boilerplate)
- Remove decorative section divider and constructor comment

### service_sharedfile.go
- Remove decorative section divider and constructor comment