### PR TITLE
fix!: change EstimatedHours and ActualHours from int to float64

### DIFF
--- a/internal/core/option_float.go
+++ b/internal/core/option_float.go
@@ -1,9 +1,22 @@
 package core
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
 )
+
+// WithActualHours returns an option to set the `actualHours` parameter.
+// Any positive float64 value is accepted (e.g. 2.5).
+func (s *OptionService) WithActualHours(hours float64) RequestOption {
+	return positiveFloat64Option(ParamActualHours, hours)
+}
+
+// WithEstimatedHours returns an option to set the `estimatedHours` parameter.
+// Any positive float64 value is accepted (e.g. 2.5).
+func (s *OptionService) WithEstimatedHours(hours float64) RequestOption {
+	return positiveFloat64Option(ParamEstimatedHours, hours)
+}
 
 // WithInitialValue sets `initialValue` for Number type custom fields.
 // Any float64 value is accepted, including zero and negative values.
@@ -29,6 +42,20 @@ func (s *OptionService) WithMin(min float64) RequestOption {
 	return &APIParamOption{
 		Type:    ParamMin,
 		SetFunc: setFloat64Func(ParamMin, min),
+	}
+}
+
+// positiveFloat64Option builds a RequestOption that validates a float64 is > 0 and sets it.
+func positiveFloat64Option(paramType APIParamOptionType, value float64) RequestOption {
+	return &APIParamOption{
+		Type: paramType,
+		CheckFunc: func() error {
+			if value <= 0 {
+				return NewValidationError(fmt.Sprintf("invalid %s: must be greater than 0", paramType.Value()))
+			}
+			return nil
+		},
+		SetFunc: setFloat64Func(paramType, value),
 	}
 }
 

--- a/internal/core/option_int.go
+++ b/internal/core/option_int.go
@@ -8,10 +8,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/model"
 )
 
-func (s *OptionService) WithActualHours(hours int) RequestOption {
-	return positiveIntOption(ParamActualHours, hours)
-}
-
 func (s *OptionService) WithAssigneeID(id int) RequestOption {
 	return positiveIntOption(ParamAssigneeID, id)
 }
@@ -23,10 +19,6 @@ func (s *OptionService) WithCommentID(id int) RequestOption {
 // WithCount sets `count`. Valid range: 1–100.
 func (s *OptionService) WithCount(count int) RequestOption {
 	return intRangeOption(ParamCount, count, 1, 100)
-}
-
-func (s *OptionService) WithEstimatedHours(hours int) RequestOption {
-	return positiveIntOption(ParamEstimatedHours, hours)
 }
 
 func (s *OptionService) WithFieldType(fieldType model.CustomFieldType) RequestOption {

--- a/internal/model/issue.go
+++ b/internal/model/issue.go
@@ -20,8 +20,8 @@ type Issue struct {
 	Milestone      []*Version     `json:"milestone,omitempty"`
 	StartDate      string         `json:"startDate,omitempty"`
 	DueDate        string         `json:"dueDate,omitempty"`
-	EstimatedHours int            `json:"estimatedHours,omitempty"`
-	ActualHours    int            `json:"actualHours,omitempty"`
+	EstimatedHours float64        `json:"estimatedHours,omitempty"`
+	ActualHours    float64        `json:"actualHours,omitempty"`
 	ParentIssueID  int            `json:"parentIssueId,omitempty"`
 	CreatedUser    *User          `json:"createdUser,omitempty"`
 	Created        time.Time      `json:"created,omitempty"`

--- a/issue.go
+++ b/issue.go
@@ -30,8 +30,8 @@ type Issue struct {
 	Milestone      []*Version
 	StartDate      Date
 	DueDate        Date
-	EstimatedHours int
-	ActualHours    int
+	EstimatedHours float64
+	ActualHours    float64
 	ParentIssueID  int
 	CreatedUser    *User
 	Created        Timestamp
@@ -434,7 +434,7 @@ type IssueOptionService struct {
 }
 
 // WithActualHours returns an option to set the `actualHours` parameter.
-func (s *IssueOptionService) WithActualHours(hours int) RequestOption {
+func (s *IssueOptionService) WithActualHours(hours float64) RequestOption {
 	return s.base.WithActualHours(hours)
 }
 
@@ -509,7 +509,7 @@ func (s *IssueOptionService) WithDueDateUntil(date string) RequestOption {
 }
 
 // WithEstimatedHours returns an option to set the `estimatedHours` parameter.
-func (s *IssueOptionService) WithEstimatedHours(hours int) RequestOption {
+func (s *IssueOptionService) WithEstimatedHours(hours float64) RequestOption {
 	return s.base.WithEstimatedHours(hours)
 }
 

--- a/issue_test.go
+++ b/issue_test.go
@@ -767,7 +767,7 @@ func TestIssueOptionService(t *testing.T) {
 		option  backlog.RequestOption
 		wantKey string
 	}{
-		"WithActualHours":     {option: s.WithActualHours(1), wantKey: core.ParamActualHours.Value()},
+		"WithActualHours":     {option: s.WithActualHours(1.0), wantKey: core.ParamActualHours.Value()},
 		"WithAssigneeID":      {option: s.WithAssigneeID(1), wantKey: core.ParamAssigneeID.Value()},
 		"WithAssigneeIDs":     {option: s.WithAssigneeIDs([]int{1}), wantKey: core.ParamAssigneeIDs.Value()},
 		"WithAttachment":      {option: s.WithAttachment(true), wantKey: core.ParamAttachment.Value()},
@@ -781,7 +781,7 @@ func TestIssueOptionService(t *testing.T) {
 		"WithDueDate":         {option: s.WithDueDate(date), wantKey: core.ParamDueDate.Value()},
 		"WithDueDateSince":    {option: s.WithDueDateSince(date), wantKey: core.ParamDueDateSince.Value()},
 		"WithDueDateUntil":    {option: s.WithDueDateUntil(date), wantKey: core.ParamDueDateUntil.Value()},
-		"WithEstimatedHours":  {option: s.WithEstimatedHours(1), wantKey: core.ParamEstimatedHours.Value()},
+		"WithEstimatedHours":  {option: s.WithEstimatedHours(1.0), wantKey: core.ParamEstimatedHours.Value()},
 		"WithHasDueDate":      {option: s.WithHasDueDate(false), wantKey: core.ParamHasDueDate.Value()},
 		"WithIDs":             {option: s.WithIDs([]int{1}), wantKey: core.ParamIDs.Value()},
 		"WithIssueSort":       {option: s.WithIssueSort(backlog.IssueSortCreated), wantKey: core.ParamSort.Value()},


### PR DESCRIPTION
## Summary

The Backlog API accepts and returns decimal values for `estimatedHours` and `actualHours` (e.g. `2.5`). The previous `int` type caused JSON decode errors when the API returned a fractional number, and also prevented callers from setting fractional hour values via the option methods.

## Changes

- `internal/model/issue.go`: Change `Issue.EstimatedHours` and `Issue.ActualHours` from `int` to `float64`
- `internal/core/option_int.go`: Remove `WithActualHours` and `WithEstimatedHours` (moved to float file)
- `internal/core/option_float.go`: Add `WithActualHours` and `WithEstimatedHours` as `float64` parameters with `positiveFloat64Option` validation
- `issue.go`: Change `Issue.EstimatedHours` and `Issue.ActualHours` fields from `int` to `float64`; update `IssueOptionService.WithEstimatedHours` and `WithActualHours` signatures to `float64`
- `issue_test.go`: Update call sites from `WithActualHours(1)` / `WithEstimatedHours(1)` to `WithActualHours(1.0)` / `WithEstimatedHours(1.0)`

BREAKING CHANGE: `Issue.EstimatedHours` and `Issue.ActualHours` changed from `int` to `float64`. `WithEstimatedHours` and `WithActualHours` option methods now accept `float64` instead of `int`.