### PR TITLE
ci: improve release notes format for breaking changes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -2,12 +2,22 @@
 header = ""
 body = """
 ## What's Changed
-{% for group, commits in commits | group_by(attribute="group") %}
-### {{ group }}
-{% for commit in commits %}
-- {{ commit.message | upper_first }}\
-  {% if commit.breaking %} (**BREAKING**){% endif %}
+{% set breaking_commits = commits | filter(attribute="breaking", value=true) %}\
+{% if breaking_commits %}
+### ⚠️ Breaking Changes
+{% for commit in breaking_commits %}\
+- {{ commit.breaking_description | default(value=commit.message) | upper_first }}
 {% endfor %}
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}\
+{% if group != "⚠️ Breaking Changes" %}
+### {{ group }}
+{% for commit in commits %}\
+- {{ commit.message | upper_first }}\
+{% if commit.breaking %} **(BREAKING)**{% endif %}
+
+{% endfor %}
+{% endif %}\
 {% endfor %}
 """
 trim = true
@@ -17,9 +27,9 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-  { message = "^feat!", group = "⚠️ Breaking Changes" },
-  { message = "^fix!", group = "⚠️ Breaking Changes" },
-  { message = "^refactor!", group = "⚠️ Breaking Changes" },
+  { message = "^feat!", group = "✨ Features" },
+  { message = "^fix!", group = "🐛 Bug Fixes" },
+  { message = "^refactor!", group = "🔨 Refactoring" },
   { message = "^feat", group = "✨ Features" },
   { message = "^fix", group = "🐛 Bug Fixes" },
   { message = "^refactor", group = "🔨 Refactoring" },


### PR DESCRIPTION
## Summary

Improve the release notes format so that breaking change details are surfaced more clearly.

## Changes

- Remove the `⚠️ Breaking Changes` group from `commit_parsers`; `feat!`, `fix!`, and `refactor!` commits are now routed to their respective groups (`✨ Features`, `🐛 Bug Fixes`, `🔨 Refactoring`)
- Add a dedicated Breaking Changes section at the top of the release notes, rendered from `commit.breaking_description` (the `BREAKING CHANGE:` body in PR descriptions)
- Breaking commits in their own sections are annotated with **(BREAKING)** instead of the previous `(BREAKING)` suffix

**Before:**
```
⚠️ Breaking Changes
- Change date option method arguments from time.Time to string (#319) (BREAKING)
```

**After:**
```
⚠️ Breaking Changes
- Use string in "YYYY-MM-DD" format instead of time.Time

✨ Features
- Change date option method arguments from time.Time to string (#319) **(BREAKING)**
```
