### PR TITLE
ci: add breaking change consistency check workflow

### DIFF
--- a/.github/scripts/check-breaking-change.js
+++ b/.github/scripts/check-breaking-change.js
@@ -1,0 +1,35 @@
+const title = process.env.PR_TITLE || '';
+const body = process.env.PR_BODY || '';
+const labels = JSON.parse(process.env.PR_LABELS || '[]');
+
+const hasExclamation = /^[a-z]+!/.test(title);
+const hasBreakingLabel = labels.includes('breaking change');
+const hasBreakingSection = /BREAKING CHANGE:/m.test(body);
+
+const signals = [hasExclamation, hasBreakingLabel, hasBreakingSection];
+const triggeredCount = signals.filter(Boolean).length;
+
+if (triggeredCount === 0) {
+  // Not a breaking change — all good
+  console.log('Not a breaking change. No issues found.');
+  process.exit(0);
+}
+
+if (triggeredCount === 3) {
+  // All three present — consistent
+  console.log('Breaking change is consistent: title has "!", label "breaking change" is set, and "BREAKING CHANGE:" section is present.');
+  process.exit(0);
+}
+
+// Partial — fail with detailed message
+const lines = [
+  'Breaking change consistency check failed.',
+  '',
+  `  PR title has "!" suffix : ${hasExclamation  ? '✅' : '❌'}`,
+  `  Label "breaking change" : ${hasBreakingLabel ? '✅' : '❌'}`,
+  `  "BREAKING CHANGE:" in description : ${hasBreakingSection ? '✅' : '❌'}`,
+  '',
+  'All three must be present together, or none at all.',
+];
+console.error(lines.join('\n'));
+process.exit(1);

--- a/.github/workflows/check-breaking-change.yml
+++ b/.github/workflows/check-breaking-change.yml
@@ -1,0 +1,22 @@
+name: Check Breaking Change Consistency
+
+on:
+  pull_request_target:
+    types: [opened, edited, labeled, unlabeled]
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check breaking change consistency
+        run: node .github/scripts/check-breaking-change.js
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}


### PR DESCRIPTION
## Summary

Add a CI workflow that enforces consistency across the three signals of a breaking change. Since `BREAKING CHANGE:` descriptions are now surfaced in release notes, all three must be present together or none at all.

## Changes

- Add `.github/workflows/check-breaking-change.yml` — triggers on `pull_request_target` (`opened`, `edited`, `labeled`, `unlabeled`)
- Add `.github/scripts/check-breaking-change.js` — checks the three signals and exits with code 1 if inconsistent

## Rules enforced

All three must be present together, or none at all:

| Signal | How to satisfy |
|--------|---------------|
| PR title has `!` suffix | e.g. `feat!:`, `fix!:`, `refactor!:` |
| Label `breaking change` is set | applied automatically by `label-pr.yml` when title has `!` |
| `BREAKING CHANGE:` in PR description | written manually with migration details |

**Fail example** (partial — label only, missing `!` and `BREAKING CHANGE:`):
```
Breaking change consistency check failed.

  PR title has "!" suffix              : ❌
  Label "breaking change"              : ✅
  "BREAKING CHANGE:" in description   : ❌

All three must be present together, or none at all.
```
