### PR TITLE
refactor: remove string-based named types from internal/model

### DIFF
--- a/internal/core/option_string.go
+++ b/internal/core/option_string.go
@@ -3,8 +3,6 @@ package core
 import (
 	"fmt"
 	"net/url"
-
-	"github.com/nattokin/go-backlog/internal/model"
 )
 
 func (s *OptionService) WithBase(base string) RequestOption {
@@ -88,8 +86,7 @@ func (s *OptionService) WithOrder(order string) RequestOption {
 		Type: ParamOrder,
 		CheckFunc: func() error {
 			if order != "asc" && order != "desc" {
-				msg := fmt.Sprintf("order must be only 'asc' or 'desc'")
-				return NewValidationError(msg)
+				return NewValidationError(fmt.Sprintf("order must be only 'asc' or 'desc'"))
 			}
 			return nil
 		},
@@ -128,17 +125,20 @@ func (s *OptionService) WithTemplateSummary(summary string) RequestOption {
 	}
 }
 
-func (s *OptionService) WithTextFormattingRule(format model.Format) RequestOption {
+var validFormats = []string{"backlog", "markdown"}
+
+func (s *OptionService) WithTextFormattingRule(format string) RequestOption {
 	return &APIParamOption{
 		Type: ParamTextFormattingRule,
 		CheckFunc: func() error {
-			if format != model.FormatBacklog && format != model.FormatMarkdown {
-				msg := fmt.Sprintf("format must be only '%s' or '%s'", string(model.FormatBacklog), string(model.FormatMarkdown))
-				return NewValidationError(msg)
+			for _, v := range validFormats {
+				if format == v {
+					return nil
+				}
 			}
-			return nil
+			return NewValidationError(fmt.Sprintf("format must be only 'backlog' or 'markdown'"))
 		},
-		SetFunc: setStringFunc(ParamTextFormattingRule, string(format)),
+		SetFunc: setStringFunc(ParamTextFormattingRule, format),
 	}
 }
 

--- a/internal/core/option_string.go
+++ b/internal/core/option_string.go
@@ -52,27 +52,25 @@ func (s *OptionService) WithKeyword(keyword string) RequestOption {
 	}
 }
 
-func (s *OptionService) WithIssueSort(sort model.IssueSort) RequestOption {
-	validSorts := []model.IssueSort{
-		model.IssueSortIssueType, model.IssueSortCategory, model.IssueSortVersion,
-		model.IssueSortMilestone, model.IssueSortSummary, model.IssueSortStatus,
-		model.IssueSortPriority, model.IssueSortAttachment, model.IssueSortSharedFile,
-		model.IssueSortCreated, model.IssueSortCreatedUser, model.IssueSortUpdated,
-		model.IssueSortUpdatedUser, model.IssueSortAssignee, model.IssueSortStartDate,
-		model.IssueSortDueDate, model.IssueSortEstimatedHours, model.IssueSortActualHours,
-		model.IssueSortChildIssue,
-	}
+var validIssueSorts = []string{
+	"issueType", "category", "version", "milestone", "summary", "status",
+	"priority", "attachment", "sharedFile", "created", "createdUser",
+	"updated", "updatedUser", "assignee", "startDate", "dueDate",
+	"estimatedHours", "actualHours", "childIssue",
+}
+
+func (s *OptionService) WithIssueSort(sort string) RequestOption {
 	return &APIParamOption{
 		Type: ParamSort,
 		CheckFunc: func() error {
-			for _, v := range validSorts {
+			for _, v := range validIssueSorts {
 				if sort == v {
 					return nil
 				}
 			}
-			return NewValidationError(fmt.Sprintf("invalid sort value: %q", string(sort)))
+			return NewValidationError(fmt.Sprintf("invalid sort value: %q", sort))
 		},
-		SetFunc: setStringFunc(ParamSort, string(sort)),
+		SetFunc: setStringFunc(ParamSort, sort),
 	}
 }
 
@@ -85,17 +83,17 @@ func (s *OptionService) WithName(name string) RequestOption {
 	return nonEmptyStringOption(ParamName, name)
 }
 
-func (s *OptionService) WithOrder(order model.Order) RequestOption {
+func (s *OptionService) WithOrder(order string) RequestOption {
 	return &APIParamOption{
 		Type: ParamOrder,
 		CheckFunc: func() error {
-			if order != model.OrderAsc && order != model.OrderDesc {
-				msg := fmt.Sprintf("order must be only '%s' or '%s'", string(model.OrderAsc), string(model.OrderDesc))
+			if order != "asc" && order != "desc" {
+				msg := fmt.Sprintf("order must be only 'asc' or 'desc'")
 				return NewValidationError(msg)
 			}
 			return nil
 		},
-		SetFunc: setStringFunc(ParamOrder, string(order)),
+		SetFunc: setStringFunc(ParamOrder, order),
 	}
 }
 

--- a/internal/core/option_string.go
+++ b/internal/core/option_string.go
@@ -86,7 +86,7 @@ func (s *OptionService) WithOrder(order string) RequestOption {
 		Type: ParamOrder,
 		CheckFunc: func() error {
 			if order != "asc" && order != "desc" {
-				return NewValidationError(fmt.Sprintf("order must be only 'asc' or 'desc'"))
+				return NewValidationError("order must be only 'asc' or 'desc'")
 			}
 			return nil
 		},
@@ -136,7 +136,7 @@ func (s *OptionService) WithTextFormattingRule(format string) RequestOption {
 					return nil
 				}
 			}
-			return NewValidationError(fmt.Sprintf("format must be only 'backlog' or 'markdown'"))
+			return NewValidationError("format must be only 'backlog' or 'markdown'")
 		},
 		SetFunc: setStringFunc(ParamTextFormattingRule, format),
 	}

--- a/internal/core/option_string_test.go
+++ b/internal/core/option_string_test.go
@@ -161,12 +161,12 @@ func TestOptionService_string(t *testing.T) {
 			wantValue: "kg",
 		},
 		"WithOrder-asc": {
-			option:    o.WithOrder(model.OrderAsc),
+			option:    o.WithOrder("asc"),
 			key:       core.ParamOrder.Value(),
 			wantValue: "asc",
 		},
 		"WithOrder-desc": {
-			option:    o.WithOrder(model.OrderDesc),
+			option:    o.WithOrder("desc"),
 			key:       core.ParamOrder.Value(),
 			wantValue: "desc",
 		},
@@ -241,28 +241,28 @@ func TestOptionService_string(t *testing.T) {
 	// --- IssueSort option ---------------------------------------------------------
 	t.Run("WithIssueSort", func(t *testing.T) {
 		cases := map[string]struct {
-			sort    model.IssueSort
+			sort    string
 			wantErr bool
 		}{
-			"actualHours":    {sort: model.IssueSortActualHours},
-			"assignee":       {sort: model.IssueSortAssignee},
-			"attachment":     {sort: model.IssueSortAttachment},
-			"category":       {sort: model.IssueSortCategory},
-			"childIssue":     {sort: model.IssueSortChildIssue},
-			"created":        {sort: model.IssueSortCreated},
-			"createdUser":    {sort: model.IssueSortCreatedUser},
-			"dueDate":        {sort: model.IssueSortDueDate},
-			"estimatedHours": {sort: model.IssueSortEstimatedHours},
-			"issueType":      {sort: model.IssueSortIssueType},
-			"milestone":      {sort: model.IssueSortMilestone},
-			"priority":       {sort: model.IssueSortPriority},
-			"sharedFile":     {sort: model.IssueSortSharedFile},
-			"startDate":      {sort: model.IssueSortStartDate},
-			"status":         {sort: model.IssueSortStatus},
-			"summary":        {sort: model.IssueSortSummary},
-			"updated":        {sort: model.IssueSortUpdated},
-			"updatedUser":    {sort: model.IssueSortUpdatedUser},
-			"version":        {sort: model.IssueSortVersion},
+			"actualHours":    {sort: "actualHours"},
+			"assignee":       {sort: "assignee"},
+			"attachment":     {sort: "attachment"},
+			"category":       {sort: "category"},
+			"childIssue":     {sort: "childIssue"},
+			"created":        {sort: "created"},
+			"createdUser":    {sort: "createdUser"},
+			"dueDate":        {sort: "dueDate"},
+			"estimatedHours": {sort: "estimatedHours"},
+			"issueType":      {sort: "issueType"},
+			"milestone":      {sort: "milestone"},
+			"priority":       {sort: "priority"},
+			"sharedFile":     {sort: "sharedFile"},
+			"startDate":      {sort: "startDate"},
+			"status":         {sort: "status"},
+			"summary":        {sort: "summary"},
+			"updated":        {sort: "updated"},
+			"updatedUser":    {sort: "updatedUser"},
+			"version":        {sort: "version"},
 
 			"empty":   {sort: "", wantErr: true},
 			"invalid": {sort: "invalid", wantErr: true},
@@ -281,7 +281,7 @@ func TestOptionService_string(t *testing.T) {
 				}
 				require.NoError(t, err)
 				_ = opt.Set(q)
-				assert.Equal(t, string(tc.sort), q.Get(core.ParamSort.Value()))
+				assert.Equal(t, tc.sort, q.Get(core.ParamSort.Value()))
 			})
 		}
 	})

--- a/internal/core/option_string_test.go
+++ b/internal/core/option_string_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/model"
 )
 
 func TestOptionService_string(t *testing.T) {
@@ -211,14 +210,14 @@ func TestOptionService_string(t *testing.T) {
 			wantErr: true,
 		},
 		"WithTextFormattingRule-valid-backlog": {
-			option:    o.WithTextFormattingRule(model.FormatBacklog),
+			option:    o.WithTextFormattingRule("backlog"),
 			key:       core.ParamTextFormattingRule.Value(),
-			wantValue: string(model.FormatBacklog),
+			wantValue: "backlog",
 		},
 		"WithTextFormattingRule-valid-markdown": {
-			option:    o.WithTextFormattingRule(model.FormatMarkdown),
+			option:    o.WithTextFormattingRule("markdown"),
 			key:       core.ParamTextFormattingRule.Value(),
-			wantValue: string(model.FormatMarkdown),
+			wantValue: "markdown",
 		},
 	}
 

--- a/internal/issue/service_test.go
+++ b/internal/issue/service_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/issue"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
@@ -56,8 +55,8 @@ func TestIssueService_All(t *testing.T) {
 		},
 		"success-with-sort-and-order": {
 			opts: []core.RequestOption{
-				o.WithIssueSort(model.IssueSortCreated),
-				o.WithOrder(model.OrderAsc),
+				o.WithIssueSort("created"),
+				o.WithOrder("asc"),
 			},
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "issues", spath)

--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -10,7 +10,7 @@ type Project struct {
 	ChartEnabled                      bool   `json:"chartEnabled,omitempty"`
 	SubtaskingEnabled                 bool   `json:"subtaskingEnabled,omitempty"`
 	ProjectLeaderCanEditProjectLeader bool   `json:"projectLeaderCanEditProjectLeader,omitempty"`
-	TextFormattingRule                Format `json:"textFormattingRule,omitempty"`
+	TextFormattingRule                string `json:"textFormattingRule,omitempty"`
 	Archived                          bool   `json:"archived,omitempty"`
 }
 

--- a/internal/model/space.go
+++ b/internal/model/space.go
@@ -17,7 +17,7 @@ type Space struct {
 	Lang               string    `json:"lang,omitempty"`
 	Timezone           string    `json:"timezone,omitempty"`
 	ReportSendTime     string    `json:"reportSendTime,omitempty"`
-	TextFormattingRule Format    `json:"textFormattingRule,omitempty"`
+	TextFormattingRule string    `json:"textFormattingRule,omitempty"`
 	Created            time.Time `json:"created,omitempty"`
 	Updated            time.Time `json:"updated,omitempty"`
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -15,44 +15,13 @@ const (
 )
 
 // Format defines the text formatting rule for a Backlog space or project.
+// This type is used for JSON deserialization of Space.TextFormattingRule and
+// Project.TextFormattingRule, so it is kept as a named type.
 type Format string
 
 const (
 	FormatMarkdown Format = "markdown"
 	FormatBacklog  Format = "backlog"
-)
-
-// IssueSort represents the field to sort issue list results by.
-type IssueSort string
-
-const (
-	IssueSortIssueType      IssueSort = "issueType"
-	IssueSortCategory       IssueSort = "category"
-	IssueSortVersion        IssueSort = "version"
-	IssueSortMilestone      IssueSort = "milestone"
-	IssueSortSummary        IssueSort = "summary"
-	IssueSortStatus         IssueSort = "status"
-	IssueSortPriority       IssueSort = "priority"
-	IssueSortAttachment     IssueSort = "attachment"
-	IssueSortSharedFile     IssueSort = "sharedFile"
-	IssueSortCreated        IssueSort = "created"
-	IssueSortCreatedUser    IssueSort = "createdUser"
-	IssueSortUpdated        IssueSort = "updated"
-	IssueSortUpdatedUser    IssueSort = "updatedUser"
-	IssueSortAssignee       IssueSort = "assignee"
-	IssueSortStartDate      IssueSort = "startDate"
-	IssueSortDueDate        IssueSort = "dueDate"
-	IssueSortEstimatedHours IssueSort = "estimatedHours"
-	IssueSortActualHours    IssueSort = "actualHours"
-	IssueSortChildIssue     IssueSort = "childIssue"
-)
-
-// Order defines the sort order for list results.
-type Order string
-
-const (
-	OrderAsc  Order = "asc"
-	OrderDesc Order = "desc"
 )
 
 // Role defines the user role type within a project.

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -14,16 +14,6 @@ const (
 	CustomFieldTypeRadio        CustomFieldType = 8
 )
 
-// Format defines the text formatting rule for a Backlog space or project.
-// This type is used for JSON deserialization of Space.TextFormattingRule and
-// Project.TextFormattingRule, so it is kept as a named type.
-type Format string
-
-const (
-	FormatMarkdown Format = "markdown"
-	FormatBacklog  Format = "backlog"
-)
-
 // Role defines the user role type within a project.
 type Role int
 

--- a/internal/project/service_activity_test.go
+++ b/internal/project/service_activity_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/project"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
@@ -99,7 +98,7 @@ func TestActivityService_List(t *testing.T) {
 		"success-withOrder": {
 			projectIDOrKey: "TEST",
 			opts: []core.RequestOption{
-				o.WithOrder(model.OrderAsc),
+				o.WithOrder("asc"),
 			},
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "asc", query.Get("order"))
@@ -114,7 +113,7 @@ func TestActivityService_List(t *testing.T) {
 				o.WithMinID(1),
 				o.WithMaxID(26),
 				o.WithCount(20),
-				o.WithOrder(model.OrderAsc),
+				o.WithOrder("asc"),
 			},
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/activities", spath)

--- a/internal/project/service_test.go
+++ b/internal/project/service_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/project"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
@@ -258,7 +257,7 @@ func TestService_Create(t *testing.T) {
 				o.WithChartEnabled(true),
 				o.WithSubtaskingEnabled(true),
 				o.WithProjectLeaderCanEditProjectLeader(true),
-				o.WithTextFormattingRule(model.FormatBacklog),
+				o.WithTextFormattingRule("backlog"),
 			},
 
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
@@ -417,7 +416,7 @@ func TestService_Update(t *testing.T) {
 				o.WithChartEnabled(true),
 				o.WithSubtaskingEnabled(true),
 				o.WithProjectLeaderCanEditProjectLeader(true),
-				o.WithTextFormattingRule(model.FormatBacklog),
+				o.WithTextFormattingRule("backlog"),
 				o.WithArchived(true),
 			},
 

--- a/internal/space/service_activity_test.go
+++ b/internal/space/service_activity_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/space"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
@@ -104,7 +103,7 @@ func TestActivityService_List(t *testing.T) {
 		},
 		"success-withOrder": {
 			opts: []core.RequestOption{
-				o.WithOrder(model.OrderAsc),
+				o.WithOrder("asc"),
 			},
 			wantError: false,
 			want: want{
@@ -122,7 +121,7 @@ func TestActivityService_List(t *testing.T) {
 				o.WithMinID(1),
 				o.WithMaxID(26),
 				o.WithCount(20),
-				o.WithOrder(model.OrderAsc),
+				o.WithOrder("asc"),
 			},
 			wantError: false,
 			want: want{

--- a/internal/user/service_activity_test.go
+++ b/internal/user/service_activity_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 	"github.com/nattokin/go-backlog/internal/user"
@@ -70,7 +69,7 @@ func TestActivityService_List(t *testing.T) {
 		},
 		"success-withOrder": {
 			userID: 1234,
-			opts:   []core.RequestOption{o.WithOrder(model.OrderAsc)},
+			opts:   []core.RequestOption{o.WithOrder("asc")},
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "asc", query.Get("order"))
 				return mock.NewJSONResponse(fixture.Activity.ListJSON), nil
@@ -83,7 +82,7 @@ func TestActivityService_List(t *testing.T) {
 				o.WithMinID(1),
 				o.WithMaxID(26),
 				o.WithCount(20),
-				o.WithOrder(model.OrderAsc),
+				o.WithOrder("asc"),
 			},
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/1234/activities", spath)

--- a/issue.go
+++ b/issue.go
@@ -354,7 +354,7 @@ func (s *IssueCommentOptionService) WithMinID(id int) RequestOption {
 
 // WithOrder sets the sort order of results.
 func (s *IssueCommentOptionService) WithOrder(order Order) RequestOption {
-	return s.base.WithOrder(model.Order(order))
+	return s.base.WithOrder(string(order))
 }
 
 // WithNotifiedUserIDs returns an option to set multiple `notifiedUserId[]` parameters.
@@ -526,7 +526,7 @@ func (s *IssueOptionService) WithIDs(ids []int) RequestOption {
 
 // WithIssueSort sets the field to sort issue list results by.
 func (s *IssueOptionService) WithIssueSort(sort IssueSort) RequestOption {
-	return s.base.WithIssueSort(model.IssueSort(sort))
+	return s.base.WithIssueSort(string(sort))
 }
 
 // WithIssueTypeID returns an option to set the `issueTypeId` parameter.
@@ -561,7 +561,7 @@ func (s *IssueOptionService) WithOffset(offset int) RequestOption {
 
 // WithOrder sets the sort order of results.
 func (s *IssueOptionService) WithOrder(order Order) RequestOption {
-	return s.base.WithOrder(model.Order(order))
+	return s.base.WithOrder(string(order))
 }
 
 // WithParentChild filters issues by subtask relationship.

--- a/models_test.go
+++ b/models_test.go
@@ -389,7 +389,7 @@ func Test_spaceFromModel(t *testing.T) {
 		Lang:               "ja",
 		Timezone:           "Asia/Tokyo",
 		ReportSendTime:     "08:00:00",
-		TextFormattingRule: model.FormatMarkdown,
+		TextFormattingRule: "markdown",
 		Created:            created,
 		Updated:            updated,
 	}

--- a/option.go
+++ b/option.go
@@ -4,7 +4,6 @@ import (
 	"net/url"
 
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/model"
 )
 
 // RequestOption defines a common interface for all option types.
@@ -47,7 +46,7 @@ func (s *ActivityOptionService) WithCount(count int) RequestOption {
 
 // WithOrder sets the sort order of results.
 func (s *ActivityOptionService) WithOrder(order Order) RequestOption {
-	return s.base.WithOrder(model.Order(order))
+	return s.base.WithOrder(string(order))
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/project.go
+++ b/project.go
@@ -171,7 +171,7 @@ func (s *ProjectOptionService) WithSubtaskingEnabled(enabled bool) RequestOption
 
 // WithTextFormattingRule sets the text formatting rule.
 func (s *ProjectOptionService) WithTextFormattingRule(format Format) RequestOption {
-	return s.base.WithTextFormattingRule(model.Format(format))
+	return s.base.WithTextFormattingRule(string(format))
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -186,9 +186,9 @@ func (s *PullRequestCommentService) All(ctx context.Context, projectIDOrKey stri
 //   - WithAttachmentIDs
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-pull-request-comment
-func (s *PullRequestCommentService) Add(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, content string, opts ...RequestOption) (*Comment, error) {
+func (s *PullRequestCommentService) Add(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, content string, opts ...RequestOption) ([]*Comment, error) {
 	v, err := s.base.Add(ctx, projectIDOrKey, repositoryIDOrName, prNumber, content, toCoreOptions(opts)...)
-	return commentFromModel(v), convertError(err)
+	return commentsFromModel(v), convertError(err)
 }
 
 // Count returns the number of comments on a pull request.
@@ -252,7 +252,7 @@ func (s *PullRequestCommentOptionService) WithNotifiedUserIDs(ids []int) Request
 
 // WithOrder sets the sort order of results.
 func (s *PullRequestCommentOptionService) WithOrder(order Order) RequestOption {
-	return s.base.WithOrder(model.Order(order))
+	return s.base.WithOrder(string(order))
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -186,9 +186,9 @@ func (s *PullRequestCommentService) All(ctx context.Context, projectIDOrKey stri
 //   - WithAttachmentIDs
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-pull-request-comment
-func (s *PullRequestCommentService) Add(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, content string, opts ...RequestOption) ([]*Comment, error) {
+func (s *PullRequestCommentService) Add(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, content string, opts ...RequestOption) (*Comment, error) {
 	v, err := s.base.Add(ctx, projectIDOrKey, repositoryIDOrName, prNumber, content, toCoreOptions(opts)...)
-	return commentsFromModel(v), convertError(err)
+	return commentFromModel(v), convertError(err)
 }
 
 // Count returns the number of comments on a pull request.

--- a/recentlyviewed.go
+++ b/recentlyviewed.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/recentlyviewed"
 )
 
@@ -100,7 +99,7 @@ func (s *RecentlyViewedOptionService) WithOffset(offset int) RequestOption {
 
 // WithOrder sets the sort order of results.
 func (s *RecentlyViewedOptionService) WithOrder(order Order) RequestOption {
-	return s.base.WithOrder(model.Order(order))
+	return s.base.WithOrder(string(order))
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/user.go
+++ b/user.go
@@ -184,7 +184,7 @@ func (s *UserStarOptionService) WithMinID(id int) RequestOption {
 
 // WithOrder sets the sort order of results.
 func (s *UserStarOptionService) WithOrder(order Order) RequestOption {
-	return s.base.WithOrder(model.Order(order))
+	return s.base.WithOrder(string(order))
 }
 
 // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Remove all string-based named types from `internal/model/types.go` that served no purpose beyond wrapping `string`. `model.IssueSort`, `model.Order`, and `model.Format` are all deleted; the corresponding fields and option function signatures now use plain `string` throughout internal packages. Root-package wrappers convert via simple `string(x)` casts where needed.

`model.Role` and `model.CustomFieldType` (int-based) are out of scope and remain unchanged.

## Changes

- `internal/model/types.go`: delete `IssueSort`, `Order`, and `Format` types and their constants
- `internal/model/project.go`: `TextFormattingRule` field `Format` → `string`
- `internal/model/space.go`: `TextFormattingRule` field `Format` → `string`
- `internal/core/option_string.go`: `WithIssueSort(string)`, `WithOrder(string)`, `WithTextFormattingRule(string)`; introduce `validIssueSorts` and `validFormats` package-level slices; drop `internal/model` import
- `internal/core/option_string_test.go`: use string literals throughout; drop `internal/model` import
- `option.go`: `ActivityOptionService.WithOrder` — `string(order)` cast; drop unused `internal/model` import
- `issue.go`: `IssueOptionService.WithIssueSort`, `WithOrder`, `IssueCommentOptionService.WithOrder` — remove `model.*` casts
- `pullrequest.go`: `PullRequestCommentOptionService.WithOrder` — remove cast
- `user.go`: `UserStarOptionService.WithOrder` — remove cast
- `project.go`: `ProjectOptionService.WithTextFormattingRule` — `string(format)` cast
