### PR TITLE
chore: update copyright year to 2020-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 nattokinxxxx
+Copyright (c) 2020-2026 nattokinxxxx
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Update the copyright year range in LICENSE from `2020` to `2020-2026`.

## Changes

- Update `Copyright (c) 2020` to `Copyright (c) 2020-2026` in LICENSE
