### PR TITLE
ci: improve release note auto-generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: github.ref_name =~ '^v[0-9]+\.[0-9]+\.[0-9]+$'
     permissions:
       contents: write
       issues: write
@@ -26,11 +27,20 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         run: node .github/scripts/milestone-check-and-close.js
 
+      - name: Get previous stable release tag
+        id: prev_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PREV=$(gh release list --repo ${{ github.repository }} --json tagName,isPrerelease,isDraft \
+            --jq '[.[] | select(.isPrerelease == false and .isDraft == false) | .tagName] | .[1]')
+          echo "tag=${PREV}" >> $GITHUB_OUTPUT
+
       - name: Generate changelog
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: cliff.toml
-          args: --latest --strip header
+          args: --strip header ${{ steps.prev_release.outputs.tag }}..HEAD
         env:
           OUTPUT: CHANGELOG.md
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PREV=$(gh release list --repo ${{ github.repository }} --json tagName,isPrerelease,isDraft \
-            --jq '[.[] | select(.isPrerelease == false and .isDraft == false) | .tagName] | .[1]')
+            --jq '[.[] | select(.isPrerelease == false and .isDraft == false) | .tagName] | .[0]')
           echo "tag=${PREV}" >> $GITHUB_OUTPUT
 
       - name: Generate changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,33 @@ on:
       - 'v*'
 
 jobs:
+  check-tag:
+    name: Check tag
+    runs-on: ubuntu-latest
+    outputs:
+      is-stable: ${{ steps.check.outputs.is-stable }}
+    steps:
+      - name: Check if stable release tag
+        id: check
+        run: |
+          if echo "${{ github.ref_name }}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "is-stable=true" >> $GITHUB_OUTPUT
+            echo "Tag ${{ github.ref_name }} is a stable release tag."
+          else
+            echo "is-stable=false" >> $GITHUB_OUTPUT
+            echo "Tag ${{ github.ref_name }} is not a stable release tag. Skipping release."
+          fi
+
   release:
     name: Release
+    needs: check-tag
+    if: needs.check-tag.outputs.is-stable == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write
 
     steps:
-      - name: Verify stable release tag
-        run: echo "${{ github.ref_name }}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,12 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.ref_name =~ '^v[0-9]+\.[0-9]+\.[0-9]+$'
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v*'
 
 jobs:
   release:
@@ -14,6 +14,9 @@ jobs:
       issues: write
 
     steps:
+      - name: Verify stable release tag
+        run: echo "${{ github.ref_name }}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary

Improve the release note auto-generation workflow to correctly handle stable vs pre-release tags and tag-without-release scenarios.

## Changes

- Restrict the workflow trigger to stable release tags only using the glob pattern `v[0-9]+.[0-9]+.[0-9]+`, excluding beta and other pre-release tags (e.g. `v1.0.0-beta.1`)
- Replace `--latest` with an explicit `--from` range by fetching the previous stable GitHub Release via `gh release list`, filtering out drafts and pre-releases. This ensures the correct diff range even when a release has been deleted but its tag remains.

Closes #327
