### PR TITLE
refactor: consolidate example doers into example_doer_test.go

### DIFF
--- a/example_doer_test.go
+++ b/example_doer_test.go
@@ -27,8 +27,11 @@ var (
 	doerCustomFieldSingle = newMockDoer(fixture.CustomField.SingleJSON)
 
 	// Issue
-	doerIssueList   = newMockDoer(fixture.Issue.ListJSON)
-	doerIssueSingle = newMockDoer(fixture.Issue.SingleJSON)
+	doerIssueList                 = newMockDoer(fixture.Issue.ListJSON)
+	doerIssueSingle               = newMockDoer(fixture.Issue.SingleJSON)
+	doerIssueCount                = newMockDoer(`{"count":2}`)
+	doerIssueCommentCount         = newMockDoer(`{"count":2}`)
+	doerIssueCommentNotifications = newMockDoer(`[{"id":25,"alreadyRead":false,"reason":2,"resourceAlreadyRead":false}]`)
 
 	// IssueType
 	doerIssueTypeList   = newMockDoer(fixture.IssueType.ListJSON)
@@ -41,15 +44,17 @@ var (
 	doerProjectIcon      = newMockBinaryDoer("image/png", "test.png", []byte("PNG"))
 
 	// PullRequest
-	doerPullRequestList   = newMockDoer(fixture.PullRequest.ListJSON)
-	doerPullRequestSingle = newMockDoer(fixture.PullRequest.SingleJSON)
+	doerPullRequestList         = newMockDoer(fixture.PullRequest.ListJSON)
+	doerPullRequestSingle       = newMockDoer(fixture.PullRequest.SingleJSON)
+	doerPullRequestCount        = newMockDoer(`{"count":2}`)
+	doerPullRequestCommentCount = newMockDoer(`{"count":2}`)
 
 	// RecentlyViewed
-	doerRecentlyViewedIssueList    = newMockDoer(fixture.RecentlyViewed.IssueListJSON)
-	doerRecentlyViewedIssueSingle  = newMockDoer(fixture.RecentlyViewed.IssueSingleJSON)
-	doerRecentlyViewedProjectList  = newMockDoer(fixture.RecentlyViewed.ProjectListJSON)
-	doerRecentlyViewedWikiList     = newMockDoer(fixture.RecentlyViewed.WikiListJSON)
-	doerRecentlyViewedWikiSingle   = newMockDoer(fixture.RecentlyViewed.WikiSingleJSON)
+	doerRecentlyViewedIssueList   = newMockDoer(fixture.RecentlyViewed.IssueListJSON)
+	doerRecentlyViewedIssueSingle = newMockDoer(fixture.RecentlyViewed.IssueSingleJSON)
+	doerRecentlyViewedProjectList = newMockDoer(fixture.RecentlyViewed.ProjectListJSON)
+	doerRecentlyViewedWikiList    = newMockDoer(fixture.RecentlyViewed.WikiListJSON)
+	doerRecentlyViewedWikiSingle  = newMockDoer(fixture.RecentlyViewed.WikiSingleJSON)
 
 	// Repository
 	doerRepositoryList   = newMockDoer(fixture.Repository.ListJSON)
@@ -86,10 +91,11 @@ var (
 	doerWebhookAllEvent = newMockDoer(fixture.Webhook.AllEventJSON)
 
 	// Wiki
-	doerWikiList        = newMockDoer(fixture.Wiki.ListJSON)
-	doerWikiSingle      = newMockDoer(fixture.Wiki.MinimumJSON)
-	doerWikiHistoryList = newMockDoer(fixture.WikiHistory.ListJSON)
+	doerWikiList               = newMockDoer(fixture.Wiki.ListJSON)
+	doerWikiSingle             = newMockDoer(fixture.Wiki.MinimumJSON)
+	doerWikiHistoryList        = newMockDoer(fixture.WikiHistory.ListJSON)
 	doerWikiAttachmentDownload = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
 	doerSharedFileGetFile      = newMockBinaryDoer("image/png", "shared.png", []byte("PNG"))
 	doerAttachmentDownload     = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
+	doerWikiCount              = newMockDoer(`{"count": 5}`)
 )

--- a/example_doer_test.go
+++ b/example_doer_test.go
@@ -1,0 +1,95 @@
+package backlog_test
+
+import (
+	"github.com/nattokin/go-backlog/internal/testutil/fixture"
+)
+
+var (
+	// Activity
+	doerActivityList   = newMockDoer(fixture.Activity.ListJSON)
+	doerActivitySingle = newMockDoer(fixture.Activity.SingleJSON)
+
+	// Attachment
+	doerAttachmentList   = newMockDoer(fixture.Attachment.ListJSON)
+	doerAttachmentSingle = newMockDoer(fixture.Attachment.SingleJSON)
+	doerAttachmentUpload = newMockDoer(fixture.Attachment.UploadJSON)
+
+	// Category
+	doerCategoryList   = newMockDoer(fixture.Category.ListJSON)
+	doerCategorySingle = newMockDoer(fixture.Category.SingleJSON)
+
+	// Comment
+	doerCommentList   = newMockDoer(fixture.Comment.ListJSON)
+	doerCommentSingle = newMockDoer(fixture.Comment.SingleJSON)
+
+	// CustomField
+	doerCustomFieldList   = newMockDoer(fixture.CustomField.ListJSON)
+	doerCustomFieldSingle = newMockDoer(fixture.CustomField.SingleJSON)
+
+	// Issue
+	doerIssueList   = newMockDoer(fixture.Issue.ListJSON)
+	doerIssueSingle = newMockDoer(fixture.Issue.SingleJSON)
+
+	// IssueType
+	doerIssueTypeList   = newMockDoer(fixture.IssueType.ListJSON)
+	doerIssueTypeSingle = newMockDoer(fixture.IssueType.SingleJSON)
+
+	// Project
+	doerProjectList      = newMockDoer(fixture.Project.ListJSON)
+	doerProjectSingle    = newMockDoer(fixture.Project.SingleJSON)
+	doerProjectDiskUsage = newMockDoer(fixture.Project.DiskUsageJSON)
+	doerProjectIcon      = newMockBinaryDoer("image/png", "test.png", []byte("PNG"))
+
+	// PullRequest
+	doerPullRequestList   = newMockDoer(fixture.PullRequest.ListJSON)
+	doerPullRequestSingle = newMockDoer(fixture.PullRequest.SingleJSON)
+
+	// RecentlyViewed
+	doerRecentlyViewedIssueList    = newMockDoer(fixture.RecentlyViewed.IssueListJSON)
+	doerRecentlyViewedIssueSingle  = newMockDoer(fixture.RecentlyViewed.IssueSingleJSON)
+	doerRecentlyViewedProjectList  = newMockDoer(fixture.RecentlyViewed.ProjectListJSON)
+	doerRecentlyViewedWikiList     = newMockDoer(fixture.RecentlyViewed.WikiListJSON)
+	doerRecentlyViewedWikiSingle   = newMockDoer(fixture.RecentlyViewed.WikiSingleJSON)
+
+	// Repository
+	doerRepositoryList   = newMockDoer(fixture.Repository.ListJSON)
+	doerRepositorySingle = newMockDoer(fixture.Repository.SingleJSON)
+
+	// SharedFile
+	doerSharedFileList   = newMockDoer(fixture.SharedFile.ListJSON)
+	doerSharedFileSingle = newMockDoer(fixture.SharedFile.SingleJSON)
+
+	// Space
+	doerSpaceSpace        = newMockDoer(fixture.Space.SpaceJSON)
+	doerSpaceDiskUsage    = newMockDoer(fixture.Space.DiskUsageJSON)
+	doerSpaceNotification = newMockDoer(fixture.Space.NotificationJSON)
+
+	// Star
+	doerStarList  = newMockDoer(fixture.Star.ListJSON)
+	doerStarCount = newMockDoer(fixture.Star.CountJSON)
+
+	// Status
+	doerStatusList   = newMockDoer(fixture.Status.ListJSON)
+	doerStatusSingle = newMockDoer(fixture.Status.SingleJSON)
+
+	// User
+	doerUserList   = newMockDoer(fixture.User.ListJSON)
+	doerUserSingle = newMockDoer(fixture.User.SingleJSON)
+	doerUserIcon   = newMockBinaryDoer("image/png", "icon.png", []byte("PNG"))
+
+	// Version
+	doerVersionList   = newMockDoer(fixture.Version.ListJSON)
+	doerVersionSingle = newMockDoer(fixture.Version.SingleJSON)
+
+	// Webhook
+	doerWebhookList     = newMockDoer(fixture.Webhook.ListJSON)
+	doerWebhookAllEvent = newMockDoer(fixture.Webhook.AllEventJSON)
+
+	// Wiki
+	doerWikiList        = newMockDoer(fixture.Wiki.ListJSON)
+	doerWikiSingle      = newMockDoer(fixture.Wiki.MinimumJSON)
+	doerWikiHistoryList = newMockDoer(fixture.WikiHistory.ListJSON)
+	doerWikiAttachmentDownload = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
+	doerSharedFileGetFile      = newMockBinaryDoer("image/png", "shared.png", []byte("PNG"))
+	doerAttachmentDownload     = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
+)

--- a/example_issue_test.go
+++ b/example_issue_test.go
@@ -7,12 +7,6 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 )
 
-var (
-	doerIssueCount        = newMockDoer(`{"count":2}`)
-	doerIssueCommentCount = newMockDoer(`{"count":2}`)
-	doerIssueCommentNotifications = newMockDoer(`[{"id":25,"alreadyRead":false,"reason":2,"resourceAlreadyRead":false}]`)
-)
-
 func ExampleIssueService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",

--- a/example_issue_test.go
+++ b/example_issue_test.go
@@ -5,45 +5,19 @@ import (
 	"fmt"
 
 	backlog "github.com/nattokin/go-backlog"
-	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 )
 
 var (
-	// IssueService
-	doerIssueAll          = newMockDoer(fixture.Issue.ListJSON)
 	doerIssueCount        = newMockDoer(`{"count":2}`)
-	doerIssueOne          = newMockDoer(fixture.Issue.SingleJSON)
-	doerIssueCreate       = newMockDoer(fixture.Issue.SingleJSON)
-	doerIssueUpdate       = newMockDoer(fixture.Issue.SingleJSON)
-	doerIssueDelete       = newMockDoer(fixture.Issue.SingleJSON)
-	doerIssueParticipants = newMockDoer(fixture.User.ListJSON)
-
-	// IssueAttachmentService
-	doerIssueAttachmentList     = newMockDoer(fixture.Attachment.ListJSON)
-	doerIssueAttachmentDownload = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
-	doerIssueAttachmentRemove   = newMockDoer(fixture.Attachment.SingleJSON)
-
-	// IssueCommentService
-	doerIssueCommentAll           = newMockDoer(fixture.Comment.ListJSON)
-	doerIssueCommentAdd           = newMockDoer(fixture.Comment.SingleJSON)
-	doerIssueCommentCount         = newMockDoer(`{"count":2}`)
-	doerIssueCommentDelete        = newMockDoer(fixture.Comment.SingleJSON)
+	doerIssueCommentCount = newMockDoer(`{"count":2}`)
 	doerIssueCommentNotifications = newMockDoer(`[{"id":25,"alreadyRead":false,"reason":2,"resourceAlreadyRead":false}]`)
-	doerIssueCommentNotify        = newMockDoer(fixture.Comment.SingleJSON)
-	doerIssueCommentOne           = newMockDoer(fixture.Comment.SingleJSON)
-	doerIssueCommentUpdate        = newMockDoer(fixture.Comment.SingleJSON)
-
-	// IssueSharedFileService
-	doerIssueSharedFileLink   = newMockDoer(fixture.SharedFile.ListJSON)
-	doerIssueSharedFileList   = newMockDoer(fixture.SharedFile.ListJSON)
-	doerIssueSharedFileUnlink = newMockDoer(fixture.SharedFile.SingleJSON)
 )
 
 func ExampleIssueService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueAll),
+		backlog.WithDoer(doerIssueList),
 	)
 
 	issues, _ := c.Issue.All(context.Background())
@@ -69,7 +43,7 @@ func ExampleIssueService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueOne),
+		backlog.WithDoer(doerIssueSingle),
 	)
 
 	issue, _ := c.Issue.One(context.Background(), "PRJ-1")
@@ -82,7 +56,7 @@ func ExampleIssueService_Create() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueCreate),
+		backlog.WithDoer(doerIssueSingle),
 	)
 
 	issue, _ := c.Issue.Create(context.Background(), 10, "First issue", 2, 3)
@@ -95,7 +69,7 @@ func ExampleIssueService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueUpdate),
+		backlog.WithDoer(doerIssueSingle),
 	)
 
 	issue, _ := c.Issue.Update(context.Background(), "PRJ-1", c.Issue.Option.WithSummary("First issue"))
@@ -108,7 +82,7 @@ func ExampleIssueService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueDelete),
+		backlog.WithDoer(doerIssueSingle),
 	)
 
 	issue, _ := c.Issue.Delete(context.Background(), "PRJ-1")
@@ -121,7 +95,7 @@ func ExampleIssueService_Participants() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueParticipants),
+		backlog.WithDoer(doerUserList),
 	)
 
 	users, _ := c.Issue.Participants(context.Background(), "PRJ-1")
@@ -134,7 +108,7 @@ func ExampleIssueAttachmentService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueAttachmentList),
+		backlog.WithDoer(doerAttachmentList),
 	)
 
 	attachments, _ := c.Issue.Attachment.List(context.Background(), "TEST-1")
@@ -147,7 +121,7 @@ func ExampleIssueAttachmentService_Download() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueAttachmentDownload),
+		backlog.WithDoer(doerAttachmentDownload),
 	)
 
 	file, _ := c.Issue.Attachment.Download(context.Background(), "TEST-1", 2)
@@ -160,7 +134,7 @@ func ExampleIssueAttachmentService_Remove() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueAttachmentRemove),
+		backlog.WithDoer(doerAttachmentSingle),
 	)
 
 	attachment, _ := c.Issue.Attachment.Remove(context.Background(), "TEST-1", 8)
@@ -173,7 +147,7 @@ func ExampleIssueCommentService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueCommentAll),
+		backlog.WithDoer(doerCommentList),
 	)
 
 	comments, _ := c.Issue.Comment.All(context.Background(), "PRJ-1")
@@ -186,7 +160,7 @@ func ExampleIssueCommentService_Add() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueCommentAdd),
+		backlog.WithDoer(doerCommentSingle),
 	)
 
 	comment, _ := c.Issue.Comment.Add(context.Background(), "PRJ-1", "This is a comment.")
@@ -212,7 +186,7 @@ func ExampleIssueCommentService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueCommentDelete),
+		backlog.WithDoer(doerCommentSingle),
 	)
 
 	comment, _ := c.Issue.Comment.Delete(context.Background(), "PRJ-1", 1)
@@ -238,7 +212,7 @@ func ExampleIssueCommentService_Notify() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueCommentNotify),
+		backlog.WithDoer(doerCommentSingle),
 	)
 
 	comment, _ := c.Issue.Comment.Notify(context.Background(), "PRJ-1", 1, []int{5686})
@@ -251,7 +225,7 @@ func ExampleIssueCommentService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueCommentOne),
+		backlog.WithDoer(doerCommentSingle),
 	)
 
 	comment, _ := c.Issue.Comment.One(context.Background(), "PRJ-1", 1)
@@ -264,7 +238,7 @@ func ExampleIssueCommentService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueCommentUpdate),
+		backlog.WithDoer(doerCommentSingle),
 	)
 
 	comment, _ := c.Issue.Comment.Update(context.Background(), "PRJ-1", 1, "This is a comment.")
@@ -277,7 +251,7 @@ func ExampleIssueSharedFileService_Link() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueSharedFileLink),
+		backlog.WithDoer(doerSharedFileList),
 	)
 
 	files, _ := c.Issue.SharedFile.Link(context.Background(), "TEST-1", []int{454403, 454404})
@@ -290,7 +264,7 @@ func ExampleIssueSharedFileService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueSharedFileList),
+		backlog.WithDoer(doerSharedFileList),
 	)
 
 	files, _ := c.Issue.SharedFile.List(context.Background(), "TEST-1")
@@ -303,7 +277,7 @@ func ExampleIssueSharedFileService_Unlink() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueSharedFileUnlink),
+		backlog.WithDoer(doerSharedFileSingle),
 	)
 
 	file, _ := c.Issue.SharedFile.Unlink(context.Background(), "TEST-1", 454403)

--- a/example_option_test.go
+++ b/example_option_test.go
@@ -5,56 +5,6 @@ import (
 	"fmt"
 
 	backlog "github.com/nattokin/go-backlog"
-	"github.com/nattokin/go-backlog/internal/testutil/fixture"
-)
-
-var (
-	// WikiOptionService
-	doerWikiOption = newMockDoer(fixture.Wiki.MinimumJSON)
-
-	// IssueOptionService
-	doerIssueOption = newMockDoer(fixture.Issue.ListJSON)
-
-	// IssueCommentOptionService
-	doerIssueCommentOption = newMockDoer(fixture.Comment.ListJSON)
-
-	// ProjectOptionService
-	doerProjectOption = newMockDoer(fixture.Project.ListJSON)
-
-	// UserOptionService
-	doerUserOption = newMockDoer(fixture.User.SingleJSON)
-
-	// UserRecentlyViewedOptionService
-	doerUserRecentlyViewedOption = newMockDoer(fixture.RecentlyViewed.IssueListJSON)
-
-	// UserStarOptionService
-	doerUserStarOption = newMockDoer(fixture.Star.ListJSON)
-
-	// PullRequestOptionService
-	doerPullRequestOption = newMockDoer(fixture.PullRequest.ListJSON)
-
-	// PullRequestCommentOptionService
-	doerPullRequestCommentOption = newMockDoer(fixture.Comment.ListJSON)
-
-	// ActivityOptionService
-	doerActivityOptionSpace   = newMockDoer(fixture.Activity.ListJSON)
-	doerActivityOptionProject = newMockDoer(fixture.Activity.ListJSON)
-	doerActivityOptionUser    = newMockDoer(fixture.Activity.ListJSON)
-
-	// ProjectCustomFieldOptionService
-	doerProjectCustomFieldOption = newMockDoer(fixture.CustomField.SingleJSON)
-
-	// ProjectIssueTypeOptionService
-	doerProjectIssueTypeOption = newMockDoer(fixture.IssueType.SingleJSON)
-
-	// ProjectStatusOptionService
-	doerProjectStatusOption = newMockDoer(fixture.Status.SingleJSON)
-
-	// ProjectVersionOptionService
-	doerProjectVersionOption = newMockDoer(fixture.Version.SingleJSON)
-
-	// ProjectWebhookOptionService
-	doerProjectWebhookOption = newMockDoer(fixture.Webhook.AllEventJSON)
 )
 
 // ExampleWikiOptionService demonstrates updating a wiki page using multiple options.
@@ -62,7 +12,7 @@ func ExampleWikiOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiOption),
+		backlog.WithDoer(doerWikiSingle),
 	)
 
 	wiki, _ := c.Wiki.Update(
@@ -81,7 +31,7 @@ func ExampleIssueOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueOption),
+		backlog.WithDoer(doerIssueList),
 	)
 
 	issues, _ := c.Issue.All(
@@ -100,7 +50,7 @@ func ExampleIssueCommentOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerIssueCommentOption),
+		backlog.WithDoer(doerCommentList),
 	)
 
 	comments, _ := c.Issue.Comment.All(
@@ -119,7 +69,7 @@ func ExampleProjectOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectOption),
+		backlog.WithDoer(doerProjectList),
 	)
 
 	projects, _ := c.Project.All(
@@ -137,7 +87,7 @@ func ExampleRecentlyViewedOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserRecentlyViewedOption),
+		backlog.WithDoer(doerRecentlyViewedIssueList),
 	)
 
 	issues, _ := c.RecentlyViewed.ListIssues(
@@ -155,7 +105,7 @@ func ExampleUserOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserOption),
+		backlog.WithDoer(doerUserSingle),
 	)
 
 	user, _ := c.User.Update(
@@ -174,7 +124,7 @@ func ExampleUserStarOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserStarOption),
+		backlog.WithDoer(doerStarList),
 	)
 
 	stars, _ := c.User.Star.List(
@@ -193,7 +143,7 @@ func ExamplePullRequestOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestOption),
+		backlog.WithDoer(doerPullRequestList),
 	)
 
 	prs, _ := c.PullRequest.All(
@@ -213,7 +163,7 @@ func ExamplePullRequestCommentOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestCommentOption),
+		backlog.WithDoer(doerCommentList),
 	)
 
 	comments, _ := c.PullRequest.Comment.All(
@@ -252,7 +202,7 @@ func ExampleActivityOptionService_spaceWithOptions() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerActivityOptionSpace),
+		backlog.WithDoer(doerActivityList),
 	)
 
 	activities, _ := c.Space.Activity.List(
@@ -270,7 +220,7 @@ func ExampleActivityOptionService_projectWithOptions() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerActivityOptionProject),
+		backlog.WithDoer(doerActivityList),
 	)
 
 	activities, _ := c.Project.Activity.List(
@@ -289,7 +239,7 @@ func ExampleActivityOptionService_userWithOptions() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerActivityOptionUser),
+		backlog.WithDoer(doerActivityList),
 	)
 
 	activities, _ := c.User.Activity.List(
@@ -308,7 +258,7 @@ func ExampleProjectCustomFieldOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCustomFieldOption),
+		backlog.WithDoer(doerCustomFieldSingle),
 	)
 
 	field, _ := c.Project.CustomField.Update(
@@ -329,7 +279,7 @@ func ExampleProjectIssueTypeOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectIssueTypeOption),
+		backlog.WithDoer(doerIssueTypeSingle),
 	)
 
 	issueType, _ := c.Project.IssueType.Update(
@@ -349,7 +299,7 @@ func ExampleProjectStatusOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectStatusOption),
+		backlog.WithDoer(doerStatusSingle),
 	)
 
 	status, _ := c.Project.Status.Update(
@@ -369,7 +319,7 @@ func ExampleProjectVersionOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectVersionOption),
+		backlog.WithDoer(doerVersionSingle),
 	)
 
 	version, _ := c.Project.Version.Update(
@@ -389,7 +339,7 @@ func ExampleProjectWebhookOptionService() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectWebhookOption),
+		backlog.WithDoer(doerWebhookAllEvent),
 	)
 
 	wh, _ := c.Project.Webhook.Update(

--- a/example_project_test.go
+++ b/example_project_test.go
@@ -5,81 +5,13 @@ import (
 	"fmt"
 
 	backlog "github.com/nattokin/go-backlog"
-	"github.com/nattokin/go-backlog/internal/testutil/fixture"
-)
-
-var (
-	// ProjectService
-	doerProjectAll       = newMockDoer(fixture.Project.ListJSON)
-	doerProjectOne       = newMockDoer(fixture.Project.SingleJSON)
-	doerProjectCreate    = newMockDoer(fixture.Project.SingleJSON)
-	doerProjectUpdate    = newMockDoer(fixture.Project.SingleJSON)
-	doerProjectDelete    = newMockDoer(fixture.Project.SingleJSON)
-	doerProjectDiskUsage = newMockDoer(fixture.Project.DiskUsageJSON)
-	doerProjectIcon      = newMockBinaryDoer("image/png", "test.png", []byte("PNG"))
-
-	// ProjectActivityService
-	doerProjectActivityList = newMockDoer(fixture.Activity.ListJSON)
-
-	// ProjectSharedFileService
-	doerProjectSharedFileList    = newMockDoer(fixture.SharedFile.ListJSON)
-	doerProjectSharedFileGetFile = newMockBinaryDoer("image/png", "shared.png", []byte("PNG"))
-
-	// ProjectCategoryService
-	doerProjectCategoryAll    = newMockDoer(fixture.Category.ListJSON)
-	doerProjectCategoryCreate = newMockDoer(fixture.Category.SingleJSON)
-	doerProjectCategoryUpdate = newMockDoer(fixture.Category.SingleJSON)
-	doerProjectCategoryDelete = newMockDoer(fixture.Category.SingleJSON)
-
-	// ProjectCustomFieldService
-	doerProjectCustomFieldAll            = newMockDoer(fixture.CustomField.ListJSON)
-	doerProjectCustomFieldCreate         = newMockDoer(fixture.CustomField.SingleJSON)
-	doerProjectCustomFieldUpdate         = newMockDoer(fixture.CustomField.SingleJSON)
-	doerProjectCustomFieldDelete         = newMockDoer(fixture.CustomField.SingleJSON)
-	doerProjectCustomFieldAddListItem    = newMockDoer(fixture.CustomField.SingleJSON)
-	doerProjectCustomFieldUpdateListItem = newMockDoer(fixture.CustomField.SingleJSON)
-	doerProjectCustomFieldDeleteListItem = newMockDoer(fixture.CustomField.SingleJSON)
-
-	// ProjectIssueTypeService
-	doerProjectIssueTypeAll    = newMockDoer(fixture.IssueType.ListJSON)
-	doerProjectIssueTypeCreate = newMockDoer(fixture.IssueType.SingleJSON)
-	doerProjectIssueTypeUpdate = newMockDoer(fixture.IssueType.SingleJSON)
-	doerProjectIssueTypeDelete = newMockDoer(fixture.IssueType.SingleJSON)
-
-	// ProjectUserService
-	doerProjectUserAll         = newMockDoer(fixture.User.ListJSON)
-	doerProjectUserAdd         = newMockDoer(fixture.User.SingleJSON)
-	doerProjectUserDelete      = newMockDoer(fixture.User.SingleJSON)
-	doerProjectUserAddAdmin    = newMockDoer(fixture.User.SingleJSON)
-	doerProjectUserAdminAll    = newMockDoer(fixture.User.ListJSON)
-	doerProjectUserDeleteAdmin = newMockDoer(fixture.User.SingleJSON)
-
-	// ProjectWebhookService
-	doerProjectWebhookAll    = newMockDoer(fixture.Webhook.ListJSON)
-	doerProjectWebhookCreate = newMockDoer(fixture.Webhook.AllEventJSON)
-	doerProjectWebhookOne    = newMockDoer(fixture.Webhook.AllEventJSON)
-	doerProjectWebhookUpdate = newMockDoer(fixture.Webhook.AllEventJSON)
-	doerProjectWebhookDelete = newMockDoer(fixture.Webhook.AllEventJSON)
-
-	// ProjectStatusService
-	doerProjectStatusAll         = newMockDoer(fixture.Status.ListJSON)
-	doerProjectStatusCreate      = newMockDoer(fixture.Status.SingleJSON)
-	doerProjectStatusUpdate      = newMockDoer(fixture.Status.SingleJSON)
-	doerProjectStatusDelete      = newMockDoer(fixture.Status.SingleJSON)
-	doerProjectStatusUpdateOrder = newMockDoer(fixture.Status.ListJSON)
-
-	// ProjectVersionService
-	doerProjectVersionAll    = newMockDoer(fixture.Version.ListJSON)
-	doerProjectVersionCreate = newMockDoer(fixture.Version.SingleJSON)
-	doerProjectVersionUpdate = newMockDoer(fixture.Version.SingleJSON)
-	doerProjectVersionDelete = newMockDoer(fixture.Version.SingleJSON)
 )
 
 func ExampleProjectService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectAll),
+		backlog.WithDoer(doerProjectList),
 	)
 
 	projects, _ := c.Project.All(context.Background())
@@ -92,7 +24,7 @@ func ExampleProjectService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectOne),
+		backlog.WithDoer(doerProjectSingle),
 	)
 
 	project, _ := c.Project.One(context.Background(), "TEST")
@@ -105,7 +37,7 @@ func ExampleProjectService_Create() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCreate),
+		backlog.WithDoer(doerProjectSingle),
 	)
 
 	project, _ := c.Project.Create(context.Background(), "TEST", "test")
@@ -118,7 +50,7 @@ func ExampleProjectService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectUpdate),
+		backlog.WithDoer(doerProjectSingle),
 	)
 
 	project, _ := c.Project.Update(context.Background(), "TEST",
@@ -133,7 +65,7 @@ func ExampleProjectService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectDelete),
+		backlog.WithDoer(doerProjectSingle),
 	)
 
 	project, _ := c.Project.Delete(context.Background(), "TEST")
@@ -172,7 +104,7 @@ func ExampleProjectActivityService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectActivityList),
+		backlog.WithDoer(doerActivityList),
 	)
 
 	activities, _ := c.Project.Activity.List(context.Background(), "TEST")
@@ -185,7 +117,7 @@ func ExampleProjectCategoryService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCategoryAll),
+		backlog.WithDoer(doerCategoryList),
 	)
 
 	categories, _ := c.Project.Category.All(context.Background(), "TEST")
@@ -198,7 +130,7 @@ func ExampleProjectCategoryService_Create() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCategoryCreate),
+		backlog.WithDoer(doerCategorySingle),
 	)
 
 	category, _ := c.Project.Category.Create(context.Background(), "TEST", "Bug")
@@ -211,7 +143,7 @@ func ExampleProjectCategoryService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCategoryUpdate),
+		backlog.WithDoer(doerCategorySingle),
 	)
 
 	category, _ := c.Project.Category.Update(context.Background(), "TEST", 12, "Bug Fixed")
@@ -224,7 +156,7 @@ func ExampleProjectCategoryService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCategoryDelete),
+		backlog.WithDoer(doerCategorySingle),
 	)
 
 	category, _ := c.Project.Category.Delete(context.Background(), "TEST", 12)
@@ -237,7 +169,7 @@ func ExampleProjectCustomFieldService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCustomFieldAll),
+		backlog.WithDoer(doerCustomFieldList),
 	)
 
 	fields, _ := c.Project.CustomField.All(context.Background(), "TEST")
@@ -250,7 +182,7 @@ func ExampleProjectCustomFieldService_Create() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCustomFieldCreate),
+		backlog.WithDoer(doerCustomFieldSingle),
 	)
 
 	field, _ := c.Project.CustomField.Create(context.Background(), "TEST", backlog.CustomFieldTypeText, "Sprint")
@@ -263,7 +195,7 @@ func ExampleProjectCustomFieldService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCustomFieldUpdate),
+		backlog.WithDoer(doerCustomFieldSingle),
 	)
 
 	field, _ := c.Project.CustomField.Update(
@@ -281,7 +213,7 @@ func ExampleProjectCustomFieldService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCustomFieldDelete),
+		backlog.WithDoer(doerCustomFieldSingle),
 	)
 
 	field, _ := c.Project.CustomField.Delete(context.Background(), "TEST", 1)
@@ -294,7 +226,7 @@ func ExampleProjectCustomFieldService_AddListItem() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCustomFieldAddListItem),
+		backlog.WithDoer(doerCustomFieldSingle),
 	)
 
 	field, _ := c.Project.CustomField.AddListItem(context.Background(), "TEST", 1, "Item1")
@@ -307,7 +239,7 @@ func ExampleProjectCustomFieldService_UpdateListItem() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCustomFieldUpdateListItem),
+		backlog.WithDoer(doerCustomFieldSingle),
 	)
 
 	field, _ := c.Project.CustomField.UpdateListItem(context.Background(), "TEST", 1, 10, "Item1 Updated")
@@ -320,7 +252,7 @@ func ExampleProjectCustomFieldService_DeleteListItem() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectCustomFieldDeleteListItem),
+		backlog.WithDoer(doerCustomFieldSingle),
 	)
 
 	field, _ := c.Project.CustomField.DeleteListItem(context.Background(), "TEST", 1, 10)
@@ -333,7 +265,7 @@ func ExampleProjectIssueTypeService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectIssueTypeAll),
+		backlog.WithDoer(doerIssueTypeList),
 	)
 
 	issueTypes, _ := c.Project.IssueType.All(context.Background(), "TEST")
@@ -346,7 +278,7 @@ func ExampleProjectIssueTypeService_Create() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectIssueTypeCreate),
+		backlog.WithDoer(doerIssueTypeSingle),
 	)
 
 	issueType, _ := c.Project.IssueType.Create(context.Background(), "TEST", "Bug", "#e30000")
@@ -359,7 +291,7 @@ func ExampleProjectIssueTypeService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectIssueTypeUpdate),
+		backlog.WithDoer(doerIssueTypeSingle),
 	)
 
 	issueType, _ := c.Project.IssueType.Update(context.Background(), "TEST", 1,
@@ -374,7 +306,7 @@ func ExampleProjectIssueTypeService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectIssueTypeDelete),
+		backlog.WithDoer(doerIssueTypeSingle),
 	)
 
 	issueType, _ := c.Project.IssueType.Delete(context.Background(), "TEST", 1, 2)
@@ -387,7 +319,7 @@ func ExampleProjectSharedFileService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectSharedFileList),
+		backlog.WithDoer(doerSharedFileList),
 	)
 
 	files, _ := c.Project.SharedFile.List(context.Background(), "TEST")
@@ -400,7 +332,7 @@ func ExampleProjectSharedFileService_GetFile() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectSharedFileGetFile),
+		backlog.WithDoer(doerSharedFileGetFile),
 	)
 
 	file, _ := c.Project.SharedFile.GetFile(context.Background(), "TEST", 1)
@@ -413,7 +345,7 @@ func ExampleProjectUserService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectUserAll),
+		backlog.WithDoer(doerUserList),
 	)
 
 	users, _ := c.Project.User.All(context.Background(), "TEST", false)
@@ -426,7 +358,7 @@ func ExampleProjectUserService_Add() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectUserAdd),
+		backlog.WithDoer(doerUserSingle),
 	)
 
 	user, _ := c.Project.User.Add(context.Background(), "TEST", 1)
@@ -439,7 +371,7 @@ func ExampleProjectUserService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectUserDelete),
+		backlog.WithDoer(doerUserSingle),
 	)
 
 	user, _ := c.Project.User.Delete(context.Background(), "TEST", 1)
@@ -452,7 +384,7 @@ func ExampleProjectUserService_AddAdmin() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectUserAddAdmin),
+		backlog.WithDoer(doerUserSingle),
 	)
 
 	user, _ := c.Project.User.AddAdmin(context.Background(), "TEST", 1)
@@ -465,7 +397,7 @@ func ExampleProjectUserService_AdminAll() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectUserAdminAll),
+		backlog.WithDoer(doerUserList),
 	)
 
 	users, _ := c.Project.User.AdminAll(context.Background(), "TEST")
@@ -478,7 +410,7 @@ func ExampleProjectUserService_DeleteAdmin() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectUserDeleteAdmin),
+		backlog.WithDoer(doerUserSingle),
 	)
 
 	user, _ := c.Project.User.DeleteAdmin(context.Background(), "TEST", 1)
@@ -491,7 +423,7 @@ func ExampleProjectWebhookService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectWebhookAll),
+		backlog.WithDoer(doerWebhookList),
 	)
 
 	webhooks, _ := c.Project.Webhook.All(context.Background(), "TEST")
@@ -504,7 +436,7 @@ func ExampleProjectWebhookService_Create() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectWebhookCreate),
+		backlog.WithDoer(doerWebhookAllEvent),
 	)
 
 	wh, _ := c.Project.Webhook.Create(
@@ -523,7 +455,7 @@ func ExampleProjectWebhookService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectWebhookOne),
+		backlog.WithDoer(doerWebhookAllEvent),
 	)
 
 	wh, _ := c.Project.Webhook.One(context.Background(), "TEST", 1)
@@ -536,7 +468,7 @@ func ExampleProjectWebhookService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectWebhookUpdate),
+		backlog.WithDoer(doerWebhookAllEvent),
 	)
 
 	wh, _ := c.Project.Webhook.Update(
@@ -554,7 +486,7 @@ func ExampleProjectWebhookService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectWebhookDelete),
+		backlog.WithDoer(doerWebhookAllEvent),
 	)
 
 	wh, _ := c.Project.Webhook.Delete(context.Background(), "TEST", 1)
@@ -567,7 +499,7 @@ func ExampleProjectStatusService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectStatusAll),
+		backlog.WithDoer(doerStatusList),
 	)
 
 	statuses, _ := c.Project.Status.All(context.Background(), "TEST")
@@ -580,7 +512,7 @@ func ExampleProjectStatusService_Create() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectStatusCreate),
+		backlog.WithDoer(doerStatusSingle),
 	)
 
 	status, _ := c.Project.Status.Create(context.Background(), "TEST", "Open", "#ed8077")
@@ -593,7 +525,7 @@ func ExampleProjectStatusService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectStatusUpdate),
+		backlog.WithDoer(doerStatusSingle),
 	)
 
 	status, _ := c.Project.Status.Update(
@@ -611,7 +543,7 @@ func ExampleProjectStatusService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectStatusDelete),
+		backlog.WithDoer(doerStatusSingle),
 	)
 
 	status, _ := c.Project.Status.Delete(context.Background(), "TEST", 1, 2)
@@ -624,7 +556,7 @@ func ExampleProjectStatusService_UpdateOrder() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectStatusUpdateOrder),
+		backlog.WithDoer(doerStatusList),
 	)
 
 	statuses, _ := c.Project.Status.UpdateOrder(context.Background(), "TEST", []int{1, 2})
@@ -637,7 +569,7 @@ func ExampleProjectVersionService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectVersionAll),
+		backlog.WithDoer(doerVersionList),
 	)
 
 	versions, _ := c.Project.Version.All(context.Background(), "TEST")
@@ -650,7 +582,7 @@ func ExampleProjectVersionService_Create() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectVersionCreate),
+		backlog.WithDoer(doerVersionSingle),
 	)
 
 	version, _ := c.Project.Version.Create(
@@ -667,7 +599,7 @@ func ExampleProjectVersionService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectVersionUpdate),
+		backlog.WithDoer(doerVersionSingle),
 	)
 
 	version, _ := c.Project.Version.Update(
@@ -685,7 +617,7 @@ func ExampleProjectVersionService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerProjectVersionDelete),
+		backlog.WithDoer(doerVersionSingle),
 	)
 
 	version, _ := c.Project.Version.Delete(context.Background(), "TEST", 1)

--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -5,35 +5,18 @@ import (
 	"fmt"
 
 	backlog "github.com/nattokin/go-backlog"
-	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 )
 
 var (
-	// PullRequestService
-	doerPullRequestAll    = newMockDoer(fixture.PullRequest.ListJSON)
-	doerPullRequestCount  = newMockDoer(`{"count":2}`)
-	doerPullRequestOne    = newMockDoer(fixture.PullRequest.SingleJSON)
-	doerPullRequestCreate = newMockDoer(fixture.PullRequest.SingleJSON)
-	doerPullRequestUpdate = newMockDoer(fixture.PullRequest.SingleJSON)
-
-	// PullRequestCommentService
-	doerPullRequestCommentAll    = newMockDoer(fixture.Comment.ListJSON)
-	doerPullRequestCommentAdd    = newMockDoer(fixture.Comment.SingleJSON)
-	doerPullRequestCommentCount  = newMockDoer(`{"count":2}`)
-	doerPullRequestCommentOne    = newMockDoer(fixture.Comment.SingleJSON)
-	doerPullRequestCommentUpdate = newMockDoer(fixture.Comment.SingleJSON)
-
-	// PullRequestAttachmentService
-	doerPullRequestAttachmentList     = newMockDoer(fixture.Attachment.ListJSON)
-	doerPullRequestAttachmentDownload = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
-	doerPullRequestAttachmentRemove   = newMockDoer(fixture.Attachment.SingleJSON)
+	doerPullRequestCount        = newMockDoer(`{"count":2}`)
+	doerPullRequestCommentCount = newMockDoer(`{"count":2}`)
 )
 
 func ExamplePullRequestService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestAll),
+		backlog.WithDoer(doerPullRequestList),
 	)
 
 	prs, _ := c.PullRequest.All(context.Background(), "TEST", "myrepo")
@@ -59,7 +42,7 @@ func ExamplePullRequestService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestOne),
+		backlog.WithDoer(doerPullRequestSingle),
 	)
 
 	pr, _ := c.PullRequest.One(context.Background(), "TEST", "myrepo", 1)
@@ -72,7 +55,7 @@ func ExamplePullRequestService_Create() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestCreate),
+		backlog.WithDoer(doerPullRequestSingle),
 	)
 
 	pr, _ := c.PullRequest.Create(context.Background(), "TEST", "myrepo", "test PR", "test description", "main", "feature/foo")
@@ -85,7 +68,7 @@ func ExamplePullRequestService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestUpdate),
+		backlog.WithDoer(doerPullRequestSingle),
 	)
 
 	pr, _ := c.PullRequest.Update(context.Background(), "TEST", "myrepo", 1, c.PullRequest.Option.WithSummary("test PR"))
@@ -98,7 +81,7 @@ func ExamplePullRequestAttachmentService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestAttachmentList),
+		backlog.WithDoer(doerAttachmentList),
 	)
 
 	attachments, _ := c.PullRequest.Attachment.List(context.Background(), "TEST", "myrepo", 1)
@@ -111,7 +94,7 @@ func ExamplePullRequestAttachmentService_Download() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestAttachmentDownload),
+		backlog.WithDoer(doerAttachmentDownload),
 	)
 
 	file, _ := c.PullRequest.Attachment.Download(context.Background(), "TEST", "myrepo", 1, 2)
@@ -124,7 +107,7 @@ func ExamplePullRequestAttachmentService_Remove() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestAttachmentRemove),
+		backlog.WithDoer(doerAttachmentSingle),
 	)
 
 	attachment, _ := c.PullRequest.Attachment.Remove(context.Background(), "TEST", "myrepo", 1, 8)
@@ -137,7 +120,7 @@ func ExamplePullRequestCommentService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestCommentAll),
+		backlog.WithDoer(doerCommentList),
 	)
 
 	comments, _ := c.PullRequest.Comment.All(context.Background(), "TEST", "myrepo", 1)
@@ -150,7 +133,7 @@ func ExamplePullRequestCommentService_Add() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestCommentAdd),
+		backlog.WithDoer(doerCommentSingle),
 	)
 
 	comment, _ := c.PullRequest.Comment.Add(context.Background(), "TEST", "myrepo", 1, "This is a comment.")
@@ -176,7 +159,7 @@ func ExamplePullRequestCommentService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestCommentOne),
+		backlog.WithDoer(doerCommentSingle),
 	)
 
 	comment, _ := c.PullRequest.Comment.One(context.Background(), "TEST", "myrepo", 1, 1)
@@ -189,7 +172,7 @@ func ExamplePullRequestCommentService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerPullRequestCommentUpdate),
+		backlog.WithDoer(doerCommentSingle),
 	)
 
 	comment, _ := c.PullRequest.Comment.Update(context.Background(), "TEST", "myrepo", 1, 1, "This is a comment.")

--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -7,11 +7,6 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 )
 
-var (
-	doerPullRequestCount        = newMockDoer(`{"count":2}`)
-	doerPullRequestCommentCount = newMockDoer(`{"count":2}`)
-)
-
 func ExamplePullRequestService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",

--- a/example_recentlyviewed_test.go
+++ b/example_recentlyviewed_test.go
@@ -5,22 +5,13 @@ import (
 	"fmt"
 
 	backlog "github.com/nattokin/go-backlog"
-	"github.com/nattokin/go-backlog/internal/testutil/fixture"
-)
-
-var (
-	doerRecentlyViewedListIssues   = newMockDoer(fixture.RecentlyViewed.IssueListJSON)
-	doerRecentlyViewedAddIssue     = newMockDoer(fixture.RecentlyViewed.IssueSingleJSON)
-	doerRecentlyViewedListProjects = newMockDoer(fixture.RecentlyViewed.ProjectListJSON)
-	doerRecentlyViewedListWikis    = newMockDoer(fixture.RecentlyViewed.WikiListJSON)
-	doerRecentlyViewedAddWiki      = newMockDoer(fixture.RecentlyViewed.WikiSingleJSON)
 )
 
 func ExampleRecentlyViewedService_ListIssues() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerRecentlyViewedListIssues),
+		backlog.WithDoer(doerRecentlyViewedIssueList),
 	)
 
 	issues, _ := c.RecentlyViewed.ListIssues(context.Background())
@@ -33,7 +24,7 @@ func ExampleRecentlyViewedService_AddIssue() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerRecentlyViewedAddIssue),
+		backlog.WithDoer(doerRecentlyViewedIssueSingle),
 	)
 
 	issue, _ := c.RecentlyViewed.AddIssue(context.Background(), 1)
@@ -46,7 +37,7 @@ func ExampleRecentlyViewedService_ListProjects() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerRecentlyViewedListProjects),
+		backlog.WithDoer(doerRecentlyViewedProjectList),
 	)
 
 	projects, _ := c.RecentlyViewed.ListProjects(context.Background())
@@ -59,7 +50,7 @@ func ExampleRecentlyViewedService_ListWikis() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerRecentlyViewedListWikis),
+		backlog.WithDoer(doerRecentlyViewedWikiList),
 	)
 
 	wikis, _ := c.RecentlyViewed.ListWikis(context.Background())
@@ -72,7 +63,7 @@ func ExampleRecentlyViewedService_AddWiki() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerRecentlyViewedAddWiki),
+		backlog.WithDoer(doerRecentlyViewedWikiSingle),
 	)
 
 	wiki, _ := c.RecentlyViewed.AddWiki(context.Background(), 10)

--- a/example_repository_test.go
+++ b/example_repository_test.go
@@ -5,20 +5,13 @@ import (
 	"fmt"
 
 	backlog "github.com/nattokin/go-backlog"
-	"github.com/nattokin/go-backlog/internal/testutil/fixture"
-)
-
-var (
-	// RepositoryService
-	doerRepositoryAll = newMockDoer(fixture.Repository.ListJSON)
-	doerRepositoryOne = newMockDoer(fixture.Repository.SingleJSON)
 )
 
 func ExampleRepositoryService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerRepositoryAll),
+		backlog.WithDoer(doerRepositoryList),
 	)
 
 	repos, _ := c.Repository.All(context.Background(), "TEST")
@@ -31,7 +24,7 @@ func ExampleRepositoryService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerRepositoryOne),
+		backlog.WithDoer(doerRepositorySingle),
 	)
 
 	repo, _ := c.Repository.One(context.Background(), "TEST", "foo")

--- a/example_space_test.go
+++ b/example_space_test.go
@@ -6,29 +6,13 @@ import (
 	"strings"
 
 	backlog "github.com/nattokin/go-backlog"
-	"github.com/nattokin/go-backlog/internal/testutil/fixture"
-)
-
-var (
-	// SpaceService
-	doerSpaceOne                = newMockDoer(fixture.Space.SpaceJSON)
-	doerSpaceDiskUsage          = newMockDoer(fixture.Space.DiskUsageJSON)
-	doerSpaceNotification       = newMockDoer(fixture.Space.NotificationJSON)
-	doerSpaceUpdateNotification = newMockDoer(fixture.Space.NotificationJSON)
-
-	// SpaceActivityService
-	doerSpaceActivityList = newMockDoer(fixture.Activity.ListJSON)
-	doerSpaceActivityGet  = newMockDoer(fixture.Activity.SingleJSON)
-
-	// SpaceAttachmentService
-	doerSpaceAttachmentUpload = newMockDoer(fixture.Attachment.UploadJSON)
 )
 
 func ExampleSpaceService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerSpaceOne),
+		backlog.WithDoer(doerSpaceSpace),
 	)
 
 	space, _ := c.Space.One(context.Background())
@@ -67,7 +51,7 @@ func ExampleSpaceService_UpdateNotification() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerSpaceUpdateNotification),
+		backlog.WithDoer(doerSpaceNotification),
 	)
 
 	notification, _ := c.Space.UpdateNotification(context.Background(), "Backlog is a project management tool.")
@@ -80,7 +64,7 @@ func ExampleSpaceActivityService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerSpaceActivityList),
+		backlog.WithDoer(doerActivityList),
 	)
 
 	activities, _ := c.Space.Activity.List(context.Background())
@@ -93,7 +77,7 @@ func ExampleSpaceActivityService_Get() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerSpaceActivityGet),
+		backlog.WithDoer(doerActivitySingle),
 	)
 
 	activity, _ := c.Space.Activity.Get(context.Background(), 3153)
@@ -106,7 +90,7 @@ func ExampleSpaceAttachmentService_Upload() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerSpaceAttachmentUpload),
+		backlog.WithDoer(doerAttachmentUpload),
 	)
 
 	attachment, _ := c.Space.Attachment.Upload(context.Background(), "test.txt", strings.NewReader("hello"))

--- a/example_test.go
+++ b/example_test.go
@@ -6,12 +6,6 @@ import (
 	"net/http"
 
 	backlog "github.com/nattokin/go-backlog"
-	"github.com/nattokin/go-backlog/internal/testutil/fixture"
-)
-
-var (
-	doerExample            = newMockDoer(fixture.Wiki.ListJSON)
-	doerExampleWithOptions = newMockDoer(fixture.Wiki.ListJSON)
 )
 
 // Example demonstrates basic usage: creating a client and listing wiki pages.
@@ -19,7 +13,7 @@ func Example() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerExample),
+		backlog.WithDoer(doerWikiList),
 	)
 
 	wikis, _ := c.Wiki.All(context.Background(), "MYPROJECT")
@@ -33,7 +27,7 @@ func Example_withOptions() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerExampleWithOptions),
+		backlog.WithDoer(doerWikiList),
 	)
 
 	wikis, _ := c.Wiki.All(

--- a/example_user_test.go
+++ b/example_user_test.go
@@ -5,32 +5,13 @@ import (
 	"fmt"
 
 	backlog "github.com/nattokin/go-backlog"
-	"github.com/nattokin/go-backlog/internal/testutil/fixture"
-)
-
-var (
-	// UserService
-	doerUserAll    = newMockDoer(fixture.User.ListJSON)
-	doerUserOne    = newMockDoer(fixture.User.SingleJSON)
-	doerUserOwn    = newMockDoer(fixture.User.SingleJSON)
-	doerUserAdd    = newMockDoer(fixture.User.SingleJSON)
-	doerUserUpdate = newMockDoer(fixture.User.SingleJSON)
-	doerUserDelete = newMockDoer(fixture.User.SingleJSON)
-	doerUserIcon   = newMockBinaryDoer("image/png", "icon.png", []byte("PNG"))
-
-	// UserActivityService
-	doerUserActivityList = newMockDoer(fixture.Activity.ListJSON)
-
-	// UserStarService
-	doerUserStarCount = newMockDoer(fixture.Star.CountJSON)
-	doerUserStarList  = newMockDoer(fixture.Star.ListJSON)
 )
 
 func ExampleUserService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserAll),
+		backlog.WithDoer(doerUserList),
 	)
 
 	users, _ := c.User.All(context.Background())
@@ -43,7 +24,7 @@ func ExampleUserService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserOne),
+		backlog.WithDoer(doerUserSingle),
 	)
 
 	user, _ := c.User.One(context.Background(), 1)
@@ -56,7 +37,7 @@ func ExampleUserService_Own() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserOwn),
+		backlog.WithDoer(doerUserSingle),
 	)
 
 	user, _ := c.User.Own(context.Background())
@@ -69,7 +50,7 @@ func ExampleUserService_Add() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserAdd),
+		backlog.WithDoer(doerUserSingle),
 	)
 
 	user, _ := c.User.Add(
@@ -89,7 +70,7 @@ func ExampleUserService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserUpdate),
+		backlog.WithDoer(doerUserSingle),
 	)
 
 	user, _ := c.User.Update(
@@ -106,7 +87,7 @@ func ExampleUserService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserDelete),
+		backlog.WithDoer(doerUserSingle),
 	)
 
 	user, _ := c.User.Delete(context.Background(), 1)
@@ -132,7 +113,7 @@ func ExampleUserActivityService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserActivityList),
+		backlog.WithDoer(doerActivityList),
 	)
 
 	activities, _ := c.User.Activity.List(context.Background(), 1)
@@ -145,7 +126,7 @@ func ExampleUserStarService_Count() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserStarCount),
+		backlog.WithDoer(doerStarCount),
 	)
 
 	count, _ := c.User.Star.Count(context.Background(), 1)
@@ -158,7 +139,7 @@ func ExampleUserStarService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerUserStarList),
+		backlog.WithDoer(doerStarList),
 	)
 
 	stars, _ := c.User.Star.List(context.Background(), 1)

--- a/example_wiki_test.go
+++ b/example_wiki_test.go
@@ -5,41 +5,17 @@ import (
 	"fmt"
 
 	backlog "github.com/nattokin/go-backlog"
-	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 )
 
 var (
-	// WikiService
-	doerWikiAll    = newMockDoer(fixture.Wiki.ListJSON)
-	doerWikiCount  = newMockDoer(`{"count": 5}`)
-	doerWikiOne    = newMockDoer(fixture.Wiki.MinimumJSON)
-	doerWikiCreate = newMockDoer(fixture.Wiki.MinimumJSON)
-	doerWikiUpdate = newMockDoer(fixture.Wiki.MinimumJSON)
-	doerWikiDelete = newMockDoer(fixture.Wiki.MinimumJSON)
-
-	// WikiAttachmentService
-	doerWikiAttachmentAttach   = newMockDoer(fixture.Attachment.ListJSON)
-	doerWikiAttachmentList     = newMockDoer(fixture.Attachment.ListJSON)
-	doerWikiAttachmentDownload = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
-	doerWikiAttachmentRemove   = newMockDoer(fixture.Attachment.SingleJSON)
-
-	// WikiHistoryService
-	doerWikiHistoryList = newMockDoer(fixture.WikiHistory.ListJSON)
-
-	// WikiSharedFileService
-	doerWikiSharedFileLink   = newMockDoer(fixture.SharedFile.ListJSON)
-	doerWikiSharedFileList   = newMockDoer(fixture.SharedFile.ListJSON)
-	doerWikiSharedFileUnlink = newMockDoer(fixture.SharedFile.SingleJSON)
-
-	// WikiStarService
-	doerWikiStarList = newMockDoer(fixture.Star.ListJSON)
+	doerWikiCount = newMockDoer(`{"count": 5}`)
 )
 
 func ExampleWikiService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiAll),
+		backlog.WithDoer(doerWikiList),
 	)
 
 	wikis, _ := c.Wiki.All(context.Background(), "MYPROJECT")
@@ -65,7 +41,7 @@ func ExampleWikiService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiOne),
+		backlog.WithDoer(doerWikiSingle),
 	)
 
 	wiki, _ := c.Wiki.One(context.Background(), 34)
@@ -78,7 +54,7 @@ func ExampleWikiService_Create() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiCreate),
+		backlog.WithDoer(doerWikiSingle),
 	)
 
 	wiki, _ := c.Wiki.Create(context.Background(), 56, "Minimum Wiki Page", "This is a minimal wiki page.")
@@ -91,7 +67,7 @@ func ExampleWikiService_Update() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiUpdate),
+		backlog.WithDoer(doerWikiSingle),
 	)
 
 	wiki, _ := c.Wiki.Update(
@@ -108,7 +84,7 @@ func ExampleWikiService_Delete() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiDelete),
+		backlog.WithDoer(doerWikiSingle),
 	)
 
 	wiki, _ := c.Wiki.Delete(context.Background(), 34)
@@ -121,7 +97,7 @@ func ExampleWikiAttachmentService_Attach() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiAttachmentAttach),
+		backlog.WithDoer(doerAttachmentList),
 	)
 
 	attachments, _ := c.Wiki.Attachment.Attach(context.Background(), 34, []int{2, 5})
@@ -134,7 +110,7 @@ func ExampleWikiAttachmentService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiAttachmentList),
+		backlog.WithDoer(doerAttachmentList),
 	)
 
 	attachments, _ := c.Wiki.Attachment.List(context.Background(), 34)
@@ -160,7 +136,7 @@ func ExampleWikiAttachmentService_Remove() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiAttachmentRemove),
+		backlog.WithDoer(doerAttachmentSingle),
 	)
 
 	attachment, _ := c.Wiki.Attachment.Remove(context.Background(), 34, 8)
@@ -186,7 +162,7 @@ func ExampleWikiSharedFileService_Link() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiSharedFileLink),
+		backlog.WithDoer(doerSharedFileList),
 	)
 
 	files, _ := c.Wiki.SharedFile.Link(context.Background(), 34, []int{454403, 454404})
@@ -199,7 +175,7 @@ func ExampleWikiSharedFileService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiSharedFileList),
+		backlog.WithDoer(doerSharedFileList),
 	)
 
 	files, _ := c.Wiki.SharedFile.List(context.Background(), 34)
@@ -212,7 +188,7 @@ func ExampleWikiSharedFileService_Unlink() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiSharedFileUnlink),
+		backlog.WithDoer(doerSharedFileSingle),
 	)
 
 	file, _ := c.Wiki.SharedFile.Unlink(context.Background(), 34, 454403)
@@ -225,7 +201,7 @@ func ExampleWikiStarService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerWikiStarList),
+		backlog.WithDoer(doerStarList),
 	)
 
 	stars, _ := c.Wiki.Star.List(context.Background(), 34)

--- a/example_wiki_test.go
+++ b/example_wiki_test.go
@@ -7,10 +7,6 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 )
 
-var (
-	doerWikiCount = newMockDoer(`{"count": 5}`)
-)
-
 func ExampleWikiService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",


### PR DESCRIPTION
## Summary

Consolidate all package-level doer variables from individual `example_*_test.go` files into a single `example_doer_test.go` file. Doers that used the same fixture are merged into one, named by fixture domain and shape (`doer<Domain><Shape>`).

## Changes

- Add `example_doer_test.go` with all shared doers, grouped by fixture domain
- Remove per-fixture-duplicate doer declarations from `example_test.go`, `example_project_test.go`, `example_wiki_test.go`, `example_issue_test.go`, `example_user_test.go`, `example_pullrequest_test.go`, `example_space_test.go`, `example_recentlyviewed_test.go`, `example_repository_test.go`, `example_option_test.go`
- Inline-JSON doers with unique payloads (e.g. `doerWikiCount`, `doerIssueCount`) remain local to each file
- Update all `WithDoer(...)` call sites to reference the new consolidated names