### PR TITLE
refactor: use explicit integer values for Role constants

### DIFF
--- a/const.go
+++ b/const.go
@@ -88,13 +88,12 @@ type Role int
 
 // Available user roles within a project.
 const (
-	_ Role = iota
-	RoleAdministrator
-	RoleNormalUser
-	RoleReporter
-	RoleViewer
-	RoleGuestReporter
-	RoleGuestViewer
+	RoleAdministrator Role = 1
+	RoleNormalUser    Role = 2
+	RoleReporter      Role = 3
+	RoleViewer        Role = 4
+	RoleGuestReporter Role = 5
+	RoleGuestViewer   Role = 6
 )
 
 func (r Role) String() string {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -18,11 +18,10 @@ const (
 type Role int
 
 const (
-	_ Role = iota
-	RoleAdministrator
-	RoleNormalUser
-	RoleReporter
-	RoleViewer
-	RoleGuestReporter
-	RoleGuestViewer
+	RoleAdministrator Role = 1
+	RoleNormalUser    Role = 2
+	RoleReporter      Role = 3
+	RoleViewer        Role = 4
+	RoleGuestReporter Role = 5
+	RoleGuestViewer   Role = 6
 )


### PR DESCRIPTION
## Summary

Replace `iota`-based `Role` constants with explicit integer values to match the style of `CustomFieldType` and make the mapping to Backlog API values self-documenting.

## Changes

- `const.go`: Replace `_ Role = iota` with explicit `Role = 1..6`
- `internal/model/types.go`: Same change for the internal `Role` type
