### PR TITLE
refactor: merge internal/shared/version into internal/project

### DIFF
--- a/internal/domain/project/service_version.go
+++ b/internal/domain/project/service_version.go
@@ -1,5 +1,5 @@
 // Package version implements the Backlog Version/Milestone API service.
-package version
+package project
 
 import (
 	"context"
@@ -12,15 +12,15 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// Service provides Version/Milestone API operations.
-type Service struct {
+// VersionService provides Version/Milestone API operations.
+type VersionService struct {
 	method *core.Method
 }
 
 // All returns versions/milestones in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-version-milestone-list
-func (s *Service) All(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Version, error) {
+func (s *VersionService) All(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Version, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (s *Service) All(ctx context.Context, projectIDOrKey string, opts ...core.R
 // Add adds a version/milestone to a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/add-version-milestone
-func (s *Service) Add(ctx context.Context, projectIDOrKey, name string, opts ...core.RequestOption) (*model.Version, error) {
+func (s *VersionService) Add(ctx context.Context, projectIDOrKey, name string, opts ...core.RequestOption) (*model.Version, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (s *Service) Add(ctx context.Context, projectIDOrKey, name string, opts ...
 // Update updates a version/milestone.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-version-milestone
-func (s *Service) Update(ctx context.Context, projectIDOrKey string, versionID int, option core.RequestOption, opts ...core.RequestOption) (*model.Version, error) {
+func (s *VersionService) Update(ctx context.Context, projectIDOrKey string, versionID int, option core.RequestOption, opts ...core.RequestOption) (*model.Version, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (s *Service) Update(ctx context.Context, projectIDOrKey string, versionID i
 // Delete deletes a version/milestone.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-version-milestone
-func (s *Service) Delete(ctx context.Context, projectIDOrKey string, versionID int) (*model.Version, error) {
+func (s *VersionService) Delete(ctx context.Context, projectIDOrKey string, versionID int) (*model.Version, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -149,6 +149,6 @@ func (s *Service) Delete(ctx context.Context, projectIDOrKey string, versionID i
 	return &v, nil
 }
 
-func NewService(method *core.Method) *Service {
-	return &Service{method: method}
+func NewVersionService(method *core.Method) *VersionService {
+	return &VersionService{method: method}
 }

--- a/internal/domain/project/service_version_test.go
+++ b/internal/domain/project/service_version_test.go
@@ -1,4 +1,4 @@
-package version_test
+package project_test
 
 import (
 	"context"
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nattokin/go-backlog/internal/core"
-	"github.com/nattokin/go-backlog/internal/shared/version"
+	"github.com/nattokin/go-backlog/internal/domain/project"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestService_All(t *testing.T) {
+func TestVersionService_All(t *testing.T) {
 	option := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -71,7 +71,7 @@ func TestService_All(t *testing.T) {
 			t.Parallel()
 			m := mock.NewMethod(t)
 			m.Get = tc.mockGetFn
-			s := version.NewService(m)
+			s := project.NewVersionService(m)
 			got, err := s.All(context.Background(), tc.projectIDOrKey, tc.opts...)
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -85,7 +85,7 @@ func TestService_All(t *testing.T) {
 	}
 }
 
-func TestService_Add(t *testing.T) {
+func TestVersionService_Add(t *testing.T) {
 	o := &core.OptionService{}
 	date := "2025-01-01"
 
@@ -156,7 +156,7 @@ func TestService_Add(t *testing.T) {
 			if tc.mockPostFn != nil {
 				m.Post = tc.mockPostFn
 			}
-			s := version.NewService(m)
+			s := project.NewVersionService(m)
 			got, err := s.Add(context.Background(), tc.projectIDOrKey, tc.name, tc.opts...)
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -170,7 +170,7 @@ func TestService_Add(t *testing.T) {
 	}
 }
 
-func TestService_Update(t *testing.T) {
+func TestVersionService_Update(t *testing.T) {
 	o := &core.OptionService{}
 	date := "2025-01-01"
 
@@ -246,7 +246,7 @@ func TestService_Update(t *testing.T) {
 			if tc.mockPatchFn != nil {
 				m.Patch = tc.mockPatchFn
 			}
-			s := version.NewService(m)
+			s := project.NewVersionService(m)
 			got, err := s.Update(context.Background(), tc.projectIDOrKey, tc.versionID, tc.option, tc.opts...)
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -260,7 +260,7 @@ func TestService_Update(t *testing.T) {
 	}
 }
 
-func TestService_Delete(t *testing.T) {
+func TestVersionService_Delete(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 		versionID      int
@@ -305,7 +305,7 @@ func TestService_Delete(t *testing.T) {
 
 			m := mock.NewMethod(t)
 			m.Delete = tc.mockDeleteFn
-			s := version.NewService(m)
+			s := project.NewVersionService(m)
 			got, err := s.Delete(context.Background(), tc.projectIDOrKey, tc.versionID)
 			if tc.wantErrType != nil {
 				assert.Error(t, err)

--- a/project_process.go
+++ b/project_process.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/domain/project"
-	"github.com/nattokin/go-backlog/internal/shared/version"
 )
 
 // ──────────────────────────────────────────────────────────────
@@ -69,7 +68,7 @@ func (s *ProjectStatusService) UpdateOrder(ctx context.Context, projectIDOrKey s
 
 // ProjectVersionService handles communication with the project version/milestone-related methods of the Backlog API.
 type ProjectVersionService struct {
-	base   *version.Service
+	base   *project.VersionService
 	Option *ProjectVersionOptionService
 }
 
@@ -193,7 +192,7 @@ func newProjectStatusService(method *core.Method, option *core.OptionService) *P
 
 func newProjectVersionService(method *core.Method, option *core.OptionService) *ProjectVersionService {
 	return &ProjectVersionService{
-		base:   version.NewService(method),
+		base:   project.NewVersionService(method),
 		Option: newVersionOptionService(option),
 	}
 }


### PR DESCRIPTION
## Summary

`version` is exclusively used as a sub-service of `ProjectService`,
so it does not belong in `shared/`. Merge it directly into the `project`
package to reflect this ownership.

## Changes

- Add `internal/project/service_version.go` with `VersionService` (formerly `version.Service`)
- Add `internal/project/service_version_test.go`
- Remove `internal/shared/version/`
- Update root package import from `internal/shared/version` to `internal/project`