### PR TITLE
refactor: domain service tests to inline expected entity assertions

### DIFF
--- a/internal/domain/project/service_user_test.go
+++ b/internal/domain/project/service_user_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/domain/project"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
@@ -25,7 +24,6 @@ func TestProjectUserService_All(t *testing.T) {
 
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
-		wantUsers   []*model.User
 		wantErrType error
 	}{
 		"success-projectKey-valid": {
@@ -37,15 +35,6 @@ func TestProjectUserService_All(t *testing.T) {
 				assert.Equal(t, "false", query.Get("excludeGroupMembers"))
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
-
-			wantUsers: []*model.User{
-				{
-					UserID:      "admin",
-					Name:        "admin",
-					MailAddress: "eguchi@nulab.example",
-					RoleType:    1,
-				},
-			},
 		},
 		"success-excludeGroupMembers-true": {
 			projectKey:          "TEST2",
@@ -56,15 +45,6 @@ func TestProjectUserService_All(t *testing.T) {
 				assert.Equal(t, "true", query.Get("excludeGroupMembers"))
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
-
-			wantUsers: []*model.User{
-				{
-					UserID:      "admin",
-					Name:        "admin",
-					MailAddress: "eguchi@nulab.example",
-					RoleType:    1,
-				},
-			},
 		},
 		"success-excludeGroupMembers-false": {
 			projectKey:          "TEST3",
@@ -74,15 +54,6 @@ func TestProjectUserService_All(t *testing.T) {
 				assert.Equal(t, "projects/TEST3/users", spath)
 				assert.Equal(t, "false", query.Get("excludeGroupMembers"))
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
-			},
-
-			wantUsers: []*model.User{
-				{
-					UserID:      "admin",
-					Name:        "admin",
-					MailAddress: "eguchi@nulab.example",
-					RoleType:    1,
-				},
 			},
 		},
 		"error-validation-projectKey-empty": {
@@ -125,10 +96,10 @@ func TestProjectUserService_All(t *testing.T) {
 			assert.NoError(t, err)
 			require.Len(t, users, 4)
 			require.NotNil(t, users[0])
-			assert.Equal(t, tc.wantUsers[0].UserID, users[0].UserID)
-			assert.Equal(t, tc.wantUsers[0].Name, users[0].Name)
-			assert.Equal(t, tc.wantUsers[0].MailAddress, users[0].MailAddress)
-			assert.Equal(t, tc.wantUsers[0].RoleType, users[0].RoleType)
+			assert.Equal(t, "admin", users[0].UserID)
+			assert.Equal(t, "admin", users[0].Name)
+			assert.Equal(t, "eguchi@nulab.example", users[0].MailAddress)
+			assert.Equal(t, 1, users[0].RoleType)
 		})
 	}
 }
@@ -140,7 +111,6 @@ func TestProjectUserService_Add(t *testing.T) {
 
 		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
-		wantUser    *model.User
 		wantErrType error
 	}{
 		"success-projectKey-valid": {
@@ -151,13 +121,6 @@ func TestProjectUserService_Add(t *testing.T) {
 				assert.Equal(t, "projects/TEST/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
-			},
-
-			wantUser: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
 			},
 		},
 		"error-validation-projectKey-empty": {
@@ -179,13 +142,6 @@ func TestProjectUserService_Add(t *testing.T) {
 				assert.Equal(t, "projects/TEST2/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
-			},
-
-			wantUser: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
 			},
 		},
 		"error-response-invalid-json": {
@@ -223,10 +179,10 @@ func TestProjectUserService_Add(t *testing.T) {
 
 			assert.NoError(t, err)
 			require.NotNil(t, u)
-			assert.Equal(t, tc.wantUser.UserID, u.UserID)
-			assert.Equal(t, tc.wantUser.Name, u.Name)
-			assert.Equal(t, tc.wantUser.MailAddress, u.MailAddress)
-			assert.Equal(t, tc.wantUser.RoleType, u.RoleType)
+			assert.Equal(t, "admin", u.UserID)
+			assert.Equal(t, "admin", u.Name)
+			assert.Equal(t, "eguchi@nulab.example", u.MailAddress)
+			assert.Equal(t, 1, u.RoleType)
 		})
 	}
 }
@@ -238,7 +194,6 @@ func TestProjectUserService_Delete(t *testing.T) {
 
 		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
-		wantUser    *model.User
 		wantErrType error
 	}{
 		"success-delete-user": {
@@ -250,13 +205,6 @@ func TestProjectUserService_Delete(t *testing.T) {
 				assert.Equal(t, "1", form.Get("userId"))
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
-
-			wantUser: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
-			},
 		},
 		"success-projectIDOrKey-number": {
 			projectKey: "1234",
@@ -266,13 +214,6 @@ func TestProjectUserService_Delete(t *testing.T) {
 				assert.Equal(t, "projects/1234/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
-			},
-
-			wantUser: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
 			},
 		},
 		"error-validation-projectKey-empty": {
@@ -295,13 +236,6 @@ func TestProjectUserService_Delete(t *testing.T) {
 				assert.Equal(t, "projects/TEST2/users", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
-			},
-
-			wantUser: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
 			},
 		},
 		"error-response-invalid-json": {
@@ -339,10 +273,10 @@ func TestProjectUserService_Delete(t *testing.T) {
 
 			assert.NoError(t, err)
 			require.NotNil(t, u)
-			assert.Equal(t, tc.wantUser.UserID, u.UserID)
-			assert.Equal(t, tc.wantUser.Name, u.Name)
-			assert.Equal(t, tc.wantUser.MailAddress, u.MailAddress)
-			assert.Equal(t, tc.wantUser.RoleType, u.RoleType)
+			assert.Equal(t, "admin", u.UserID)
+			assert.Equal(t, "admin", u.Name)
+			assert.Equal(t, "eguchi@nulab.example", u.MailAddress)
+			assert.Equal(t, 1, u.RoleType)
 		})
 	}
 }
@@ -354,7 +288,6 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 
 		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
-		wantUser    *model.User
 		wantErrType error
 	}{
 		"success-projectKey-valid": {
@@ -365,13 +298,6 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 				assert.Equal(t, "projects/TEST/administrators", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
-			},
-
-			wantUser: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
 			},
 		},
 		"error-validation-projectKey-empty": {
@@ -393,13 +319,6 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 				assert.Equal(t, "projects/TEST2/administrators", spath)
 				assert.Equal(t, "1", form.Get("userId"))
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
-			},
-
-			wantUser: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
 			},
 		},
 		"error-response-invalid-json": {
@@ -437,10 +356,10 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 
 			assert.NoError(t, err)
 			require.NotNil(t, u)
-			assert.Equal(t, tc.wantUser.UserID, u.UserID)
-			assert.Equal(t, tc.wantUser.Name, u.Name)
-			assert.Equal(t, tc.wantUser.MailAddress, u.MailAddress)
-			assert.Equal(t, tc.wantUser.RoleType, u.RoleType)
+			assert.Equal(t, "admin", u.UserID)
+			assert.Equal(t, "admin", u.Name)
+			assert.Equal(t, "eguchi@nulab.example", u.MailAddress)
+			assert.Equal(t, 1, u.RoleType)
 		})
 	}
 }

--- a/internal/domain/user/service_test.go
+++ b/internal/domain/user/service_test.go
@@ -39,7 +39,7 @@ func TestUserService_One(t *testing.T) {
 
 			mockGetFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				assert.Equal(t, "users/100", spath)
-				return mock.NewJSONResponse(`{}`), nil
+				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 		},
 		"error-validation-id-zero": {

--- a/internal/domain/user/service_test.go
+++ b/internal/domain/user/service_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/domain/user"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
@@ -25,7 +24,6 @@ func TestUserService_One(t *testing.T) {
 
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
-		wantUser    *model.User
 		wantErrType error
 	}{
 		"success-id-1": {
@@ -35,13 +33,6 @@ func TestUserService_One(t *testing.T) {
 				assert.Equal(t, "users/1", spath)
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
-
-			wantUser: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
-			},
 		},
 		"success-id-100": {
 			id: 100,
@@ -50,8 +41,6 @@ func TestUserService_One(t *testing.T) {
 				assert.Equal(t, "users/100", spath)
 				return mock.NewJSONResponse(`{}`), nil
 			},
-
-			wantUser: &model.User{},
 		},
 		"error-validation-id-zero": {
 			id: 0,
@@ -82,10 +71,10 @@ func TestUserService_One(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, user)
 
-			assert.Equal(t, tc.wantUser.UserID, user.UserID)
-			assert.Equal(t, tc.wantUser.Name, user.Name)
-			assert.Equal(t, tc.wantUser.MailAddress, user.MailAddress)
-			assert.Equal(t, tc.wantUser.RoleType, user.RoleType)
+			assert.Equal(t, "admin", user.UserID)
+			assert.Equal(t, "admin", user.Name)
+			assert.Equal(t, "eguchi@nulab.example", user.MailAddress)
+			assert.Equal(t, 1, user.RoleType)
 		})
 	}
 }
@@ -100,7 +89,6 @@ func TestUserService_Add(t *testing.T) {
 
 		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
-		wantUser    *model.User
 		wantErrType error
 	}{
 		"success-add-user": {
@@ -118,13 +106,6 @@ func TestUserService_Add(t *testing.T) {
 				assert.Equal(t, "eguchi@nulab.example", form.Get("mailAddress"))
 				assert.Equal(t, strconv.Itoa(int(1)), form.Get("roleType"))
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
-			},
-
-			wantUser: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
 			},
 		},
 		"error-client-network": {
@@ -223,10 +204,10 @@ func TestUserService_Add(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, user)
 
-			assert.Equal(t, tc.wantUser.UserID, user.UserID)
-			assert.Equal(t, tc.wantUser.Name, user.Name)
-			assert.Equal(t, tc.wantUser.MailAddress, user.MailAddress)
-			assert.Equal(t, tc.wantUser.RoleType, user.RoleType)
+			assert.Equal(t, "admin", user.UserID)
+			assert.Equal(t, "admin", user.Name)
+			assert.Equal(t, "eguchi@nulab.example", user.MailAddress)
+			assert.Equal(t, 1, user.RoleType)
 		})
 	}
 }
@@ -236,7 +217,6 @@ func TestUserService_All(t *testing.T) {
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantLen     int
-		wantFirst   *model.User
 		wantErrType error
 	}{
 		"success-get-users": {
@@ -245,14 +225,7 @@ func TestUserService_All(t *testing.T) {
 				assert.Nil(t, query)
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
-
 			wantLen: 4,
-			wantFirst: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
-			},
 		},
 		"error-client-network": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
@@ -260,7 +233,6 @@ func TestUserService_All(t *testing.T) {
 				assert.Nil(t, query)
 				return nil, errors.New("error")
 			},
-
 			wantErrType: errors.New(""),
 		},
 		"error-response-invalid-json": {
@@ -269,7 +241,6 @@ func TestUserService_All(t *testing.T) {
 				assert.Nil(t, query)
 				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
-
 			wantErrType: &json.SyntaxError{},
 		},
 	}
@@ -297,10 +268,10 @@ func TestUserService_All(t *testing.T) {
 			require.Len(t, users, tc.wantLen)
 
 			require.NotNil(t, users[0])
-			assert.Equal(t, tc.wantFirst.UserID, users[0].UserID)
-			assert.Equal(t, tc.wantFirst.Name, users[0].Name)
-			assert.Equal(t, tc.wantFirst.MailAddress, users[0].MailAddress)
-			assert.Equal(t, tc.wantFirst.RoleType, users[0].RoleType)
+			assert.Equal(t, "admin", users[0].UserID)
+			assert.Equal(t, "admin", users[0].Name)
+			assert.Equal(t, "eguchi@nulab.example", users[0].MailAddress)
+			assert.Equal(t, 1, users[0].RoleType)
 		})
 	}
 }
@@ -315,7 +286,6 @@ func TestUserService_Update(t *testing.T) {
 
 		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
-		wantUser    *model.User
 		wantErrType error
 	}{
 		"success-update-user": {
@@ -334,13 +304,6 @@ func TestUserService_Update(t *testing.T) {
 				assert.Equal(t, "eguchi@nulab.example", form.Get("mailAddress"))
 				assert.Equal(t, strconv.Itoa(int(1)), form.Get("roleType"))
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
-			},
-
-			wantUser: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
 			},
 		},
 		"error-response-invalid-json": {
@@ -463,10 +426,10 @@ func TestUserService_Update(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, user)
 
-			assert.Equal(t, tc.wantUser.UserID, user.UserID)
-			assert.Equal(t, tc.wantUser.Name, user.Name)
-			assert.Equal(t, tc.wantUser.MailAddress, user.MailAddress)
-			assert.Equal(t, tc.wantUser.RoleType, user.RoleType)
+			assert.Equal(t, "admin", user.UserID)
+			assert.Equal(t, "admin", user.Name)
+			assert.Equal(t, "eguchi@nulab.example", user.MailAddress)
+			assert.Equal(t, 1, user.RoleType)
 		})
 	}
 }
@@ -475,7 +438,6 @@ func TestUserService_Own(t *testing.T) {
 	cases := map[string]struct {
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
-		wantUser    *model.User
 		wantErrType error
 	}{
 		"success-get-own-user": {
@@ -483,13 +445,6 @@ func TestUserService_Own(t *testing.T) {
 				assert.Equal(t, "users/myself", spath)
 				assert.Nil(t, query)
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
-			},
-
-			wantUser: &model.User{
-				UserID:      "admin",
-				Name:        "admin",
-				MailAddress: "eguchi@nulab.example",
-				RoleType:    1,
 			},
 		},
 		"error-client-network": {
@@ -533,10 +488,10 @@ func TestUserService_Own(t *testing.T) {
 
 			assert.NoError(t, err)
 			require.NotNil(t, user)
-			assert.Equal(t, tc.wantUser.UserID, user.UserID)
-			assert.Equal(t, tc.wantUser.Name, user.Name)
-			assert.Equal(t, tc.wantUser.MailAddress, user.MailAddress)
-			assert.Equal(t, tc.wantUser.RoleType, user.RoleType)
+			assert.Equal(t, "admin", user.UserID)
+			assert.Equal(t, "admin", user.Name)
+			assert.Equal(t, "eguchi@nulab.example", user.MailAddress)
+			assert.Equal(t, 1, user.RoleType)
 		})
 	}
 }

--- a/internal/domain/wiki/service_test.go
+++ b/internal/domain/wiki/service_test.go
@@ -13,17 +13,11 @@ import (
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/domain/wiki"
-	"github.com/nattokin/go-backlog/internal/model"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
 func TestWikiService_All(t *testing.T) {
-	const testWiki1ID = 112
-	const testWiki2ID = 115
-	const testWiki1Name = "test1"
-	const testWiki2Name = "test2"
-
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -33,8 +27,6 @@ func TestWikiService_All(t *testing.T) {
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantErrType error
-		wantIDs     []int
-		wantNames   []string
 	}{
 		"success-projectIDOrKey-id": {
 			projectIDOrKey: "103",
@@ -44,9 +36,6 @@ func TestWikiService_All(t *testing.T) {
 				assert.Equal(t, "103", query.Get("projectIdOrKey"))
 				return mock.NewJSONResponse(fixture.Wiki.ListJSON), nil
 			},
-
-			wantIDs:   []int{testWiki1ID, testWiki2ID},
-			wantNames: []string{testWiki1Name, testWiki2Name},
 		},
 
 		"success-projectIDOrKey-key-with-options": {
@@ -61,9 +50,6 @@ func TestWikiService_All(t *testing.T) {
 				assert.Equal(t, "test", query.Get("keyword"))
 				return mock.NewJSONResponse(fixture.Wiki.ListJSON), nil
 			},
-
-			wantIDs:   []int{testWiki1ID, testWiki2ID},
-			wantNames: []string{testWiki1Name, testWiki2Name},
 		},
 
 		"error-validation-projectIDOrKey-empty": {
@@ -131,11 +117,9 @@ func TestWikiService_All(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, wikis)
 
-			assert.Len(t, wikis, len(tc.wantIDs))
-			for i := range wikis {
-				assert.Equal(t, tc.wantIDs[i], wikis[i].ID)
-				assert.Equal(t, tc.wantNames[i], wikis[i].Name)
-			}
+			assert.Len(t, wikis, 2)
+			assert.Equal(t, 112, wikis[0].ID)
+			assert.Equal(t, "test1", wikis[0].Name)
 		})
 	}
 }
@@ -231,9 +215,7 @@ func TestWikiService_One(t *testing.T) {
 
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
-		wantErrType  error
-		wantWikiID   int
-		wantWikiName string
+		wantErrType error
 	}{
 		"success-wikiID-normal": {
 			wikiID: 34,
@@ -243,9 +225,6 @@ func TestWikiService_One(t *testing.T) {
 				assert.Nil(t, query)
 				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
-
-			wantWikiID:   34,
-			wantWikiName: "Maximum Wiki Page",
 		},
 		"error-validation-wikiID-zero": {
 			wikiID:      0,
@@ -301,8 +280,8 @@ func TestWikiService_One(t *testing.T) {
 
 			assert.NoError(t, err)
 			require.NotNil(t, wiki)
-			assert.Equal(t, tc.wantWikiID, wiki.ID)
-			assert.Equal(t, tc.wantWikiName, wiki.Name)
+			assert.Equal(t, 34, wiki.ID)
+			assert.Equal(t, "Maximum Wiki Page", wiki.Name)
 		})
 	}
 }
@@ -318,7 +297,6 @@ func TestWikiService_Create(t *testing.T) {
 
 		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
-		wantWiki    *model.Wiki
 		wantErrType error
 	}{
 		"success-projectID-name-content-minimum": {
@@ -332,12 +310,6 @@ func TestWikiService_Create(t *testing.T) {
 				assert.Equal(t, "Minimum Wiki Page", form.Get("name"))
 				assert.Equal(t, "This is a minimal wiki page.", form.Get("content"))
 				return mock.NewJSONResponse(fixture.Wiki.MinimumJSON), nil
-			},
-
-			wantWiki: &model.Wiki{
-				ID:      34,
-				Name:    "Minimum Wiki Page",
-				Content: "This is a minimal wiki page.",
 			},
 		},
 		"success-projectID-name-content-withMailNotify": {
@@ -353,12 +325,6 @@ func TestWikiService_Create(t *testing.T) {
 				assert.Equal(t, "This is a minimal wiki page.", form.Get("content"))
 				assert.Equal(t, "true", form.Get("mailNotify"))
 				return mock.NewJSONResponse(fixture.Wiki.MinimumJSON), nil
-			},
-
-			wantWiki: &model.Wiki{
-				ID:      34,
-				Name:    "Minimum Wiki Page",
-				Content: "This is a minimal wiki page.",
 			},
 		},
 		"error-validation-projectID-zero": {
@@ -448,9 +414,9 @@ func TestWikiService_Create(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, wiki)
 
-			assert.Equal(t, tc.wantWiki.ID, wiki.ID)
-			assert.Equal(t, tc.wantWiki.Name, wiki.Name)
-			assert.Equal(t, tc.wantWiki.Content, wiki.Content)
+			assert.Equal(t, 34, wiki.ID)
+			assert.Equal(t, "Minimum Wiki Page", wiki.Name)
+			assert.Equal(t, "This is a minimal wiki page.", wiki.Content)
 		})
 	}
 }
@@ -466,7 +432,6 @@ func TestWikiService_Update(t *testing.T) {
 		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantErrType error
-		wantWiki    *model.Wiki
 	}{
 		"success-wikiID-name-only": {
 			wikiID: 34,
@@ -477,12 +442,6 @@ func TestWikiService_Update(t *testing.T) {
 				assert.Equal(t, "New Page Name", form.Get("name"))
 				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
-
-			wantWiki: &model.Wiki{
-				ID:      34,
-				Name:    "Maximum Wiki Page",
-				Content: "This is a muximal wiki page.",
-			},
 		},
 		"success-wikiID-content-only": {
 			wikiID: 34,
@@ -492,12 +451,6 @@ func TestWikiService_Update(t *testing.T) {
 				assert.Equal(t, "wikis/34", spath)
 				assert.Equal(t, "Full Options Content", form.Get("content"))
 				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
-			},
-
-			wantWiki: &model.Wiki{
-				ID:      34,
-				Name:    "Maximum Wiki Page",
-				Content: "This is a muximal wiki page.",
 			},
 		},
 		"success-wikiID-mailNotify-name": {
@@ -512,12 +465,6 @@ func TestWikiService_Update(t *testing.T) {
 				assert.Equal(t, "Full Options Name", form.Get("name"))
 				assert.Equal(t, "true", form.Get("mailNotify"))
 				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
-			},
-
-			wantWiki: &model.Wiki{
-				ID:      34,
-				Name:    "Maximum Wiki Page",
-				Content: "This is a muximal wiki page.",
 			},
 		},
 		"success-wikiID-full-options": {
@@ -534,12 +481,6 @@ func TestWikiService_Update(t *testing.T) {
 				assert.Equal(t, "Full Options Content", form.Get("content"))
 				assert.Equal(t, "true", form.Get("mailNotify"))
 				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
-			},
-
-			wantWiki: &model.Wiki{
-				ID:      34,
-				Name:    "Maximum Wiki Page",
-				Content: "This is a muximal wiki page.",
 			},
 		},
 		"error-validation-required-option": {
@@ -614,9 +555,9 @@ func TestWikiService_Update(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, wiki)
 
-			assert.Equal(t, tc.wantWiki.ID, wiki.ID)
-			assert.Equal(t, tc.wantWiki.Name, wiki.Name)
-			assert.Equal(t, tc.wantWiki.Content, wiki.Content)
+			assert.Equal(t, 34, wiki.ID)
+			assert.Equal(t, "Maximum Wiki Page", wiki.Name)
+			assert.Equal(t, "This is a muximal wiki page.", wiki.Content)
 		})
 	}
 }
@@ -630,7 +571,6 @@ func TestWikiService_Delete(t *testing.T) {
 
 		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
-		wantWikiID  int
 		wantErrType error
 	}{
 		"success-wikiID-withMailNotify": {
@@ -642,8 +582,6 @@ func TestWikiService_Delete(t *testing.T) {
 				assert.Equal(t, "true", form.Get("mailNotify"))
 				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
-
-			wantWikiID: 34,
 		},
 		"success-wikiID-no-option": {
 			wikiID: 1,
@@ -652,8 +590,6 @@ func TestWikiService_Delete(t *testing.T) {
 				assert.Equal(t, "wikis/1", spath)
 				return mock.NewJSONResponse(fixture.Wiki.MaximumJSON), nil
 			},
-
-			wantWikiID: 34,
 		},
 		"error-validation-wikiID-zero": {
 			wikiID:      0,
@@ -718,7 +654,7 @@ func TestWikiService_Delete(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, wiki)
 
-			assert.Equal(t, tc.wantWikiID, wiki.ID)
+			assert.Equal(t, 34, wiki.ID)
 		})
 	}
 }


### PR DESCRIPTION
This PR simplifies domain service tests by removing redundant expected entity fixtures from table-driven test cases and replacing them with direct inline assertions.

## Changes

* Removed wantUser, wantUsers, wantWiki, wantWikiID, wantWikiName, wantIDs, and wantNames fields from test case definitions
* Replaced indirect comparisons with explicit assertions against returned values
* Removed unused model imports
* Simplified test setup and reduced duplicated fixture structures

## Affected Tests

* internal/domain/project/service_user_test.go
* internal/domain/user/service_test.go
* internal/domain/wiki/service_test.go

## Benefits

* Reduces boilerplate in table-driven tests
* Improves readability of assertions
* Makes expected values easier to identify directly in test bodies
* Removes unnecessary dependency on internal model structs for assertion setup