### PR TITLE
refactor: move UserStarService into dedicated file

### DIFF
--- a/user.go
+++ b/user.go
@@ -124,70 +124,6 @@ func (s *UserActivityService) List(ctx context.Context, userID int, opts ...Requ
 }
 
 // ──────────────────────────────────────────────────────────────
-//  UserStarService
-// ──────────────────────────────────────────────────────────────
-
-// UserStarService handles communication with the user star-related methods of the Backlog API.
-type UserStarService struct {
-	base *user.StarService
-
-	Option *UserStarOptionService
-}
-
-// List returns a list of stars received by the user with the given ID.
-//
-// This method supports options returned by methods in "*Client.User.Star.Option",
-// such as:
-//   - WithCount
-//   - WithMaxID
-//   - WithMinID
-//   - WithOrder
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-received-star-list
-func (s *UserStarService) List(ctx context.Context, userID int, opts ...RequestOption) ([]*Star, error) {
-	v, err := s.base.List(ctx, userID, toCoreOptions(opts)...)
-	return starsFromModel(v), convertError(err)
-}
-
-// Count returns the number of stars received by the user with the given ID.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-user-received-stars
-func (s *UserStarService) Count(ctx context.Context, userID int) (int, error) {
-	v, err := s.base.Count(ctx, userID)
-	return v, convertError(err)
-}
-
-// ──────────────────────────────────────────────────────────────
-//  UserStarOptionService
-// ──────────────────────────────────────────────────────────────
-
-// UserStarOptionService provides a domain-specific set of option builders
-// for operations within the UserStarService.
-type UserStarOptionService struct {
-	base *core.OptionService
-}
-
-// WithCount sets the number of results to return.
-func (s *UserStarOptionService) WithCount(count int) RequestOption {
-	return s.base.WithCount(count)
-}
-
-// WithMaxID sets the maximum ID to filter results.
-func (s *UserStarOptionService) WithMaxID(id int) RequestOption {
-	return s.base.WithMaxID(id)
-}
-
-// WithMinID sets the minimum ID to filter results.
-func (s *UserStarOptionService) WithMinID(id int) RequestOption {
-	return s.base.WithMinID(id)
-}
-
-// WithOrder sets the sort order of results.
-func (s *UserStarOptionService) WithOrder(order Order) RequestOption {
-	return s.base.WithOrder(string(order))
-}
-
-// ──────────────────────────────────────────────────────────────
 //  UserOptionService
 // ──────────────────────────────────────────────────────────────
 
@@ -249,21 +185,8 @@ func newUserActivityService(method *core.Method, option *core.OptionService) *Us
 	}
 }
 
-func newUserStarService(method *core.Method, option *core.OptionService) *UserStarService {
-	return &UserStarService{
-		base:   user.NewStarService(method),
-		Option: newUserStarOptionService(option),
-	}
-}
-
 func newUserOptionService(option *core.OptionService) *UserOptionService {
 	return &UserOptionService{
-		base: option,
-	}
-}
-
-func newUserStarOptionService(option *core.OptionService) *UserStarOptionService {
-	return &UserStarOptionService{
 		base: option,
 	}
 }

--- a/user_star.go
+++ b/user_star.go
@@ -1,0 +1,77 @@
+package backlog
+
+import (
+	"context"
+
+	"github.com/nattokin/go-backlog/internal/core"
+	"github.com/nattokin/go-backlog/internal/domain/user"
+)
+
+// UserStarService handles communication with the user star-related methods of the Backlog API.
+type UserStarService struct {
+	base *user.StarService
+
+	Option *UserStarOptionService
+}
+
+// List returns a list of stars received by the user with the given ID.
+//
+// This method supports options returned by methods in "*Client.User.Star.Option",
+// such as:
+//   - WithCount
+//   - WithMaxID
+//   - WithMinID
+//   - WithOrder
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-received-star-list
+func (s *UserStarService) List(ctx context.Context, userID int, opts ...RequestOption) ([]*Star, error) {
+	v, err := s.base.List(ctx, userID, toCoreOptions(opts)...)
+	return starsFromModel(v), convertError(err)
+}
+
+// Count returns the number of stars received by the user with the given ID.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-user-received-stars
+func (s *UserStarService) Count(ctx context.Context, userID int) (int, error) {
+	v, err := s.base.Count(ctx, userID)
+	return v, convertError(err)
+}
+
+// UserStarOptionService provides a domain-specific set of option builders
+// for operations within the UserStarService.
+type UserStarOptionService struct {
+	base *core.OptionService
+}
+
+// WithCount sets the number of results to return.
+func (s *UserStarOptionService) WithCount(count int) RequestOption {
+	return s.base.WithCount(count)
+}
+
+// WithMaxID sets the maximum ID to filter results.
+func (s *UserStarOptionService) WithMaxID(id int) RequestOption {
+	return s.base.WithMaxID(id)
+}
+
+// WithMinID sets the minimum ID to filter results.
+func (s *UserStarOptionService) WithMinID(id int) RequestOption {
+	return s.base.WithMinID(id)
+}
+
+// WithOrder sets the sort order of results.
+func (s *UserStarOptionService) WithOrder(order Order) RequestOption {
+	return s.base.WithOrder(string(order))
+}
+
+func newUserStarService(method *core.Method, option *core.OptionService) *UserStarService {
+	return &UserStarService{
+		base:   user.NewStarService(method),
+		Option: newUserStarOptionService(option),
+	}
+}
+
+func newUserStarOptionService(option *core.OptionService) *UserStarOptionService {
+	return &UserStarOptionService{
+		base: option,
+	}
+}


### PR DESCRIPTION
## Summary

Extract UserStarService and UserStarOptionService from user.go into a new dedicated user_star.go file.

## Changes

* Added user_star.go
    * Moved UserStarService
    * Moved UserStarOptionService
    * Moved related constructors
        * newUserStarService
        * newUserStarOptionService
* Removed the moved implementations from user.go

## Notes

This refactor improves file organization by separating user star-related functionality into its own file without changing behavior.