### PR TITLE
fix: remove statusId from Create's validTypes in IssueService

### DIFF
--- a/internal/domain/issue/service.go
+++ b/internal/domain/issue/service.go
@@ -165,7 +165,6 @@ func (s *Service) Create(ctx context.Context, projectID int, summary string, iss
 		core.ParamMilestoneIDs,
 		core.ParamAssigneeID,
 		core.ParamParentIssueID,
-		core.ParamStatusID,
 		core.ParamNotifiedUserIDs,
 		core.ParamAttachmentIDs,
 	}

--- a/issue.go
+++ b/issue.go
@@ -153,7 +153,6 @@ func (s *IssueService) One(ctx context.Context, issueIDOrKey string) (*Issue, er
 //   - WithMilestoneIDs
 //   - WithAssigneeID
 //   - WithParentIssueID
-//   - WithStatusID
 //   - WithNotifiedUserIDs
 //   - WithAttachmentIDs
 //


### PR DESCRIPTION
## Summary

The Backlog API's Add Issue endpoint does not accept a `statusId` parameter. However, `core.ParamStatusID` was included in the `validTypes` for `Service.Create`, allowing `WithStatusID` to be silently passed to the API where it has no effect.

## Changes

- Remove `core.ParamStatusID` from `validTypes` in `Service.Create` (`internal/domain/issue/service.go`)
- Remove `WithStatusID` from the supported options list in the `IssueService.Create` godoc (`issue.go`)

Closes #341