### PR TITLE
feat: support comment parameter in IssueService.Update

### DIFF
--- a/internal/domain/issue/service.go
+++ b/internal/domain/issue/service.go
@@ -222,6 +222,7 @@ func (s *Service) Update(ctx context.Context, issueIDOrKey string, option core.R
 		core.ParamResolutionID,
 		core.ParamNotifiedUserIDs,
 		core.ParamAttachmentIDs,
+		core.ParamComment,
 	}
 	options := append([]core.RequestOption{option}, opts...)
 	if err := core.ApplyOptions(form, validTypes, options...); err != nil {

--- a/issue.go
+++ b/issue.go
@@ -183,6 +183,7 @@ func (s *IssueService) Create(ctx context.Context, projectID int, summary string
 //   - WithResolutionID
 //   - WithNotifiedUserIDs
 //   - WithAttachmentIDs
+//   - WithComment
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/update-issue
 func (s *IssueService) Update(ctx context.Context, issueIDOrKey string, option RequestOption, opts ...RequestOption) (*Issue, error) {
@@ -267,6 +268,11 @@ func (s *IssueOptionService) WithAttachmentIDs(ids []int) RequestOption {
 // WithCategoryIDs filters issues by category IDs.
 func (s *IssueOptionService) WithCategoryIDs(ids []int) RequestOption {
 	return s.base.WithCategoryIDs(ids)
+}
+
+// WithComment returns an option to set the `comment` parameter.
+func (s *IssueOptionService) WithComment(comment string) RequestOption {
+	return s.base.WithComment(comment)
 }
 
 // WithCount sets the number of issues to retrieve (1-100).

--- a/issue_test.go
+++ b/issue_test.go
@@ -359,6 +359,7 @@ func TestIssueOptionService(t *testing.T) {
 		"WithAttachment":      {option: s.WithAttachment(true), wantKey: core.ParamAttachment.Value()},
 		"WithAttachmentIDs":   {option: s.WithAttachmentIDs([]int{1}), wantKey: core.ParamAttachmentIDs.Value()},
 		"WithCategoryIDs":     {option: s.WithCategoryIDs([]int{1}), wantKey: core.ParamCategoryIDs.Value()},
+		"WithComment":         {option: s.WithComment("comment"), wantKey: core.ParamComment.Value()},
 		"WithCount":           {option: s.WithCount(20), wantKey: core.ParamCount.Value()},
 		"WithCreatedSince":    {option: s.WithCreatedSince(date), wantKey: core.ParamCreatedSince.Value()},
 		"WithCreatedUntil":    {option: s.WithCreatedUntil(date), wantKey: core.ParamCreatedUntil.Value()},


### PR DESCRIPTION
## Summary

The Backlog API's Update Issue endpoint accepts a `comment` parameter that allows posting a comment simultaneously with updating the issue. This was not previously supported.

## Changes

- Add `core.ParamComment` to `validTypes` in `Service.Update` (`internal/domain/issue/service.go`)
- Add `WithComment` method to `IssueOptionService` (`issue.go`)
- Add `WithComment` to the supported options list in the `IssueService.Update` godoc

Closes #342