### PR TITLE
feat: add missing fields to Project model

### DIFF
--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -12,6 +12,15 @@ type Project struct {
 	ProjectLeaderCanEditProjectLeader bool   `json:"projectLeaderCanEditProjectLeader,omitempty"`
 	TextFormattingRule                string `json:"textFormattingRule,omitempty"`
 	Archived                          bool   `json:"archived,omitempty"`
+	UseResolvedForChart               bool   `json:"useResolvedForChart,omitempty"`
+	UseWiki                           bool   `json:"useWiki,omitempty"`
+	UseFileSharing                    bool   `json:"useFileSharing,omitempty"`
+	UseWikiTreeView                   bool   `json:"useWikiTreeView,omitempty"`
+	UseSubversion                     bool   `json:"useSubversion,omitempty"`
+	UseGit                            bool   `json:"useGit,omitempty"`
+	UseOriginalImageSizeAtWiki        bool   `json:"useOriginalImageSizeAtWiki,omitempty"`
+	DisplayOrder                      int    `json:"displayOrder,omitempty"`
+	UseDevAttributes                  bool   `json:"useDevAttributes,omitempty"`
 }
 
 // DiskUsageProject represents disk usage for a specific project.

--- a/internal/testutil/fixture/testdata_project.go
+++ b/internal/testutil/fixture/testdata_project.go
@@ -58,17 +58,17 @@ var Project = projectFixtures{
 }
 `,
 	Single: &backlog.Project{
-		ID:                         6,
-		ProjectKey:                 "TEST",
-		Name:                       "test",
-		TextFormattingRule:         backlog.FormatMarkdown,
-		UseResolvedForChart:        true,
-		UseWiki:                    true,
-		UseFileSharing:             true,
-		UseWikiTreeView:            true,
-		UseGit:                     true,
-		DisplayOrder:               2147483646,
-		UseDevAttributes:           true,
+		ID:                  6,
+		ProjectKey:          "TEST",
+		Name:                "test",
+		TextFormattingRule:  backlog.FormatMarkdown,
+		UseResolvedForChart: true,
+		UseWiki:             true,
+		UseFileSharing:      true,
+		UseWikiTreeView:     true,
+		UseGit:              true,
+		DisplayOrder:        2147483646,
+		UseDevAttributes:    true,
 	},
 	ListJSON: `
 [

--- a/internal/testutil/fixture/testdata_project.go
+++ b/internal/testutil/fixture/testdata_project.go
@@ -45,14 +45,30 @@ var Project = projectFixtures{
     "subtaskingEnabled": false,
     "projectLeaderCanEditProjectLeader": false,
     "textFormattingRule": "markdown",
-    "archived": false
+    "archived": false,
+    "useResolvedForChart": true,
+    "useWiki": true,
+    "useFileSharing": true,
+    "useWikiTreeView": true,
+    "useSubversion": false,
+    "useGit": true,
+    "useOriginalImageSizeAtWiki": false,
+    "displayOrder": 2147483646,
+    "useDevAttributes": true
 }
 `,
 	Single: &backlog.Project{
-		ID:                 6,
-		ProjectKey:         "TEST",
-		Name:               "test",
-		TextFormattingRule: backlog.FormatMarkdown,
+		ID:                         6,
+		ProjectKey:                 "TEST",
+		Name:                       "test",
+		TextFormattingRule:         backlog.FormatMarkdown,
+		UseResolvedForChart:        true,
+		UseWiki:                    true,
+		UseFileSharing:             true,
+		UseWikiTreeView:            true,
+		UseGit:                     true,
+		DisplayOrder:               2147483646,
+		UseDevAttributes:           true,
 	},
 	ListJSON: `
 [

--- a/project.go
+++ b/project.go
@@ -22,6 +22,15 @@ type Project struct {
 	ProjectLeaderCanEditProjectLeader bool
 	TextFormattingRule                Format
 	Archived                          bool
+	UseResolvedForChart               bool
+	UseWiki                           bool
+	UseFileSharing                    bool
+	UseWikiTreeView                   bool
+	UseSubversion                     bool
+	UseGit                            bool
+	UseOriginalImageSizeAtWiki        bool
+	DisplayOrder                      int
+	UseDevAttributes                  bool
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -217,6 +226,15 @@ func projectFromModel(m *model.Project) *Project {
 		ProjectLeaderCanEditProjectLeader: m.ProjectLeaderCanEditProjectLeader,
 		TextFormattingRule:                Format(m.TextFormattingRule),
 		Archived:                          m.Archived,
+		UseResolvedForChart:               m.UseResolvedForChart,
+		UseWiki:                           m.UseWiki,
+		UseFileSharing:                    m.UseFileSharing,
+		UseWikiTreeView:                   m.UseWikiTreeView,
+		UseSubversion:                     m.UseSubversion,
+		UseGit:                            m.UseGit,
+		UseOriginalImageSizeAtWiki:        m.UseOriginalImageSizeAtWiki,
+		DisplayOrder:                      m.DisplayOrder,
+		UseDevAttributes:                  m.UseDevAttributes,
 	}
 }
 


### PR DESCRIPTION
## Summary

Add 9 fields to the `Project` struct that are present in the Backlog API response but were missing from the current model. Identified by comparing the API response example from the Get Notification endpoint against the current implementation.

## Changes

- Add missing fields to `Project` in `internal/model/project.go`
- Add missing fields to `Project` in `project.go`
- Update `projectFromModel` helper in `project.go` to map all new fields

### Fields added

| JSON field | Go field | Type |
|---|---|---|
| `useResolvedForChart` | `UseResolvedForChart` | `bool` |
| `useWiki` | `UseWiki` | `bool` |
| `useFileSharing` | `UseFileSharing` | `bool` |
| `useWikiTreeView` | `UseWikiTreeView` | `bool` |
| `useSubversion` | `UseSubversion` | `bool` |
| `useGit` | `UseGit` | `bool` |
| `useOriginalImageSizeAtWiki` | `UseOriginalImageSizeAtWiki` | `bool` |
| `displayOrder` | `DisplayOrder` | `int` |
| `useDevAttributes` | `UseDevAttributes` | `bool` |

Closes #344