### PR TITLE
docs: add issue_export example

### DIFF
--- a/examples/issue_export/README.md
+++ b/examples/issue_export/README.md
@@ -1,0 +1,47 @@
+# issue_export
+
+Export issues in a project to TSV format on stdout.
+
+## Prerequisites
+
+- `BACKLOG_BASE_URL`: Your Backlog space URL (e.g. `https://example.backlog.com`)
+- `BACKLOG_TOKEN`: Your Backlog API access token
+
+## Usage
+
+```
+export BACKLOG_BASE_URL=https://example.backlog.com
+export BACKLOG_TOKEN=your_token
+
+go run . <PROJECT_KEY> [--status <id,...>]
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--status` | Comma-separated status IDs to filter (e.g. `1,2,3`) |
+
+## Output
+
+TSV with the following columns:
+
+| Column | Description |
+|--------|-------------|
+| ID | Issue ID |
+| Key | Issue key (e.g. `PROJECT-123`) |
+| Summary | Issue summary |
+| Status | Status name |
+| Assignee | Assignee name |
+| Priority | Priority name |
+| Comments | Number of comments |
+| Attachments | Number of attachments |
+| Created | Created datetime |
+| Updated | Last updated datetime |
+
+## Example
+
+```
+go run . MYPROJECT > issues.tsv
+go run . MYPROJECT --status 1,2 > open_issues.tsv
+```

--- a/examples/issue_export/main.go
+++ b/examples/issue_export/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/csv"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/nattokin/go-backlog"
@@ -60,11 +62,10 @@ func main() {
 		log.Fatalf("failed to fetch issues: %v", err)
 	}
 
-	// Header
-	fmt.Fprintln(os.Stdout, strings.Join([]string{
-		"ID", "Key", "Summary", "Status", "Assignee", "Priority",
-		"Comments", "Attachments", "Created", "Updated",
-	}, "\t"))
+	w := csv.NewWriter(os.Stdout)
+	w.Comma = '\t'
+
+	_ = w.Write([]string{"ID", "Key", "Summary", "Status", "Assignee", "Priority", "Comments", "Attachments", "Created", "Updated"})
 
 	for _, issue := range issues {
 		comments, err := c.Issue.Comment.All(ctx, issue.IssueKey)
@@ -90,19 +91,21 @@ func main() {
 			priorityName = issue.Priority.Name
 		}
 
-		fmt.Fprintf(os.Stdout, "%d\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\n",
-			issue.ID,
+		_ = w.Write([]string{
+			strconv.Itoa(issue.ID),
 			issue.IssueKey,
 			issue.Summary,
 			statusName,
 			assigneeName,
 			priorityName,
-			len(comments),
-			len(attachments),
+			strconv.Itoa(len(comments)),
+			strconv.Itoa(len(attachments)),
 			issue.Created.String(),
 			issue.Updated.String(),
-		)
+		})
 	}
+
+	w.Flush()
 }
 
 // parseIntList parses a comma-separated string of integers.

--- a/examples/issue_export/main.go
+++ b/examples/issue_export/main.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/nattokin/go-backlog"
+)
+
+func main() {
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	if baseURL == "" {
+		log.Fatalln("You need Backlog base url.")
+	}
+	token := os.Getenv("BACKLOG_TOKEN")
+	if token == "" {
+		log.Fatalln("You need Backlog access token.")
+	}
+
+	statusFlag := flag.String("status", "", "comma-separated status IDs to filter (e.g. 1,2,3)")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 1 {
+		log.Fatalln("Usage: go run . <PROJECT_KEY> [--status <id,...>]")
+	}
+	projectKey := args[0]
+
+	c, err := backlog.NewClient(baseURL, token)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	ctx := context.Background()
+
+	// Resolve project key to project ID required by Issue.All.
+	project, err := c.Project.One(ctx, projectKey)
+	if err != nil {
+		log.Fatalf("failed to get project %q: %v", projectKey, err)
+	}
+
+	opts := []backlog.RequestOption{
+		c.Issue.Option.WithProjectIDs([]int{project.ID}),
+		c.Issue.Option.WithCount(100),
+	}
+
+	if *statusFlag != "" {
+		ids := parseIntList(*statusFlag)
+		if len(ids) > 0 {
+			opts = append(opts, c.Issue.Option.WithStatusIDs(ids))
+		}
+	}
+
+	issues, err := c.Issue.All(ctx, opts...)
+	if err != nil {
+		log.Fatalf("failed to fetch issues: %v", err)
+	}
+
+	// Header
+	fmt.Fprintln(os.Stdout, strings.Join([]string{
+		"ID", "Key", "Summary", "Status", "Assignee", "Priority",
+		"Comments", "Attachments", "Created", "Updated",
+	}, "\t"))
+
+	for _, issue := range issues {
+		comments, err := c.Issue.Comment.All(ctx, issue.IssueKey)
+		if err != nil {
+			log.Printf("warning: failed to fetch comments for %s: %v", issue.IssueKey, err)
+		}
+
+		attachments, err := c.Issue.Attachment.List(ctx, issue.IssueKey)
+		if err != nil {
+			log.Printf("warning: failed to fetch attachments for %s: %v", issue.IssueKey, err)
+		}
+
+		statusName := ""
+		if issue.Status != nil {
+			statusName = issue.Status.Name
+		}
+		assigneeName := ""
+		if issue.Assignee != nil {
+			assigneeName = issue.Assignee.Name
+		}
+		priorityName := ""
+		if issue.Priority != nil {
+			priorityName = issue.Priority.Name
+		}
+
+		fmt.Fprintf(os.Stdout, "%d\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\n",
+			issue.ID,
+			issue.IssueKey,
+			issue.Summary,
+			statusName,
+			assigneeName,
+			priorityName,
+			len(comments),
+			len(attachments),
+			issue.Created.String(),
+			issue.Updated.String(),
+		)
+	}
+}
+
+// parseIntList parses a comma-separated string of integers.
+func parseIntList(s string) []int {
+	parts := strings.Split(s, ",")
+	result := make([]int, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		var n int
+		if _, err := fmt.Sscanf(p, "%d", &n); err == nil {
+			result = append(result, n)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

Add a runnable CLI example that exports issues in a project to TSV format on stdout.

## Changes

- Add `examples/issue_export/main.go`
  - Reads `BACKLOG_BASE_URL` and `BACKLOG_TOKEN` from environment variables
  - Accepts `<PROJECT_KEY>` as a positional argument and optional `--status <id,...>` flag
  - Resolves project key to project ID via `Project.One`, then fetches issues with `Issue.All`
  - For each issue, fetches comment count via `Issue.Comment.All` and attachment count via `Issue.Attachment.List`
  - Outputs TSV with columns: ID, Key, Summary, Status, Assignee, Priority, Comments, Attachments, Created, Updated

## Usage

```
BACKLOG_BASE_URL=https://example.backlog.com BACKLOG_TOKEN=xxx \
  go run . PROJECT_KEY > issues.tsv

# with status filter
go run . PROJECT_KEY --status 1,2
```

Closes #349