### PR TITLE
docs: add project_list example

### DIFF
--- a/examples/project_list/README.md
+++ b/examples/project_list/README.md
@@ -1,0 +1,30 @@
+# project_list
+
+List all projects in a space with their issue types and statuses.
+
+## Prerequisites
+
+- `BACKLOG_BASE_URL`: Your Backlog space URL (e.g. `https://example.backlog.com`)
+- `BACKLOG_TOKEN`: Your Backlog API access token
+
+## Usage
+
+```
+export BACKLOG_BASE_URL=https://example.backlog.com
+export BACKLOG_TOKEN=your_token
+
+go run .
+```
+
+No arguments required.
+
+## Output
+
+```
+3 project(s) found.
+
+[MYPROJECT] My Project (ID: 12345)
+  Issue Types : Bug, Task, Feature
+  Statuses    : Open, In Progress, Resolved, Closed
+...
+```

--- a/examples/project_list/main.go
+++ b/examples/project_list/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/nattokin/go-backlog"
+)
+
+func main() {
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	if baseURL == "" {
+		log.Fatalln("You need Backlog base url.")
+	}
+	token := os.Getenv("BACKLOG_TOKEN")
+	if token == "" {
+		log.Fatalln("You need Backlog access token.")
+	}
+
+	c, err := backlog.NewClient(baseURL, token)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	ctx := context.Background()
+
+	projects, err := c.Project.All(ctx)
+	if err != nil {
+		log.Fatalf("failed to fetch projects: %v", err)
+	}
+
+	fmt.Printf("%d project(s) found.\n", len(projects))
+
+	for _, p := range projects {
+		fmt.Printf("\n[%s] %s (ID: %d)\n", p.ProjectKey, p.Name, p.ID)
+
+		issueTypes, err := c.Project.IssueType.All(ctx, p.ProjectKey)
+		if err != nil {
+			log.Printf("warning: failed to fetch issue types for %s: %v", p.ProjectKey, err)
+		}
+		names := make([]string, len(issueTypes))
+		for i, t := range issueTypes {
+			names[i] = t.Name
+		}
+		fmt.Printf("  Issue Types : %s\n", strings.Join(names, ", "))
+
+		statuses, err := c.Project.Status.All(ctx, p.ProjectKey)
+		if err != nil {
+			log.Printf("warning: failed to fetch statuses for %s: %v", p.ProjectKey, err)
+		}
+		names = make([]string, len(statuses))
+		for i, s := range statuses {
+			names[i] = s.Name
+		}
+		fmt.Printf("  Statuses    : %s\n", strings.Join(names, ", "))
+	}
+}


### PR DESCRIPTION
## Summary

Add a runnable CLI example that lists all projects in a space with their issue types and statuses.

## Changes

- Add `examples/project_list/main.go`
  - Reads `BACKLOG_BASE_URL` and `BACKLOG_TOKEN` from environment variables
  - Fetches all projects via `Project.All`
  - For each project, fetches issue types via `Project.IssueType.All` and statuses via `Project.Status.All`
  - Prints each project with its key, name, ID, issue types, and statuses
- Add `examples/project_list/README.md`

## Note

The issue mentions `Project.Process.List` but the actual public API is `Project.Status.All`.

Closes #352