### PR TITLE
docs: add space_info example

### DIFF
--- a/examples/space_info/README.md
+++ b/examples/space_info/README.md
@@ -1,0 +1,38 @@
+# space_info
+
+Display space information, disk usage, and recent activity.
+
+## Prerequisites
+
+- `BACKLOG_BASE_URL`: Your Backlog space URL (e.g. `https://example.backlog.com`)
+- `BACKLOG_TOKEN`: Your Backlog API access token
+
+## Usage
+
+```
+export BACKLOG_BASE_URL=https://example.backlog.com
+export BACKLOG_TOKEN=your_token
+
+go run .
+```
+
+No arguments required.
+
+## Output
+
+```
+Space     : My Space (myspace)
+Timezone  : Asia/Tokyo
+Lang      : ja
+
+Disk Usage (capacity: 10.00 GB)
+  Issue      : 123.45 MB
+  Wiki       : 12.34 MB
+  File       : 456.78 MB
+  Git        : 0 B
+  Subversion : 0 B
+
+Recent Activity (10 entries)
+  [type:1] John Doe — MYPROJECT-123: Fix login bug
+  ...
+```

--- a/examples/space_info/main.go
+++ b/examples/space_info/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/nattokin/go-backlog"
+)
+
+func main() {
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	if baseURL == "" {
+		log.Fatalln("You need Backlog base url.")
+	}
+	token := os.Getenv("BACKLOG_TOKEN")
+	if token == "" {
+		log.Fatalln("You need Backlog access token.")
+	}
+
+	c, err := backlog.NewClient(baseURL, token)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	ctx := context.Background()
+
+	// Space info
+	space, err := c.Space.One(ctx)
+	if err != nil {
+		log.Fatalf("failed to fetch space info: %v", err)
+	}
+	fmt.Printf("Space     : %s (%s)\n", space.Name, space.SpaceKey)
+	fmt.Printf("Timezone  : %s\n", space.Timezone)
+	fmt.Printf("Lang      : %s\n", space.Lang)
+
+	// Disk usage
+	fmt.Println()
+	disk, err := c.Space.DiskUsage(ctx)
+	if err != nil {
+		log.Fatalf("failed to fetch disk usage: %v", err)
+	}
+	fmt.Printf("Disk Usage (capacity: %s)\n", formatBytes(disk.Capacity))
+	fmt.Printf("  Issue      : %s\n", formatBytes(disk.Issue))
+	fmt.Printf("  Wiki       : %s\n", formatBytes(disk.Wiki))
+	fmt.Printf("  File       : %s\n", formatBytes(disk.File))
+	fmt.Printf("  Git        : %s\n", formatBytes(disk.Git))
+	fmt.Printf("  Subversion : %s\n", formatBytes(disk.Subversion))
+
+	// Recent activity
+	fmt.Println()
+	activities, err := c.Space.Activity.List(ctx, c.Space.Activity.Option.WithCount(10))
+	if err != nil {
+		log.Fatalf("failed to fetch activities: %v", err)
+	}
+	fmt.Printf("Recent Activity (%d entries)\n", len(activities))
+	for _, a := range activities {
+		user := ""
+		if a.CreatedUser != nil {
+			user = a.CreatedUser.Name
+		}
+		summary := ""
+		if a.Content != nil {
+			summary = a.Content.Summary
+		}
+		fmt.Printf("  [type:%d] %s — %s\n", a.Type, user, summary)
+	}
+}
+
+// formatBytes formats a byte count into a human-readable string.
+func formatBytes(b int) string {
+	const (
+		KB = 1024
+		MB = 1024 * KB
+		GB = 1024 * MB
+	)
+	switch {
+	case b >= GB:
+		return fmt.Sprintf("%.2f GB", float64(b)/GB)
+	case b >= MB:
+		return fmt.Sprintf("%.2f MB", float64(b)/MB)
+	case b >= KB:
+		return fmt.Sprintf("%.2f KB", float64(b)/KB)
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}


### PR DESCRIPTION
## Summary

Add a runnable CLI example that displays space information, disk usage, and recent activity.

## Changes

- Add `examples/space_info/main.go`
  - Reads `BACKLOG_BASE_URL` and `BACKLOG_TOKEN` from environment variables
  - Fetches space metadata via `Space.One` and prints name, space key, timezone, and language
  - Fetches disk usage via `Space.DiskUsage` and prints capacity and per-category breakdown
  - Fetches the latest 10 activities via `Space.Activity.List` and prints type, user, and content summary
  - Includes a `formatBytes` helper for human-readable byte formatting
- Add `examples/space_info/README.md`

Closes #351