### PR TITLE
docs: add attachment_download example

### DIFF
--- a/examples/attachment_download/README.md
+++ b/examples/attachment_download/README.md
@@ -1,0 +1,42 @@
+# attachment_download
+
+Download all attachments from an issue or wiki page to a local directory.
+
+## Prerequisites
+
+- `BACKLOG_BASE_URL`: Your Backlog space URL (e.g. `https://example.backlog.com`)
+- `BACKLOG_TOKEN`: Your Backlog API access token
+
+## Usage
+
+```
+export BACKLOG_BASE_URL=https://example.backlog.com
+export BACKLOG_TOKEN=your_token
+
+# Download attachments from an issue
+go run . --target issue <ISSUE_KEY> <OUTPUT_DIR>
+
+# Download attachments from a wiki page
+go run . --target wiki <WIKI_ID> <OUTPUT_DIR>
+```
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--target` | `issue` | Target type: `issue` or `wiki` |
+
+## Output
+
+Files are saved to `<OUTPUT_DIR>/` using the original filename returned by the API.
+
+```
+3 attachment(s) found on issue MYPROJECT-42
+  downloading report.pdf...
+  downloading screenshot.png...
+  downloading data.csv...
+```
+
+## Note
+
+This example demonstrates the `io.Reader`-based `FileData` response and the caller's responsibility to close `FileData.Body` after use.

--- a/examples/attachment_download/README.md
+++ b/examples/attachment_download/README.md
@@ -14,7 +14,7 @@ export BACKLOG_BASE_URL=https://example.backlog.com
 export BACKLOG_TOKEN=your_token
 
 # Download attachments from an issue
-go run . --target issue <ISSUE_KEY> <OUTPUT_DIR>
+go run . --target issue <ISSUE_ID> <OUTPUT_DIR>
 
 # Download attachments from a wiki page
 go run . --target wiki <WIKI_ID> <OUTPUT_DIR>
@@ -26,12 +26,19 @@ go run . --target wiki <WIKI_ID> <OUTPUT_DIR>
 |------|---------|-------------|
 | `--target` | `issue` | Target type: `issue` or `wiki` |
 
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `ID` | Numeric ID of the issue or wiki page |
+| `OUTPUT_DIR` | Directory to save downloaded files |
+
 ## Output
 
 Files are saved to `<OUTPUT_DIR>/` using the original filename returned by the API.
 
 ```
-3 attachment(s) found on issue MYPROJECT-42
+3 attachment(s) found on issue 100
   downloading report.pdf...
   downloading screenshot.png...
   downloading data.csv...

--- a/examples/attachment_download/main.go
+++ b/examples/attachment_download/main.go
@@ -28,9 +28,12 @@ func main() {
 
 	args := flag.Args()
 	if len(args) < 2 {
-		log.Fatalln("Usage: go run . [--target issue|wiki] <ISSUE_KEY_OR_WIKI_ID> <OUTPUT_DIR>")
+		log.Fatalln("Usage: go run . [--target issue|wiki] <ID> <OUTPUT_DIR>")
 	}
-	key := args[0]
+	id, err := strconv.Atoi(args[0])
+	if err != nil {
+		log.Fatalf("ID must be an integer, got %q", args[0])
+	}
 	outDir := args[1]
 
 	if err := os.MkdirAll(outDir, 0755); err != nil {
@@ -46,28 +49,25 @@ func main() {
 
 	switch *target {
 	case "issue":
-		downloadIssueAttachments(ctx, c, key, outDir)
+		downloadIssueAttachments(ctx, c, id, outDir)
 	case "wiki":
-		wikiID, err := strconv.Atoi(key)
-		if err != nil {
-			log.Fatalf("wiki ID must be an integer, got %q", key)
-		}
-		downloadWikiAttachments(ctx, c, wikiID, outDir)
+		downloadWikiAttachments(ctx, c, id, outDir)
 	default:
 		log.Fatalf("unknown target %q: must be issue or wiki", *target)
 	}
 }
 
-func downloadIssueAttachments(ctx context.Context, c *backlog.Client, issueKey, outDir string) {
-	attachments, err := c.Issue.Attachment.List(ctx, issueKey)
+func downloadIssueAttachments(ctx context.Context, c *backlog.Client, issueID int, outDir string) {
+	issueIDStr := strconv.Itoa(issueID)
+	attachments, err := c.Issue.Attachment.List(ctx, issueIDStr)
 	if err != nil {
 		log.Fatalf("failed to list attachments: %v", err)
 	}
-	fmt.Printf("%d attachment(s) found on issue %s\n", len(attachments), issueKey)
+	fmt.Printf("%d attachment(s) found on issue %d\n", len(attachments), issueID)
 
 	for _, a := range attachments {
 		fmt.Printf("  downloading %s...\n", a.Name)
-		fd, err := c.Issue.Attachment.Download(ctx, issueKey, a.ID)
+		fd, err := c.Issue.Attachment.Download(ctx, issueIDStr, a.ID)
 		if err != nil {
 			log.Printf("warning: failed to download %s: %v", a.Name, err)
 			continue

--- a/examples/attachment_download/main.go
+++ b/examples/attachment_download/main.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/nattokin/go-backlog"
+)
+
+func main() {
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	if baseURL == "" {
+		log.Fatalln("You need Backlog base url.")
+	}
+	token := os.Getenv("BACKLOG_TOKEN")
+	if token == "" {
+		log.Fatalln("You need Backlog access token.")
+	}
+
+	target := flag.String("target", "issue", "target type: issue or wiki")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 2 {
+		log.Fatalln("Usage: go run . [--target issue|wiki] <ISSUE_KEY_OR_WIKI_ID> <OUTPUT_DIR>")
+	}
+	key := args[0]
+	outDir := args[1]
+
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		log.Fatalf("failed to create output directory: %v", err)
+	}
+
+	c, err := backlog.NewClient(baseURL, token)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	ctx := context.Background()
+
+	switch *target {
+	case "issue":
+		downloadIssueAttachments(ctx, c, key, outDir)
+	case "wiki":
+		wikiID, err := strconv.Atoi(key)
+		if err != nil {
+			log.Fatalf("wiki ID must be an integer, got %q", key)
+		}
+		downloadWikiAttachments(ctx, c, wikiID, outDir)
+	default:
+		log.Fatalf("unknown target %q: must be issue or wiki", *target)
+	}
+}
+
+func downloadIssueAttachments(ctx context.Context, c *backlog.Client, issueKey, outDir string) {
+	attachments, err := c.Issue.Attachment.List(ctx, issueKey)
+	if err != nil {
+		log.Fatalf("failed to list attachments: %v", err)
+	}
+	fmt.Printf("%d attachment(s) found on issue %s\n", len(attachments), issueKey)
+
+	for _, a := range attachments {
+		fmt.Printf("  downloading %s...\n", a.Name)
+		fd, err := c.Issue.Attachment.Download(ctx, issueKey, a.ID)
+		if err != nil {
+			log.Printf("warning: failed to download %s: %v", a.Name, err)
+			continue
+		}
+		if err := saveFile(fd, outDir); err != nil {
+			log.Printf("warning: failed to save %s: %v", a.Name, err)
+		}
+	}
+}
+
+func downloadWikiAttachments(ctx context.Context, c *backlog.Client, wikiID int, outDir string) {
+	attachments, err := c.Wiki.Attachment.List(ctx, wikiID)
+	if err != nil {
+		log.Fatalf("failed to list attachments: %v", err)
+	}
+	fmt.Printf("%d attachment(s) found on wiki %d\n", len(attachments), wikiID)
+
+	for _, a := range attachments {
+		fmt.Printf("  downloading %s...\n", a.Name)
+		fd, err := c.Wiki.Attachment.Download(ctx, wikiID, a.ID)
+		if err != nil {
+			log.Printf("warning: failed to download %s: %v", a.Name, err)
+			continue
+		}
+		if err := saveFile(fd, outDir); err != nil {
+			log.Printf("warning: failed to save %s: %v", a.Name, err)
+		}
+	}
+}
+
+// saveFile writes FileData to a file in outDir and closes the body.
+func saveFile(fd *backlog.FileData, outDir string) error {
+	defer fd.Body.Close()
+
+	path := filepath.Join(outDir, fd.Filename)
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, fd.Body); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Add a runnable CLI example that downloads all attachments from an issue or wiki page to a local directory.

## Changes

- Add `examples/attachment_download/main.go`
  - Reads `BACKLOG_BASE_URL` and `BACKLOG_TOKEN` from environment variables
  - Accepts `--target issue|wiki` flag (default: `issue`), a key/ID argument, and an output directory argument
  - For issue: lists attachments via `Issue.Attachment.List`, downloads each via `Issue.Attachment.Download`
  - For wiki: lists attachments via `Wiki.Attachment.List`, downloads each via `Wiki.Attachment.Download`
  - Demonstrates `FileData.Body` handling — deferred `Close()` in `saveFile` helper
- Add `examples/attachment_download/README.md`

Closes #354