### PR TITLE
docs: add attachment_upload example

### DIFF
--- a/examples/attachment_upload/README.md
+++ b/examples/attachment_upload/README.md
@@ -1,0 +1,40 @@
+# attachment_upload
+
+Upload a local file to the space and attach it to a specified issue.
+
+This example demonstrates the standard Backlog API two-step flow:
+1. Upload the file to the space via `Space.Attachment.Upload` to obtain an attachment ID
+2. Attach it to the issue via `Issue.Update` with `WithAttachmentIDs`
+
+## Prerequisites
+
+- `BACKLOG_BASE_URL`: Your Backlog space URL (e.g. `https://example.backlog.com`)
+- `BACKLOG_TOKEN`: Your Backlog API access token
+
+## Usage
+
+```
+export BACKLOG_BASE_URL=https://example.backlog.com
+export BACKLOG_TOKEN=your_token
+
+go run . <ISSUE_ID> <FILE_PATH>
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `ISSUE_ID` | Numeric ID of the issue |
+| `FILE_PATH` | Path to the local file to upload |
+
+## Output
+
+```
+Uploading report.pdf to space...
+Uploaded: ID=123, name=report.pdf
+Attaching to issue 456...
+Done.
+Attachments on issue 456 (2 total):
+  ID=122, name=previous.png
+  ID=123, name=report.pdf
+```

--- a/examples/attachment_upload/main.go
+++ b/examples/attachment_upload/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/nattokin/go-backlog"
+)
+
+func main() {
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	if baseURL == "" {
+		log.Fatalln("You need Backlog base url.")
+	}
+	token := os.Getenv("BACKLOG_TOKEN")
+	if token == "" {
+		log.Fatalln("You need Backlog access token.")
+	}
+
+	flag.Parse()
+	args := flag.Args()
+	if len(args) < 2 {
+		log.Fatalln("Usage: go run . <ISSUE_ID> <FILE_PATH>")
+	}
+	issueID, err := strconv.Atoi(args[0])
+	if err != nil {
+		log.Fatalf("ISSUE_ID must be an integer, got %q", args[0])
+	}
+	issueIDStr := strconv.Itoa(issueID)
+	filePath := args[1]
+
+	c, err := backlog.NewClient(baseURL, token)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	ctx := context.Background()
+
+	// Step 1: Upload the file to the space.
+	f, err := os.Open(filePath)
+	if err != nil {
+		log.Fatalf("failed to open file: %v", err)
+	}
+	defer f.Close()
+
+	fileName := filepath.Base(filePath)
+	fmt.Printf("Uploading %s to space...\n", fileName)
+	attachment, err := c.Space.Attachment.Upload(ctx, fileName, f)
+	if err != nil {
+		log.Fatalf("failed to upload file: %v", err)
+	}
+	fmt.Printf("Uploaded: ID=%d, name=%s\n", attachment.ID, attachment.Name)
+
+	// Step 2: Attach the uploaded file to the issue via Issue.Update.
+	fmt.Printf("Attaching to issue %d...\n", issueID)
+	_, err = c.Issue.Update(ctx, issueIDStr, c.Issue.Option.WithAttachmentIDs([]int{attachment.ID}))
+	if err != nil {
+		log.Fatalf("failed to attach file to issue: %v", err)
+	}
+	fmt.Println("Done.")
+
+	// Confirm: list attachments on the issue.
+	attachments, err := c.Issue.Attachment.List(ctx, issueIDStr)
+	if err != nil {
+		log.Printf("warning: failed to list attachments: %v", err)
+		return
+	}
+	fmt.Printf("Attachments on issue %d (%d total):\n", issueID, len(attachments))
+	for _, a := range attachments {
+		fmt.Printf("  ID=%d, name=%s\n", a.ID, a.Name)
+	}
+}


### PR DESCRIPTION
## Summary

Add a runnable CLI example that uploads a local file to the space and attaches it to a specified issue.

## Changes

- Add `examples/attachment_upload/main.go`
  - Reads `BACKLOG_BASE_URL` and `BACKLOG_TOKEN` from environment variables
  - Accepts a numeric `ISSUE_ID` and a `FILE_PATH` as positional arguments
  - Step 1: uploads the file via `Space.Attachment.Upload` to obtain an attachment ID
  - Step 2: attaches it to the issue via `Issue.Update` with `WithAttachmentIDs`
  - Confirms the result by listing attachments via `Issue.Attachment.List`
- Add `examples/attachment_upload/README.md`

Closes #353