### PR TITLE
docs: add pr_list example

### DIFF
--- a/examples/pr_list/README.md
+++ b/examples/pr_list/README.md
@@ -1,0 +1,35 @@
+# pr_list
+
+List pull requests in a repository with comment counts.
+
+## Prerequisites
+
+- `BACKLOG_BASE_URL`: Your Backlog space URL (e.g. `https://example.backlog.com`)
+- `BACKLOG_TOKEN`: Your Backlog API access token
+
+## Usage
+
+```
+export BACKLOG_BASE_URL=https://example.backlog.com
+export BACKLOG_TOKEN=your_token
+
+go run . <PROJECT_KEY> <REPO_NAME> [--status open|closed|merged|draft]
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--status` | Filter by status: `open`, `closed`, `merged`, or `draft` |
+
+## Output
+
+```
+3 pull request(s) found in MYPROJECT/myrepo
+#42 [Open] Fix login bug
+  branch   : feature/fix-login -> main
+  assignee : John Doe
+  comments : 5
+  created  : 2026-01-15 10:00:00 +0000 UTC
+...
+```

--- a/examples/pr_list/main.go
+++ b/examples/pr_list/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/nattokin/go-backlog"
+)
+
+// prStatusIDs maps status name to Backlog API status IDs.
+// 1=Open, 2=Closed, 3=Merged, 4=Draft
+var prStatusIDs = map[string]int{
+	"open":   1,
+	"closed": 2,
+	"merged": 3,
+	"draft":  4,
+}
+
+func main() {
+	baseURL := os.Getenv("BACKLOG_BASE_URL")
+	if baseURL == "" {
+		log.Fatalln("You need Backlog base url.")
+	}
+	token := os.Getenv("BACKLOG_TOKEN")
+	if token == "" {
+		log.Fatalln("You need Backlog access token.")
+	}
+
+	statusFlag := flag.String("status", "", "filter by status: open, closed, merged, draft")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 2 {
+		log.Fatalln("Usage: go run . [--status open|closed|merged|draft] <PROJECT_KEY> <REPO_NAME>")
+	}
+	projectKey := args[0]
+	repoName := args[1]
+
+	c, err := backlog.NewClient(baseURL, token)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	ctx := context.Background()
+
+	opts := []backlog.RequestOption{}
+	if *statusFlag != "" {
+		id, ok := prStatusIDs[*statusFlag]
+		if !ok {
+			log.Fatalf("unknown status %q: must be open, closed, merged, or draft", *statusFlag)
+		}
+		opts = append(opts, c.PullRequest.Option.WithStatusIDs([]int{id}))
+	}
+
+	total, err := c.PullRequest.Count(ctx, projectKey, repoName, opts...)
+	if err != nil {
+		log.Fatalf("failed to count pull requests: %v", err)
+	}
+	fmt.Printf("%d pull request(s) found in %s/%s\n", total, projectKey, repoName)
+
+	prs, err := c.PullRequest.All(ctx, projectKey, repoName, opts...)
+	if err != nil {
+		log.Fatalf("failed to fetch pull requests: %v", err)
+	}
+
+	for _, pr := range prs {
+		statusName := ""
+		if pr.Status != nil {
+			statusName = pr.Status.Name
+		}
+		assigneeName := ""
+		if pr.Assignee != nil {
+			assigneeName = pr.Assignee.Name
+		}
+
+		comments, err := c.PullRequest.Comment.All(ctx, projectKey, repoName, pr.Number)
+		if err != nil {
+			log.Printf("warning: failed to fetch comments for PR #%d: %v", pr.Number, err)
+		}
+
+		fmt.Printf("#%d [%s] %s\n", pr.Number, statusName, pr.Summary)
+		fmt.Printf("  branch   : %s -> %s\n", pr.Branch, pr.Base)
+		fmt.Printf("  assignee : %s\n", assigneeName)
+		fmt.Printf("  comments : %d\n", len(comments))
+		fmt.Printf("  created  : %s\n", pr.Created.String())
+	}
+}


### PR DESCRIPTION
## Summary

Add a runnable CLI example that lists pull requests in a repository with comment counts.

## Changes

- Add `examples/pr_list/main.go`
  - Reads `BACKLOG_BASE_URL` and `BACKLOG_TOKEN` from environment variables
  - Accepts `<PROJECT_KEY>` and `<REPO_NAME>` as positional arguments
  - Optional `--status open|closed|merged|draft` flag mapped to Backlog API status IDs (1/2/3/4)
  - Fetches total count via `PullRequest.Count`, then fetches the list via `PullRequest.All`
  - For each PR, fetches comment count via `PullRequest.Comment.All`
  - Prints PR number, status, summary, branch, assignee, comment count, and created date
- Add `examples/pr_list/README.md`

Closes #350