### PR TITLE
fix: add missing Created field to Activity

### DIFF
--- a/examples/space_info/README.md
+++ b/examples/space_info/README.md
@@ -33,6 +33,6 @@ Disk Usage (capacity: 10.00 GB)
   Subversion : 0 B
 
 Recent Activity (10 entries)
-  [type:1] John Doe — MYPROJECT-123: Fix login bug
+  [type:1] John Doe — MYPROJECT-123: Fix login bug (2026-05-14 10:00:00)
   ...
 ```

--- a/examples/space_info/main.go
+++ b/examples/space_info/main.go
@@ -64,7 +64,7 @@ func main() {
 		if a.Content != nil {
 			summary = a.Content.Summary
 		}
-		fmt.Printf("  [type:%d] %s — %s\n", a.Type, user, summary)
+		fmt.Printf("  [type:%d] %s — %s (%s)\n", a.Type, user, summary, a.Created.Format("2006-01-02 15:04:05"))
 	}
 }
 

--- a/internal/model/activity.go
+++ b/internal/model/activity.go
@@ -1,6 +1,8 @@
 // Package model defines the data structures returned by the Backlog API.
 package model
 
+import "time"
+
 // Activity represents a recent update or change in the project or space.
 type Activity struct {
 	ID            int              `json:"id,omitempty"`
@@ -9,6 +11,7 @@ type Activity struct {
 	Content       *ActivityContent `json:"content,omitempty"`
 	Notifications []*Notification  `json:"notifications,omitempty"`
 	CreatedUser   *User            `json:"createdUser,omitempty"`
+	Created       time.Time        `json:"created,omitempty"`
 }
 
 // ActivityContent represents the detailed content of an activity.

--- a/internal/testutil/fixture/testdata_activity.go
+++ b/internal/testutil/fixture/testdata_activity.go
@@ -202,6 +202,7 @@ var Activity = activityFixtures{
 				Lang:        "ja",
 				MailAddress: "eguchi@nulab.example",
 			},
+			Created: mustTimestamp("2014-07-21T06:48:40Z"),
 		},
 	},
 	SingleJSON: `{
@@ -260,5 +261,6 @@ var Activity = activityFixtures{
 			Lang:        "ja",
 			MailAddress: "eguchi@nulab.example",
 		},
+		Created: mustTimestamp("2014-07-21T06:48:40Z"),
 	},
 }

--- a/models.go
+++ b/models.go
@@ -23,6 +23,7 @@ type Activity struct {
 	Content       *ActivityContent
 	Notifications []*Notification
 	CreatedUser   *User
+	Created       Timestamp
 }
 
 // ActivityContent represents the detailed content of an activity.
@@ -255,6 +256,7 @@ func activityFromModel(m *model.Activity) *Activity {
 		Content:       activityContentFromModel(m.Content),
 		Notifications: notifications,
 		CreatedUser:   userFromModel(m.CreatedUser),
+		Created:       Timestamp{m.Created},
 	}
 }
 


### PR DESCRIPTION
## Summary

The Backlog API returns a `created` field in activity responses, but it was missing from both `internal/model.Activity` and the root package `Activity` struct.

## Changes

- Add `Created time.Time` to `internal/model.Activity` with `json:"created,omitempty"`
- Add `Created Timestamp` to the root package `Activity` struct
- Map `Created` in `activityFromModel`
- Update `fixture.Activity` (both `List`/`Single` structs and JSON strings) to include `created`
- Use `Activity.Created` in `examples/space_info` activity output

Closes #358