### PR TITLE
refactor!: rename API endpoints

### DIFF
--- a/.github/scripts/update-parent-pr.js
+++ b/.github/scripts/update-parent-pr.js
@@ -201,7 +201,7 @@ function normalizeDescription(body) {
  * Format (no leading "- " on the parent row to avoid GitHub's duplicate link rendering):
  *
  *   feat!: add context.Context to WikiService (#107)
- *   - Add ctx to Wiki.All
+ *   - Add ctx to Wiki.List
  *   - Add ctx to Wiki.Create
  *
  * The parent row is identified by `(#childNumber)` on a non-indented, non-list line.

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ c, err := backlog.NewClient(
 )
 
 // Get all Wiki pages in a project.
-wikis, err := c.Wiki.All(context.Background(), "MYPROJECT")
+wikis, err := c.Wiki.List(context.Background(), "MYPROJECT")
 
 // Filter by keyword using an option.
-wikis, err = c.Wiki.All(context.Background(), "MYPROJECT",
+wikis, err = c.Wiki.List(context.Background(), "MYPROJECT",
     c.Wiki.Option.WithKeyword("design"),
 )
 ```

--- a/error_test.go
+++ b/error_test.go
@@ -136,7 +136,7 @@ func Test_convertError_default_passthroughsUnknownError(t *testing.T) {
 		}}),
 	)
 	require.NoError(t, err)
-	_, err = c.Wiki.All(context.Background(), "PROJECT")
+	_, err = c.Wiki.List(context.Background(), "PROJECT")
 	assert.True(t, errors.Is(err, sentinel))
 }
 
@@ -164,7 +164,7 @@ func callWikiAllWithStatus(t *testing.T, statusCode int) error {
 		}}),
 	)
 	require.NoError(t, err)
-	_, err = c.Wiki.All(context.Background(), "PROJECT")
+	_, err = c.Wiki.List(context.Background(), "PROJECT")
 	return err
 }
 
@@ -174,6 +174,6 @@ func callWikiAllWithInvalidOption(t *testing.T) error {
 	t.Helper()
 	c, err := backlog.NewClient("https://example.backlog.com", "token")
 	require.NoError(t, err)
-	_, err = c.Wiki.All(context.Background(), "PROJECT", c.Wiki.Option.WithContent("x"))
+	_, err = c.Wiki.List(context.Background(), "PROJECT", c.Wiki.Option.WithContent("x"))
 	return err
 }

--- a/example_doer_test.go
+++ b/example_doer_test.go
@@ -95,7 +95,7 @@ var (
 	doerWikiSingle             = newMockDoer(fixture.Wiki.MinimumJSON)
 	doerWikiHistoryList        = newMockDoer(fixture.WikiHistory.ListJSON)
 	doerWikiAttachmentDownload = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
-	doerSharedFileGetFile      = newMockBinaryDoer("image/png", "shared.png", []byte("PNG"))
+	doerSharedFileGetDownload  = newMockBinaryDoer("image/png", "shared.png", []byte("PNG"))
 	doerAttachmentDownload     = newMockBinaryDoer("image/png", "A.png", []byte("PNG"))
 	doerWikiCount              = newMockDoer(`{"count": 5}`)
 )

--- a/example_issue_test.go
+++ b/example_issue_test.go
@@ -7,14 +7,14 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 )
 
-func ExampleIssueService_All() {
+func ExampleIssueService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerIssueList),
 	)
 
-	issues, _ := c.Issue.All(context.Background())
+	issues, _ := c.Issue.List(context.Background())
 	fmt.Printf("Count: %d, ID: %d, Summary: %s\n", len(issues), issues[0].ID, issues[0].Summary)
 	// Output:
 	// Count: 2, ID: 1, Summary: First issue
@@ -137,14 +137,14 @@ func ExampleIssueAttachmentService_Remove() {
 	// ID: 8, Name: IMG0088.png
 }
 
-func ExampleIssueCommentService_All() {
+func ExampleIssueCommentService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerCommentList),
 	)
 
-	comments, _ := c.Issue.Comment.All(context.Background(), "PRJ-1")
+	comments, _ := c.Issue.Comment.List(context.Background(), "PRJ-1")
 	fmt.Printf("Count: %d, ID: %d, Content: %s\n", len(comments), comments[0].ID, comments[0].Content)
 	// Output:
 	// Count: 2, ID: 1, Content: This is a comment.

--- a/example_option_test.go
+++ b/example_option_test.go
@@ -35,7 +35,7 @@ func ExampleIssueOptionService() {
 		backlog.WithDoer(doerIssueList),
 	)
 
-	issues, _ := c.Issue.All(
+	issues, _ := c.Issue.List(
 		context.Background(),
 		c.Issue.Option.WithProjectIDs([]int{10}),
 		c.Issue.Option.WithKeyword("first"),
@@ -108,7 +108,7 @@ func ExampleIssueCommentOptionService() {
 		backlog.WithDoer(doerCommentList),
 	)
 
-	comments, _ := c.Issue.Comment.All(
+	comments, _ := c.Issue.Comment.List(
 		context.Background(),
 		"PRJ-1",
 		c.Issue.Comment.Option.WithCount(20),
@@ -127,7 +127,7 @@ func ExampleProjectOptionService() {
 		backlog.WithDoer(doerProjectList),
 	)
 
-	projects, _ := c.Project.All(
+	projects, _ := c.Project.List(
 		context.Background(),
 		c.Project.Option.WithAll(true),
 		c.Project.Option.WithArchived(false),
@@ -201,7 +201,7 @@ func ExamplePullRequestOptionService() {
 		backlog.WithDoer(doerPullRequestList),
 	)
 
-	prs, _ := c.PullRequest.All(
+	prs, _ := c.PullRequest.List(
 		context.Background(),
 		"TEST",
 		"myrepo",
@@ -221,7 +221,7 @@ func ExamplePullRequestCommentOptionService() {
 		backlog.WithDoer(doerCommentList),
 	)
 
-	comments, _ := c.PullRequest.Comment.All(
+	comments, _ := c.PullRequest.Comment.List(
 		context.Background(),
 		"TEST",
 		"myrepo",

--- a/example_project_test.go
+++ b/example_project_test.go
@@ -113,14 +113,14 @@ func ExampleProjectActivityService_List() {
 	// ID: 3153, Type: 2
 }
 
-func ExampleProjectCategoryService_All() {
+func ExampleProjectCategoryService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerCategoryList),
 	)
 
-	categories, _ := c.Project.Category.All(context.Background(), "TEST")
+	categories, _ := c.Project.Category.List(context.Background(), "TEST")
 	fmt.Printf("ID: %d, Name: %s\n", categories[0].ID, categories[0].Name)
 	// Output:
 	// ID: 12, Name: Bug
@@ -165,14 +165,14 @@ func ExampleProjectCategoryService_Delete() {
 	// ID: 12, Name: Bug
 }
 
-func ExampleProjectCustomFieldService_All() {
+func ExampleProjectCustomFieldService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerCustomFieldList),
 	)
 
-	fields, _ := c.Project.CustomField.All(context.Background(), "TEST")
+	fields, _ := c.Project.CustomField.List(context.Background(), "TEST")
 	fmt.Printf("ID: %d, Name: %s\n", fields[0].ID, fields[0].Name)
 	// Output:
 	// ID: 1, Name: Sprint
@@ -261,14 +261,14 @@ func ExampleProjectCustomFieldService_DeleteListItem() {
 	// ID: 1, Name: Sprint
 }
 
-func ExampleProjectIssueTypeService_All() {
+func ExampleProjectIssueTypeService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerIssueTypeList),
 	)
 
-	issueTypes, _ := c.Project.IssueType.All(context.Background(), "TEST")
+	issueTypes, _ := c.Project.IssueType.List(context.Background(), "TEST")
 	fmt.Printf("ID: %d, Name: %s, Color: %s\n", issueTypes[0].ID, issueTypes[0].Name, issueTypes[0].Color)
 	// Output:
 	// ID: 1, Name: Bug, Color: #e30000
@@ -341,14 +341,14 @@ func ExampleProjectSharedFileService_Download() {
 	// ContentType: image/png, FileName: shared.png
 }
 
-func ExampleProjectUserService_All() {
+func ExampleProjectUserService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerUserList),
 	)
 
-	users, _ := c.Project.User.All(context.Background(), "TEST", false)
+	users, _ := c.Project.User.List(context.Background(), "TEST", false)
 	fmt.Printf("ID: %d, UserID: %s\n", users[0].ID, users[0].UserID)
 	// Output:
 	// ID: 1, UserID: admin
@@ -393,14 +393,14 @@ func ExampleProjectUserService_AddAdmin() {
 	// ID: 1, UserID: admin
 }
 
-func ExampleProjectUserService_AdminAll() {
+func ExampleProjectUserService_AdminList() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerUserList),
 	)
 
-	users, _ := c.Project.User.AdminAll(context.Background(), "TEST")
+	users, _ := c.Project.User.AdminList(context.Background(), "TEST")
 	fmt.Printf("ID: %d, UserID: %s\n", users[0].ID, users[0].UserID)
 	// Output:
 	// ID: 1, UserID: admin
@@ -419,14 +419,14 @@ func ExampleProjectUserService_DeleteAdmin() {
 	// ID: 1, UserID: admin
 }
 
-func ExampleProjectWebhookService_All() {
+func ExampleProjectWebhookService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerWebhookList),
 	)
 
-	webhooks, _ := c.Project.Webhook.All(context.Background(), "TEST")
+	webhooks, _ := c.Project.Webhook.List(context.Background(), "TEST")
 	fmt.Printf("ID: %d, Name: %s\n", webhooks[0].ID, webhooks[0].Name)
 	// Output:
 	// ID: 1, Name: Example Webhook
@@ -495,14 +495,14 @@ func ExampleProjectWebhookService_Delete() {
 	// ID: 1, Name: Example Webhook
 }
 
-func ExampleProjectStatusService_All() {
+func ExampleProjectStatusService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerStatusList),
 	)
 
-	statuses, _ := c.Project.Status.All(context.Background(), "TEST")
+	statuses, _ := c.Project.Status.List(context.Background(), "TEST")
 	fmt.Printf("ID: %d, Name: %s\n", statuses[0].ID, statuses[0].Name)
 	// Output:
 	// ID: 1, Name: Open

--- a/example_project_test.go
+++ b/example_project_test.go
@@ -341,14 +341,14 @@ func ExampleProjectSharedFileService_GetFile() {
 	// ContentType: image/png, FileName: shared.png
 }
 
-func ExampleProjectUserService_List() {
+func ExampleProjectUserService_All() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerUserList),
 	)
 
-	users, _ := c.Project.User.List(context.Background(), "TEST", false)
+	users, _ := c.Project.User.All(context.Background(), "TEST", false)
 	fmt.Printf("ID: %d, UserID: %s\n", users[0].ID, users[0].UserID)
 	// Output:
 	// ID: 1, UserID: admin

--- a/example_project_test.go
+++ b/example_project_test.go
@@ -7,14 +7,14 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 )
 
-func ExampleProjectService_All() {
+func ExampleProjectService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerProjectList),
 	)
 
-	projects, _ := c.Project.All(context.Background())
+	projects, _ := c.Project.List(context.Background())
 	fmt.Printf("ID: %d, Key: %s\n", projects[0].ID, projects[0].ProjectKey)
 	// Output:
 	// ID: 1, Key: TEST
@@ -341,14 +341,14 @@ func ExampleProjectSharedFileService_GetFile() {
 	// ContentType: image/png, FileName: shared.png
 }
 
-func ExampleProjectUserService_All() {
+func ExampleProjectUserService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerUserList),
 	)
 
-	users, _ := c.Project.User.All(context.Background(), "TEST", false)
+	users, _ := c.Project.User.List(context.Background(), "TEST", false)
 	fmt.Printf("ID: %d, UserID: %s\n", users[0].ID, users[0].UserID)
 	// Output:
 	// ID: 1, UserID: admin
@@ -565,14 +565,14 @@ func ExampleProjectStatusService_UpdateOrder() {
 	// ID: 1, Name: Open
 }
 
-func ExampleProjectVersionService_All() {
+func ExampleProjectVersionService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerVersionList),
 	)
 
-	versions, _ := c.Project.Version.All(context.Background(), "TEST")
+	versions, _ := c.Project.Version.List(context.Background(), "TEST")
 	fmt.Printf("ID: %d, Name: %s\n", versions[0].ID, versions[0].Name)
 	// Output:
 	// ID: 1, Name: Version 1.0

--- a/example_project_test.go
+++ b/example_project_test.go
@@ -328,14 +328,14 @@ func ExampleProjectSharedFileService_List() {
 	// ID: 454403, Name: 01_buz.png
 }
 
-func ExampleProjectSharedFileService_GetFile() {
+func ExampleProjectSharedFileService_Download() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
-		backlog.WithDoer(doerSharedFileGetFile),
+		backlog.WithDoer(doerSharedFileGetDownload),
 	)
 
-	file, _ := c.Project.SharedFile.GetFile(context.Background(), "TEST", 1)
+	file, _ := c.Project.SharedFile.Download(context.Background(), "TEST", 1)
 	fmt.Printf("ContentType: %s, FileName: %s\n", file.ContentType, file.Filename)
 	// Output:
 	// ContentType: image/png, FileName: shared.png

--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -7,14 +7,14 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 )
 
-func ExamplePullRequestService_All() {
+func ExamplePullRequestService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerPullRequestList),
 	)
 
-	prs, _ := c.PullRequest.All(context.Background(), "TEST", "myrepo")
+	prs, _ := c.PullRequest.List(context.Background(), "TEST", "myrepo")
 	fmt.Printf("Count: %d, ID: %d, Summary: %s\n", len(prs), prs[0].ID, prs[0].Summary)
 	// Output:
 	// Count: 2, ID: 2, Summary: test PR
@@ -111,14 +111,14 @@ func ExamplePullRequestAttachmentService_Remove() {
 	// ID: 8, Name: IMG0088.png
 }
 
-func ExamplePullRequestCommentService_All() {
+func ExamplePullRequestCommentService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerCommentList),
 	)
 
-	comments, _ := c.PullRequest.Comment.All(context.Background(), "TEST", "myrepo", 1)
+	comments, _ := c.PullRequest.Comment.List(context.Background(), "TEST", "myrepo", 1)
 	fmt.Printf("Count: %d, ID: %d, Content: %s\n", len(comments), comments[0].ID, comments[0].Content)
 	// Output:
 	// Count: 2, ID: 1, Content: This is a comment.

--- a/example_repository_test.go
+++ b/example_repository_test.go
@@ -7,14 +7,14 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 )
 
-func ExampleRepositoryService_All() {
+func ExampleRepositoryService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerRepositoryList),
 	)
 
-	repos, _ := c.Repository.All(context.Background(), "TEST")
+	repos, _ := c.Repository.List(context.Background(), "TEST")
 	fmt.Printf("Count: %d, ID: %d, Name: %s\n", len(repos), repos[0].ID, repos[0].Name)
 	// Output:
 	// Count: 2, ID: 5, Name: foo

--- a/example_space_test.go
+++ b/example_space_test.go
@@ -8,14 +8,14 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 )
 
-func ExampleSpaceService_One() {
+func ExampleSpaceService_Info() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerSpaceSpace),
 	)
 
-	space, _ := c.Space.One(context.Background())
+	space, _ := c.Space.Info(context.Background())
 	fmt.Printf("SpaceKey: %s, Name: %s\n", space.SpaceKey, space.Name)
 	// Output:
 	// SpaceKey: nulab, Name: Nulab Inc.

--- a/example_space_test.go
+++ b/example_space_test.go
@@ -73,14 +73,14 @@ func ExampleSpaceActivityService_List() {
 	// ID: 3153, Type: 2
 }
 
-func ExampleSpaceActivityService_Get() {
+func ExampleSpaceActivityService_One() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerActivitySingle),
 	)
 
-	activity, _ := c.Space.Activity.Get(context.Background(), 3153)
+	activity, _ := c.Space.Activity.One(context.Background(), 3153)
 	fmt.Printf("ID: %d, Type: %d\n", activity.ID, activity.Type)
 	// Output:
 	// ID: 3153, Type: 2

--- a/example_test.go
+++ b/example_test.go
@@ -16,7 +16,7 @@ func Example() {
 		backlog.WithDoer(doerWikiList),
 	)
 
-	wikis, _ := c.Wiki.All(context.Background(), "MYPROJECT")
+	wikis, _ := c.Wiki.List(context.Background(), "MYPROJECT")
 	fmt.Printf("ID: %d, Name: %s\n", wikis[0].ID, wikis[0].Name)
 	// Output:
 	// ID: 112, Name: test1
@@ -30,7 +30,7 @@ func Example_withOptions() {
 		backlog.WithDoer(doerWikiList),
 	)
 
-	wikis, _ := c.Wiki.All(
+	wikis, _ := c.Wiki.List(
 		context.Background(),
 		"MYPROJECT",
 		c.Wiki.Option.WithKeyword("test"),

--- a/example_user_test.go
+++ b/example_user_test.go
@@ -7,14 +7,14 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 )
 
-func ExampleUserService_All() {
+func ExampleUserService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerUserList),
 	)
 
-	users, _ := c.User.All(context.Background())
+	users, _ := c.User.List(context.Background())
 	fmt.Printf("ID: %d, UserID: %s\n", users[0].ID, users[0].UserID)
 	// Output:
 	// ID: 1, UserID: admin

--- a/example_user_test.go
+++ b/example_user_test.go
@@ -33,14 +33,14 @@ func ExampleUserService_One() {
 	// ID: 1, UserID: admin
 }
 
-func ExampleUserService_Own() {
+func ExampleUserService_Me() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerUserSingle),
 	)
 
-	user, _ := c.User.Own(context.Background())
+	user, _ := c.User.Me(context.Background())
 	fmt.Printf("ID: %d, UserID: %s\n", user.ID, user.UserID)
 	// Output:
 	// ID: 1, UserID: admin

--- a/example_wiki_test.go
+++ b/example_wiki_test.go
@@ -7,14 +7,14 @@ import (
 	backlog "github.com/nattokin/go-backlog"
 )
 
-func ExampleWikiService_All() {
+func ExampleWikiService_List() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",
 		"token",
 		backlog.WithDoer(doerWikiList),
 	)
 
-	wikis, _ := c.Wiki.All(context.Background(), "MYPROJECT")
+	wikis, _ := c.Wiki.List(context.Background(), "MYPROJECT")
 	fmt.Printf("ID: %d, Name: %s\n", wikis[0].ID, wikis[0].Name)
 	// Output:
 	// ID: 112, Name: test1

--- a/examples/issue_export/main.go
+++ b/examples/issue_export/main.go
@@ -57,7 +57,7 @@ func main() {
 		}
 	}
 
-	issues, err := c.Issue.All(ctx, opts...)
+	issues, err := c.Issue.List(ctx, opts...)
 	if err != nil {
 		log.Fatalf("failed to fetch issues: %v", err)
 	}
@@ -68,7 +68,7 @@ func main() {
 	_ = w.Write([]string{"ID", "Key", "Summary", "Status", "Assignee", "Priority", "Comments", "Attachments", "Created", "Updated"})
 
 	for _, issue := range issues {
-		comments, err := c.Issue.Comment.All(ctx, issue.IssueKey)
+		comments, err := c.Issue.Comment.List(ctx, issue.IssueKey)
 		if err != nil {
 			log.Printf("warning: failed to fetch comments for %s: %v", issue.IssueKey, err)
 		}

--- a/examples/issue_export/main.go
+++ b/examples/issue_export/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	ctx := context.Background()
 
-	// Resolve project key to project ID required by Issue.All.
+	// Resolve project key to project ID required by Issue.List.
 	project, err := c.Project.One(ctx, projectKey)
 	if err != nil {
 		log.Fatalf("failed to get project %q: %v", projectKey, err)

--- a/examples/pr_list/main.go
+++ b/examples/pr_list/main.go
@@ -61,7 +61,7 @@ func main() {
 	}
 	fmt.Printf("%d pull request(s) found in %s/%s\n", total, projectKey, repoName)
 
-	prs, err := c.PullRequest.All(ctx, projectKey, repoName, opts...)
+	prs, err := c.PullRequest.List(ctx, projectKey, repoName, opts...)
 	if err != nil {
 		log.Fatalf("failed to fetch pull requests: %v", err)
 	}
@@ -76,7 +76,7 @@ func main() {
 			assigneeName = pr.Assignee.Name
 		}
 
-		comments, err := c.PullRequest.Comment.All(ctx, projectKey, repoName, pr.Number)
+		comments, err := c.PullRequest.Comment.List(ctx, projectKey, repoName, pr.Number)
 		if err != nil {
 			log.Printf("warning: failed to fetch comments for PR #%d: %v", pr.Number, err)
 		}

--- a/examples/project_list/main.go
+++ b/examples/project_list/main.go
@@ -37,7 +37,7 @@ func main() {
 	for _, p := range projects {
 		fmt.Printf("\n[%s] %s (ID: %d)\n", p.ProjectKey, p.Name, p.ID)
 
-		issueTypes, err := c.Project.IssueType.All(ctx, p.ProjectKey)
+		issueTypes, err := c.Project.IssueType.List(ctx, p.ProjectKey)
 		if err != nil {
 			log.Printf("warning: failed to fetch issue types for %s: %v", p.ProjectKey, err)
 		}
@@ -47,7 +47,7 @@ func main() {
 		}
 		fmt.Printf("  Issue Types : %s\n", strings.Join(names, ", "))
 
-		statuses, err := c.Project.Status.All(ctx, p.ProjectKey)
+		statuses, err := c.Project.Status.List(ctx, p.ProjectKey)
 		if err != nil {
 			log.Printf("warning: failed to fetch statuses for %s: %v", p.ProjectKey, err)
 		}

--- a/examples/project_list/main.go
+++ b/examples/project_list/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	ctx := context.Background()
 
-	projects, err := c.Project.All(ctx)
+	projects, err := c.Project.List(ctx)
 	if err != nil {
 		log.Fatalf("failed to fetch projects: %v", err)
 	}

--- a/examples/space_info/main.go
+++ b/examples/space_info/main.go
@@ -27,7 +27,7 @@ func main() {
 	ctx := context.Background()
 
 	// Space info
-	space, err := c.Space.One(ctx)
+	space, err := c.Space.Info(ctx)
 	if err != nil {
 		log.Fatalf("failed to fetch space info: %v", err)
 	}

--- a/examples/wiki_backup/main.go
+++ b/examples/wiki_backup/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	ctx := context.Background()
 
-	wikis, err := c.Wiki.All(ctx, projectKey)
+	wikis, err := c.Wiki.List(ctx, projectKey)
 	if err != nil {
 		log.Fatalf("failed to fetch wiki list: %v", err)
 	}

--- a/examples/wiki_rename/main.go
+++ b/examples/wiki_rename/main.go
@@ -30,7 +30,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	wikis, err := c.Wiki.All(context.Background(), projectKey)
+	wikis, err := c.Wiki.List(context.Background(), projectKey)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/internal/core/client_test.go
+++ b/internal/core/client_test.go
@@ -747,7 +747,7 @@ type httpCapture struct {
 // Example:
 //
 //	client, captured := makeClient(t)
-//	_, _ = client.Wiki.All()
+//	_, _ = client.Wiki.List()
 //	assert.Equal(t, "GET", captured.Method)
 //	assert.Contains(t, captured.URL.Path, "/api/v2/wikis")
 func makeClient(t *testing.T) (*core.Client, *httpCapture) {

--- a/internal/domain/issue/service.go
+++ b/internal/domain/issue/service.go
@@ -17,10 +17,10 @@ type Service struct {
 	method *core.Method
 }
 
-// All returns a list of issues.
+// List returns a list of issues.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-list
-func (s *Service) All(ctx context.Context, opts ...core.RequestOption) ([]*model.Issue, error) {
+func (s *Service) List(ctx context.Context, opts ...core.RequestOption) ([]*model.Issue, error) {
 	query := url.Values{}
 	validTypes := []core.APIParamOptionType{
 		core.ParamProjectIDs,

--- a/internal/domain/issue/service_comment.go
+++ b/internal/domain/issue/service_comment.go
@@ -20,16 +20,16 @@ type CommentService struct {
 	method *core.Method
 }
 
-// All returns a list of comments on an issue.
+// List returns a list of comments on an issue.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-comment-list
-func (s *CommentService) All(ctx context.Context, issueIDOrKey string, opts ...core.RequestOption) ([]*model.Comment, error) {
+func (s *CommentService) List(ctx context.Context, issueIDOrKey string, opts ...core.RequestOption) ([]*model.Comment, error) {
 	if err := validate.ValidateIssueIDOrKey(issueIDOrKey); err != nil {
 		return nil, err
 	}
 
 	spath := path.Join("issues", issueIDOrKey, "comments")
-	return s.base.All(ctx, spath, opts...)
+	return s.base.List(ctx, spath, opts...)
 }
 
 // Add adds a comment to an issue.

--- a/internal/domain/issue/service_comment_test.go
+++ b/internal/domain/issue/service_comment_test.go
@@ -113,7 +113,7 @@ func TestCommentService_All(t *testing.T) {
 
 			s := issue.NewCommentService(method)
 
-			got, err := s.All(context.Background(), tc.issueIDOrKey, tc.opts...)
+			got, err := s.List(context.Background(), tc.issueIDOrKey, tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)

--- a/internal/domain/issue/service_comment_test.go
+++ b/internal/domain/issue/service_comment_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestCommentService_All(t *testing.T) {
+func TestCommentService_List(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {

--- a/internal/domain/issue/service_test.go
+++ b/internal/domain/issue/service_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestIssueService_All(t *testing.T) {
+func TestIssueService_List(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -770,7 +770,7 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"Service.All", func(t *testing.T, m *core.Method) {
+		{"Service.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := issue.NewService(m)
 			s.List(ctx) //nolint:errcheck
@@ -820,7 +820,7 @@ func Test_contextPropagation(t *testing.T) {
 			s := issue.NewAttachmentService(m)
 			s.Download(ctx, "TEST-1", 1) //nolint:errcheck
 		}},
-		{"CommentService.All", func(t *testing.T, m *core.Method) {
+		{"CommentService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := issue.NewCommentService(m)
 			s.List(ctx, "ISSUE-1") //nolint:errcheck

--- a/internal/domain/issue/service_test.go
+++ b/internal/domain/issue/service_test.go
@@ -154,7 +154,7 @@ func TestIssueService_All(t *testing.T) {
 
 			s := issue.NewService(method)
 
-			issues, err := s.All(context.Background(), tc.opts...)
+			issues, err := s.List(context.Background(), tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -773,7 +773,7 @@ func Test_contextPropagation(t *testing.T) {
 		{"Service.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := issue.NewService(m)
-			s.All(ctx) //nolint:errcheck
+			s.List(ctx) //nolint:errcheck
 		}},
 		{"Service.Count", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
@@ -823,7 +823,7 @@ func Test_contextPropagation(t *testing.T) {
 		{"CommentService.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := issue.NewCommentService(m)
-			s.All(ctx, "ISSUE-1") //nolint:errcheck
+			s.List(ctx, "ISSUE-1") //nolint:errcheck
 		}},
 		{"CommentService.Add", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)

--- a/internal/domain/project/service.go
+++ b/internal/domain/project/service.go
@@ -16,10 +16,10 @@ type Service struct {
 	method *core.Method
 }
 
-// All returns a list of projects in the space.
+// List returns a list of projects in the space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-list
-func (s *Service) All(ctx context.Context, opts ...core.RequestOption) ([]*model.Project, error) {
+func (s *Service) List(ctx context.Context, opts ...core.RequestOption) ([]*model.Project, error) {
 
 	query := url.Values{}
 	validTypes := []core.APIParamOptionType{core.ParamAll, core.ParamArchived}

--- a/internal/domain/project/service_category.go
+++ b/internal/domain/project/service_category.go
@@ -16,10 +16,10 @@ type CategoryService struct {
 	method *core.Method
 }
 
-// All returns a list of categories in a project.
+// List returns a list of categories in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-category-list
-func (s *CategoryService) All(ctx context.Context, projectIDOrKey string) ([]*model.Category, error) {
+func (s *CategoryService) List(ctx context.Context, projectIDOrKey string) ([]*model.Category, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/project/service_category_test.go
+++ b/internal/domain/project/service_category_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestCategoryService_All(t *testing.T) {
+func TestCategoryService_List(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 
@@ -83,7 +83,7 @@ func TestCategoryService_All(t *testing.T) {
 			}
 			s := project.NewCategoryService(method)
 
-			categories, err := s.All(context.Background(), tc.projectIDOrKey)
+			categories, err := s.List(context.Background(), tc.projectIDOrKey)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)

--- a/internal/domain/project/service_context_test.go
+++ b/internal/domain/project/service_context_test.go
@@ -71,10 +71,10 @@ func Test_contextPropagation(t *testing.T) {
 			s := project.NewActivityService(m)
 			s.List(ctx, "TEST") //nolint:errcheck
 		}},
-		{"CategoryService.All", func(t *testing.T, m *core.Method) {
+		{"CategoryService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewCategoryService(m)
-			s.All(ctx, "TEST") //nolint:errcheck
+			s.List(ctx, "TEST") //nolint:errcheck
 		}},
 		{"CategoryService.Create", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
@@ -91,10 +91,10 @@ func Test_contextPropagation(t *testing.T) {
 			s := project.NewCategoryService(m)
 			s.Delete(ctx, "TEST", 12) //nolint:errcheck
 		}},
-		{"CustomFieldService.All", func(t *testing.T, m *core.Method) {
+		{"CustomFieldService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewCustomFieldService(m)
-			s.All(ctx, "TEST") //nolint:errcheck
+			s.List(ctx, "TEST") //nolint:errcheck
 		}},
 		{"CustomFieldService.Create", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
@@ -126,10 +126,10 @@ func Test_contextPropagation(t *testing.T) {
 			s := project.NewCustomFieldService(m)
 			s.DeleteListItem(ctx, "TEST", 1, 10) //nolint:errcheck
 		}},
-		{"IssueTypeService.All", func(t *testing.T, m *core.Method) {
+		{"IssueTypeService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewIssueTypeService(m)
-			s.All(ctx, "TEST") //nolint:errcheck
+			s.List(ctx, "TEST") //nolint:errcheck
 		}},
 		{"IssueTypeService.Create", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
@@ -146,10 +146,10 @@ func Test_contextPropagation(t *testing.T) {
 			s := project.NewIssueTypeService(m)
 			s.Delete(ctx, "TEST", 1, 2) //nolint:errcheck
 		}},
-		{"StatusService.All", func(t *testing.T, m *core.Method) {
+		{"StatusService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewStatusService(m)
-			s.All(ctx, "TEST") //nolint:errcheck
+			s.List(ctx, "TEST") //nolint:errcheck
 		}},
 		{"StatusService.Create", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
@@ -181,10 +181,10 @@ func Test_contextPropagation(t *testing.T) {
 			s := project.NewSharedFileService(m)
 			s.Download(ctx, "TEST", 1) //nolint:errcheck
 		}},
-		{"UserService.All", func(t *testing.T, m *core.Method) {
+		{"UserService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewUserService(m)
-			s.All(ctx, "TEST", false) //nolint:errcheck
+			s.List(ctx, "TEST", false) //nolint:errcheck
 		}},
 		{"UserService.Add", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)
@@ -201,10 +201,10 @@ func Test_contextPropagation(t *testing.T) {
 			s := project.NewUserService(m)
 			s.AddAdmin(ctx, "TEST", 1) //nolint:errcheck
 		}},
-		{"UserService.AdminAll", func(t *testing.T, m *core.Method) {
+		{"UserService.AdminList", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewUserService(m)
-			s.AdminAll(ctx, "TEST") //nolint:errcheck
+			s.AdminList(ctx, "TEST") //nolint:errcheck
 		}},
 		{"UserService.DeleteAdmin", func(t *testing.T, m *core.Method) {
 			m.Delete = makeMockFn(t)

--- a/internal/domain/project/service_context_test.go
+++ b/internal/domain/project/service_context_test.go
@@ -176,10 +176,10 @@ func Test_contextPropagation(t *testing.T) {
 			s := project.NewSharedFileService(m)
 			s.List(ctx, "TEST") //nolint:errcheck
 		}},
-		{"SharedFileService.GetFile", func(t *testing.T, m *core.Method) {
+		{"SharedFileService.Download", func(t *testing.T, m *core.Method) {
 			m.Download = makeMockFn(t)
 			s := project.NewSharedFileService(m)
-			s.GetFile(ctx, "TEST", 1) //nolint:errcheck
+			s.Download(ctx, "TEST", 1) //nolint:errcheck
 		}},
 		{"UserService.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)

--- a/internal/domain/project/service_context_test.go
+++ b/internal/domain/project/service_context_test.go
@@ -181,10 +181,10 @@ func Test_contextPropagation(t *testing.T) {
 			s := project.NewSharedFileService(m)
 			s.GetFile(ctx, "TEST", 1) //nolint:errcheck
 		}},
-		{"UserService.List", func(t *testing.T, m *core.Method) {
+		{"UserService.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewUserService(m)
-			s.List(ctx, "TEST", false) //nolint:errcheck
+			s.All(ctx, "TEST", false) //nolint:errcheck
 		}},
 		{"UserService.Add", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)

--- a/internal/domain/project/service_context_test.go
+++ b/internal/domain/project/service_context_test.go
@@ -31,7 +31,7 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"Service.All", func(t *testing.T, m *core.Method) {
+		{"Service.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewService(m)
 			s.List(ctx) //nolint:errcheck
@@ -181,7 +181,7 @@ func Test_contextPropagation(t *testing.T) {
 			s := project.NewSharedFileService(m)
 			s.GetFile(ctx, "TEST", 1) //nolint:errcheck
 		}},
-		{"UserService.All", func(t *testing.T, m *core.Method) {
+		{"UserService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewUserService(m)
 			s.List(ctx, "TEST", false) //nolint:errcheck

--- a/internal/domain/project/service_context_test.go
+++ b/internal/domain/project/service_context_test.go
@@ -34,7 +34,7 @@ func Test_contextPropagation(t *testing.T) {
 		{"Service.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewService(m)
-			s.All(ctx) //nolint:errcheck
+			s.List(ctx) //nolint:errcheck
 		}},
 		{"Service.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
@@ -184,7 +184,7 @@ func Test_contextPropagation(t *testing.T) {
 		{"UserService.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewUserService(m)
-			s.All(ctx, "TEST", false) //nolint:errcheck
+			s.List(ctx, "TEST", false) //nolint:errcheck
 		}},
 		{"UserService.Add", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)

--- a/internal/domain/project/service_customfield.go
+++ b/internal/domain/project/service_customfield.go
@@ -16,10 +16,10 @@ type CustomFieldService struct {
 	method *core.Method
 }
 
-// All returns a list of custom fields in a project.
+// List returns a list of custom fields in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-custom-field-list
-func (s *CustomFieldService) All(ctx context.Context, projectIDOrKey string) ([]*model.CustomField, error) {
+func (s *CustomFieldService) List(ctx context.Context, projectIDOrKey string) ([]*model.CustomField, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/project/service_customfield_test.go
+++ b/internal/domain/project/service_customfield_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestCustomFieldService_All(t *testing.T) {
+func TestCustomFieldService_List(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 
@@ -83,7 +83,7 @@ func TestCustomFieldService_All(t *testing.T) {
 			}
 			s := project.NewCustomFieldService(method)
 
-			fields, err := s.All(context.Background(), tc.projectIDOrKey)
+			fields, err := s.List(context.Background(), tc.projectIDOrKey)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)

--- a/internal/domain/project/service_issuetype.go
+++ b/internal/domain/project/service_issuetype.go
@@ -16,10 +16,10 @@ type IssueTypeService struct {
 	method *core.Method
 }
 
-// All returns a list of issue types in a project.
+// List returns a list of issue types in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-type-list
-func (s *IssueTypeService) All(ctx context.Context, projectIDOrKey string) ([]*model.IssueType, error) {
+func (s *IssueTypeService) List(ctx context.Context, projectIDOrKey string) ([]*model.IssueType, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/project/service_issuetype_test.go
+++ b/internal/domain/project/service_issuetype_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestIssueTypeService_All(t *testing.T) {
+func TestIssueTypeService_List(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 
@@ -83,7 +83,7 @@ func TestIssueTypeService_All(t *testing.T) {
 			}
 			s := project.NewIssueTypeService(method)
 
-			issueTypes, err := s.All(context.Background(), tc.projectIDOrKey)
+			issueTypes, err := s.List(context.Background(), tc.projectIDOrKey)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)

--- a/internal/domain/project/service_sharedfile.go
+++ b/internal/domain/project/service_sharedfile.go
@@ -11,7 +11,7 @@ import (
 )
 
 // SharedFileService handles project shared-file-related Backlog API calls.
-// Kept separate from internal/sharedfile because GetFile is project-specific
+// Kept separate from internal/sharedfile because Download is project-specific
 // and does not fit the spath-agnostic pattern used by that package.
 type SharedFileService struct {
 	method *core.Method

--- a/internal/domain/project/service_sharedfile.go
+++ b/internal/domain/project/service_sharedfile.go
@@ -39,11 +39,11 @@ func (s *SharedFileService) List(ctx context.Context, projectIDOrKey string) ([]
 	return v, nil
 }
 
-// GetFile downloads a shared file from the project.
+// Download downloads a shared file from the project.
 // The caller is responsible for closing FileData.Body after use.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-file
-func (s *SharedFileService) GetFile(ctx context.Context, projectIDOrKey string, sharedFileID int) (*model.FileData, error) {
+func (s *SharedFileService) Download(ctx context.Context, projectIDOrKey string, sharedFileID int) (*model.FileData, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/project/service_sharedfile_test.go
+++ b/internal/domain/project/service_sharedfile_test.go
@@ -99,7 +99,7 @@ func TestSharedFileService_List(t *testing.T) {
 	}
 }
 
-func TestSharedFileService_GetFile(t *testing.T) {
+func TestSharedFileService_Download(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 		sharedFileID   int
@@ -167,7 +167,7 @@ func TestSharedFileService_GetFile(t *testing.T) {
 			}
 			s := project.NewSharedFileService(method)
 
-			got, err := s.GetFile(context.Background(), tc.projectIDOrKey, tc.sharedFileID)
+			got, err := s.Download(context.Background(), tc.projectIDOrKey, tc.sharedFileID)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)

--- a/internal/domain/project/service_status.go
+++ b/internal/domain/project/service_status.go
@@ -16,10 +16,10 @@ type StatusService struct {
 	method *core.Method
 }
 
-// All returns a list of statuses in a project.
+// List returns a list of statuses in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-status-list-of-project
-func (s *StatusService) All(ctx context.Context, projectIDOrKey string) ([]*model.Status, error) {
+func (s *StatusService) List(ctx context.Context, projectIDOrKey string) ([]*model.Status, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/project/service_status_test.go
+++ b/internal/domain/project/service_status_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestStatusService_All(t *testing.T) {
+func TestStatusService_List(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 
@@ -83,7 +83,7 @@ func TestStatusService_All(t *testing.T) {
 			}
 			s := project.NewStatusService(method)
 
-			statuses, err := s.All(context.Background(), tc.projectIDOrKey)
+			statuses, err := s.List(context.Background(), tc.projectIDOrKey)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)

--- a/internal/domain/project/service_test.go
+++ b/internal/domain/project/service_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestService_All(t *testing.T) {
+func TestService_List(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {

--- a/internal/domain/project/service_test.go
+++ b/internal/domain/project/service_test.go
@@ -101,7 +101,7 @@ func TestService_All(t *testing.T) {
 			}
 			s := project.NewService(method)
 
-			projects, err := s.All(context.Background(), tc.opts...)
+			projects, err := s.List(context.Background(), tc.opts...)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)

--- a/internal/domain/project/service_user.go
+++ b/internal/domain/project/service_user.go
@@ -67,10 +67,10 @@ type UserService struct {
 	method *core.Method
 }
 
-// All returns a list of users in the project.
+// List returns a list of users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-user-list
-func (s *UserService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*model.User, error) {
+func (s *UserService) List(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/project/service_user.go
+++ b/internal/domain/project/service_user.go
@@ -67,10 +67,10 @@ type UserService struct {
 	method *core.Method
 }
 
-// List returns a list of users in the project.
+// All returns a list of users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-user-list
-func (s *UserService) List(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*model.User, error) {
+func (s *UserService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/project/service_user.go
+++ b/internal/domain/project/service_user.go
@@ -67,10 +67,10 @@ type UserService struct {
 	method *core.Method
 }
 
-// All returns a list of users in the project.
+// List returns a list of users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-user-list
-func (s *UserService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*model.User, error) {
+func (s *UserService) List(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -130,10 +130,10 @@ func (s *UserService) AddAdmin(ctx context.Context, projectIDOrKey string, userI
 	return addUser(ctx, s.method, spath, userID)
 }
 
-// AdminAll returns a list of project administrators.
+// AdminList returns a list of project administrators.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-project-administrators
-func (s *UserService) AdminAll(ctx context.Context, projectIDOrKey string) ([]*model.User, error) {
+func (s *UserService) AdminList(ctx context.Context, projectIDOrKey string) ([]*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/project/service_user_test.go
+++ b/internal/domain/project/service_user_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestProjectUserService_All(t *testing.T) {
+func TestProjectUserService_List(t *testing.T) {
 	cases := map[string]struct {
 		projectKey          string
 		excludeGroupMembers bool
@@ -84,7 +84,7 @@ func TestProjectUserService_All(t *testing.T) {
 			}
 			s := project.NewUserService(method)
 
-			users, err := s.All(context.Background(), tc.projectKey, tc.excludeGroupMembers)
+			users, err := s.List(context.Background(), tc.projectKey, tc.excludeGroupMembers)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -364,7 +364,7 @@ func TestProjectUserService_AddAdmin(t *testing.T) {
 	}
 }
 
-func TestProjectUserService_AdminAll(t *testing.T) {
+func TestProjectUserService_AdminList(t *testing.T) {
 	cases := map[string]struct {
 		projectKey string
 
@@ -400,7 +400,7 @@ func TestProjectUserService_AdminAll(t *testing.T) {
 			}
 			s := project.NewUserService(method)
 
-			users, err := s.AdminAll(context.Background(), tc.projectKey)
+			users, err := s.AdminList(context.Background(), tc.projectKey)
 
 			assert.Error(t, err)
 			assert.IsType(t, tc.wantErrType, err)

--- a/internal/domain/project/service_user_test.go
+++ b/internal/domain/project/service_user_test.go
@@ -84,7 +84,7 @@ func TestProjectUserService_All(t *testing.T) {
 			}
 			s := project.NewUserService(method)
 
-			users, err := s.All(context.Background(), tc.projectKey, tc.excludeGroupMembers)
+			users, err := s.List(context.Background(), tc.projectKey, tc.excludeGroupMembers)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)

--- a/internal/domain/project/service_user_test.go
+++ b/internal/domain/project/service_user_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestProjectUserService_List(t *testing.T) {
+func TestProjectUserService_All(t *testing.T) {
 	cases := map[string]struct {
 		projectKey          string
 		excludeGroupMembers bool
@@ -84,7 +84,7 @@ func TestProjectUserService_List(t *testing.T) {
 			}
 			s := project.NewUserService(method)
 
-			users, err := s.List(context.Background(), tc.projectKey, tc.excludeGroupMembers)
+			users, err := s.All(context.Background(), tc.projectKey, tc.excludeGroupMembers)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)

--- a/internal/domain/project/service_user_test.go
+++ b/internal/domain/project/service_user_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestProjectUserService_All(t *testing.T) {
+func TestProjectUserService_List(t *testing.T) {
 	cases := map[string]struct {
 		projectKey          string
 		excludeGroupMembers bool

--- a/internal/domain/project/service_version.go
+++ b/internal/domain/project/service_version.go
@@ -17,10 +17,10 @@ type VersionService struct {
 	method *core.Method
 }
 
-// All returns versions/milestones in a project.
+// List returns versions/milestones in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-version-milestone-list
-func (s *VersionService) All(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Version, error) {
+func (s *VersionService) List(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Version, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/project/service_version_test.go
+++ b/internal/domain/project/service_version_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestVersionService_All(t *testing.T) {
+func TestVersionService_List(t *testing.T) {
 	option := &core.OptionService{}
 
 	cases := map[string]struct {

--- a/internal/domain/project/service_version_test.go
+++ b/internal/domain/project/service_version_test.go
@@ -72,7 +72,7 @@ func TestVersionService_All(t *testing.T) {
 			m := mock.NewMethod(t)
 			m.Get = tc.mockGetFn
 			s := project.NewVersionService(m)
-			got, err := s.All(context.Background(), tc.projectIDOrKey, tc.opts...)
+			got, err := s.List(context.Background(), tc.projectIDOrKey, tc.opts...)
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
 				assert.Nil(t, got)

--- a/internal/domain/project/service_webhook.go
+++ b/internal/domain/project/service_webhook.go
@@ -89,10 +89,10 @@ func (s *WebhookService) Add(ctx context.Context, projectIDOrKey, name, hookURL 
 	return v, nil
 }
 
-// Get returns a single webhook.
+// One returns a single webhook.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-webhook/
-func (s *WebhookService) Get(ctx context.Context, projectIDOrKey string, webhookID int) (*model.Webhook, error) {
+func (s *WebhookService) One(ctx context.Context, projectIDOrKey string, webhookID int) (*model.Webhook, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/project/service_webhook_test.go
+++ b/internal/domain/project/service_webhook_test.go
@@ -241,7 +241,7 @@ func TestWebhookService_Add(t *testing.T) {
 	}
 }
 
-func TestWebhookService_Get(t *testing.T) {
+func TestWebhookService_One(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 		webhookID      int
@@ -305,7 +305,7 @@ func TestWebhookService_Get(t *testing.T) {
 			method.Get = tc.mockGetFn
 			s := project.NewWebhookService(method)
 
-			got, err := s.Get(context.Background(), tc.projectIDOrKey, tc.webhookID)
+			got, err := s.One(context.Background(), tc.projectIDOrKey, tc.webhookID)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)

--- a/internal/domain/pullrequest/service.go
+++ b/internal/domain/pullrequest/service.go
@@ -17,10 +17,10 @@ type Service struct {
 	method *core.Method
 }
 
-// All returns a list of pull requests.
+// List returns a list of pull requests.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
-func (s *Service) All(ctx context.Context, projectIDOrKey string, repoIDOrName string, opts ...core.RequestOption) ([]*model.PullRequest, error) {
+func (s *Service) List(ctx context.Context, projectIDOrKey string, repoIDOrName string, opts ...core.RequestOption) ([]*model.PullRequest, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/pullrequest/service_comment.go
+++ b/internal/domain/pullrequest/service_comment.go
@@ -18,10 +18,10 @@ type CommentService struct {
 	base *comment.Service
 }
 
-// All returns a list of comments on a pull request.
+// List returns a list of comments on a pull request.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-comment
-func (s *CommentService) All(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, opts ...core.RequestOption) ([]*model.Comment, error) {
+func (s *CommentService) List(ctx context.Context, projectIDOrKey string, repoIDOrName string, prNumber int, opts ...core.RequestOption) ([]*model.Comment, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func (s *CommentService) All(ctx context.Context, projectIDOrKey string, repoIDO
 	}
 
 	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests", strconv.Itoa(prNumber), "comments")
-	return s.base.All(ctx, spath, opts...)
+	return s.base.List(ctx, spath, opts...)
 }
 
 // Add adds a comment to a pull request.

--- a/internal/domain/pullrequest/service_comment_test.go
+++ b/internal/domain/pullrequest/service_comment_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestCommentService_All(t *testing.T) {
+func TestCommentService_List(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {

--- a/internal/domain/pullrequest/service_comment_test.go
+++ b/internal/domain/pullrequest/service_comment_test.go
@@ -141,7 +141,7 @@ func TestCommentService_All(t *testing.T) {
 
 			s := pullrequest.NewCommentService(method)
 
-			got, err := s.All(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.prNumber, tc.opts...)
+			got, err := s.List(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.prNumber, tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)

--- a/internal/domain/pullrequest/service_test.go
+++ b/internal/domain/pullrequest/service_test.go
@@ -140,7 +140,7 @@ func TestPullRequestService_All(t *testing.T) {
 			}
 
 			s := pullrequest.NewService(method)
-			prs, err := s.All(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.opts...)
+			prs, err := s.List(context.Background(), tc.projectIDOrKey, tc.repoIDOrName, tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -661,7 +661,7 @@ func Test_contextPropagation(t *testing.T) {
 		{"Service.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := pullrequest.NewService(m)
-			s.All(ctx, testProject, testRepo) //nolint:errcheck
+			s.List(ctx, testProject, testRepo) //nolint:errcheck
 		}},
 		{"Service.Count", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
@@ -701,7 +701,7 @@ func Test_contextPropagation(t *testing.T) {
 		{"CommentService.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := pullrequest.NewCommentService(m)
-			s.All(ctx, "PRJ-1", "REPO-1", 1) //nolint:errcheck
+			s.List(ctx, "PRJ-1", "REPO-1", 1) //nolint:errcheck
 		}},
 		{"CommentService.Add", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)

--- a/internal/domain/pullrequest/service_test.go
+++ b/internal/domain/pullrequest/service_test.go
@@ -22,7 +22,7 @@ const (
 	testRepo    = "repo1"
 )
 
-func TestPullRequestService_All(t *testing.T) {
+func TestPullRequestService_List(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -658,7 +658,7 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"Service.All", func(t *testing.T, m *core.Method) {
+		{"Service.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := pullrequest.NewService(m)
 			s.List(ctx, testProject, testRepo) //nolint:errcheck
@@ -698,7 +698,7 @@ func Test_contextPropagation(t *testing.T) {
 			s := pullrequest.NewAttachmentService(m)
 			s.Download(ctx, "TEST", "repo", 1, 1) //nolint:errcheck
 		}},
-		{"CommentService.All", func(t *testing.T, m *core.Method) {
+		{"CommentService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := pullrequest.NewCommentService(m)
 			s.List(ctx, "PRJ-1", "REPO-1", 1) //nolint:errcheck

--- a/internal/domain/repository/service.go
+++ b/internal/domain/repository/service.go
@@ -16,10 +16,10 @@ type Service struct {
 	method *core.Method
 }
 
-// All returns a list of Git repositories in a project.
+// List returns a list of Git repositories in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-git-repositories
-func (s *Service) All(ctx context.Context, projectIDOrKey string) ([]*model.Repository, error) {
+func (s *Service) List(ctx context.Context, projectIDOrKey string) ([]*model.Repository, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/repository/service_test.go
+++ b/internal/domain/repository/service_test.go
@@ -22,7 +22,7 @@ const (
 	testRepo    = "repo1"
 )
 
-func TestRepositoryService_All(t *testing.T) {
+func TestRepositoryService_List(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 
@@ -73,7 +73,7 @@ func TestRepositoryService_All(t *testing.T) {
 			}
 
 			s := repository.NewService(method)
-			got, err := s.All(context.Background(), tc.projectIDOrKey)
+			got, err := s.List(context.Background(), tc.projectIDOrKey)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -194,10 +194,10 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"RepositoryService.All", func(t *testing.T, m *core.Method) {
+		{"RepositoryService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := repository.NewService(m)
-			s.All(ctx, testProject) //nolint:errcheck
+			s.List(ctx, testProject) //nolint:errcheck
 		}},
 		{"RepositoryService.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)

--- a/internal/domain/space/service.go
+++ b/internal/domain/space/service.go
@@ -14,10 +14,10 @@ type Service struct {
 	method *core.Method
 }
 
-// One returns information about your space.
+// Info returns information about your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-space
-func (s *Service) One(ctx context.Context) (*model.Space, error) {
+func (s *Service) Info(ctx context.Context) (*model.Space, error) {
 	resp, err := s.method.Get(ctx, "space", nil)
 	if err != nil {
 		return nil, err

--- a/internal/domain/space/service_activity.go
+++ b/internal/domain/space/service_activity.go
@@ -25,10 +25,10 @@ func (s *ActivityService) List(ctx context.Context, opts ...core.RequestOption) 
 	return s.base.List(ctx, "space/activities", opts...)
 }
 
-// Get returns a single activity by its ID.
+// One returns a single activity by its ID.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-activity
-func (s *ActivityService) Get(ctx context.Context, activityID int) (*model.Activity, error) {
+func (s *ActivityService) One(ctx context.Context, activityID int) (*model.Activity, error) {
 	if err := validate.ValidateActivityID(activityID); err != nil {
 		return nil, err
 	}

--- a/internal/domain/space/service_activity_test.go
+++ b/internal/domain/space/service_activity_test.go
@@ -192,7 +192,7 @@ func TestActivityService_List(t *testing.T) {
 	}
 }
 
-func TestActivityService_Get(t *testing.T) {
+func TestActivityService_One(t *testing.T) {
 	type want struct {
 		spath string
 	}
@@ -250,7 +250,7 @@ func TestActivityService_Get(t *testing.T) {
 			}
 			s := space.NewActivityService(method)
 
-			if resp, err := s.Get(context.Background(), tc.activityID); tc.wantError {
+			if resp, err := s.One(context.Background(), tc.activityID); tc.wantError {
 				require.Error(t, err)
 				assert.Nil(t, resp)
 			} else {

--- a/internal/domain/space/service_test.go
+++ b/internal/domain/space/service_test.go
@@ -317,10 +317,10 @@ func Test_contextPropagation(t *testing.T) {
 			s := space.NewActivityService(m)
 			s.List(ctx) //nolint:errcheck
 		}},
-		{"ActivityService.Get", func(t *testing.T, m *core.Method) {
+		{"ActivityService.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := space.NewActivityService(m)
-			s.Get(ctx, 1) //nolint:errcheck
+			s.One(ctx, 1) //nolint:errcheck
 		}},
 		{"AttachmentService.Upload", func(t *testing.T, m *core.Method) {
 			m.Upload = makeMockUploadFn(t)

--- a/internal/domain/space/service_test.go
+++ b/internal/domain/space/service_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestSpaceService_One(t *testing.T) {
+func TestSpaceService_Info(t *testing.T) {
 	cases := map[string]struct {
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
@@ -62,7 +62,7 @@ func TestSpaceService_One(t *testing.T) {
 
 			s := space.NewService(method)
 
-			got, err := s.One(context.Background())
+			got, err := s.Info(context.Background())
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -292,10 +292,10 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"Service.One", func(t *testing.T, m *core.Method) {
+		{"Service.Info", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := space.NewService(m)
-			s.One(ctx) //nolint:errcheck
+			s.Info(ctx) //nolint:errcheck
 		}},
 		{"Service.DiskUsage", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)

--- a/internal/domain/user/service.go
+++ b/internal/domain/user/service.go
@@ -60,10 +60,10 @@ func (s *Service) One(ctx context.Context, id int) (*model.User, error) {
 	return getUser(ctx, s.method, spath)
 }
 
-// Own returns the currently authenticated user.
+// Me returns the currently authenticated user.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-own-user
-func (s *Service) Own(ctx context.Context) (*model.User, error) {
+func (s *Service) Me(ctx context.Context) (*model.User, error) {
 	return getUser(ctx, s.method, "users/myself")
 }
 

--- a/internal/domain/user/service.go
+++ b/internal/domain/user/service.go
@@ -31,10 +31,10 @@ type Service struct {
 	method *core.Method
 }
 
-// All returns a list of all users in the space.
+// List returns a list of all users in the space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-list
-func (s *Service) All(ctx context.Context) ([]*model.User, error) {
+func (s *Service) List(ctx context.Context) ([]*model.User, error) {
 	resp, err := s.method.Get(ctx, "users", nil)
 	if err != nil {
 		return nil, err

--- a/internal/domain/user/service_test.go
+++ b/internal/domain/user/service_test.go
@@ -227,7 +227,7 @@ func TestUserService_Add(t *testing.T) {
 	}
 }
 
-func TestUserService_All(t *testing.T) {
+func TestUserService_List(t *testing.T) {
 	cases := map[string]struct {
 		mockGetFn   func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 		wantLen     int
@@ -269,7 +269,7 @@ func TestUserService_All(t *testing.T) {
 			}
 			s := user.NewService(method)
 
-			users, err := s.All(context.Background())
+			users, err := s.List(context.Background())
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -652,10 +652,10 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"Service.All", func(t *testing.T, m *core.Method) {
+		{"Service.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := user.NewService(m)
-			s.All(ctx) //nolint:errcheck
+			s.List(ctx) //nolint:errcheck
 		}},
 		{"Service.One", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)

--- a/internal/domain/user/service_test.go
+++ b/internal/domain/user/service_test.go
@@ -438,7 +438,7 @@ func TestUserService_Update(t *testing.T) {
 	}
 }
 
-func TestUserService_Own(t *testing.T) {
+func TestUserService_Me(t *testing.T) {
 	cases := map[string]struct {
 		mockGetFn   func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 		wantErrType error
@@ -478,7 +478,7 @@ func TestUserService_Own(t *testing.T) {
 			}
 			s := user.NewService(method)
 
-			user, err := s.Own(context.Background())
+			user, err := s.Me(context.Background())
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -662,10 +662,10 @@ func Test_contextPropagation(t *testing.T) {
 			s := user.NewService(m)
 			s.One(ctx, 1) //nolint:errcheck
 		}},
-		{"Service.Own", func(t *testing.T, m *core.Method) {
+		{"Service.Me", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := user.NewService(m)
-			s.Own(ctx) //nolint:errcheck
+			s.Me(ctx) //nolint:errcheck
 		}},
 		{"Service.Add", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)

--- a/internal/domain/wiki/service.go
+++ b/internal/domain/wiki/service.go
@@ -16,10 +16,10 @@ type Service struct {
 	method *core.Method
 }
 
-// All returns a list of wiki pages in the project.
+// List returns a list of wiki pages in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-list
-func (s *Service) All(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Wiki, error) {
+func (s *Service) List(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.Wiki, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}

--- a/internal/domain/wiki/service_test.go
+++ b/internal/domain/wiki/service_test.go
@@ -105,7 +105,7 @@ func TestWikiService_All(t *testing.T) {
 
 			s := wiki.NewService(method)
 
-			wikis, err := s.All(context.Background(), tc.projectIDOrKey, tc.opts...)
+			wikis, err := s.List(context.Background(), tc.projectIDOrKey, tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)
@@ -680,7 +680,7 @@ func Test_contextPropagation(t *testing.T) {
 		{"Service.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := wiki.NewService(m)
-			s.All(ctx, "TEST") //nolint:errcheck
+			s.List(ctx, "TEST") //nolint:errcheck
 		}},
 		{"Service.Count", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)

--- a/internal/domain/wiki/service_test.go
+++ b/internal/domain/wiki/service_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestWikiService_All(t *testing.T) {
+func TestWikiService_List(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -677,7 +677,7 @@ func Test_contextPropagation(t *testing.T) {
 		name string
 		call func(t *testing.T, m *core.Method)
 	}{
-		{"Service.All", func(t *testing.T, m *core.Method) {
+		{"Service.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := wiki.NewService(m)
 			s.List(ctx, "TEST") //nolint:errcheck

--- a/internal/shared/comment/service.go
+++ b/internal/shared/comment/service.go
@@ -16,7 +16,7 @@ type Service struct {
 	method *core.Method
 }
 
-func (s *Service) All(ctx context.Context, spath string, opts ...core.RequestOption) ([]*model.Comment, error) {
+func (s *Service) List(ctx context.Context, spath string, opts ...core.RequestOption) ([]*model.Comment, error) {
 	query := url.Values{}
 	validTypes := []core.APIParamOptionType{
 		core.ParamMinID,

--- a/issue.go
+++ b/issue.go
@@ -80,7 +80,7 @@ type IssueService struct {
 	Option *IssueOptionService
 }
 
-// All returns a list of issues.
+// List returns a list of issues.
 //
 // This method supports options returned by methods in "*Client.Issue.Option",
 // such as:
@@ -115,8 +115,8 @@ type IssueService struct {
 //   - WithKeyword
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-list
-func (s *IssueService) All(ctx context.Context, opts ...RequestOption) ([]*Issue, error) {
-	v, err := s.base.All(ctx, toCoreOptions(opts)...)
+func (s *IssueService) List(ctx context.Context, opts ...RequestOption) ([]*Issue, error) {
+	v, err := s.base.List(ctx, toCoreOptions(opts)...)
 	return issuesFromModel(v), convertError(err)
 }
 

--- a/issue_comment.go
+++ b/issue_comment.go
@@ -13,7 +13,7 @@ type IssueCommentService struct {
 	Option *IssueCommentOptionService
 }
 
-// All returns a list of comments on an issue.
+// List returns a list of comments on an issue.
 //
 // This method supports options returned by methods in "*Client.Issue.Comment.Option",
 // such as:
@@ -23,8 +23,8 @@ type IssueCommentService struct {
 //   - WithOrder
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-comment-list
-func (s *IssueCommentService) All(ctx context.Context, issueIDOrKey string, opts ...RequestOption) ([]*Comment, error) {
-	v, err := s.base.All(ctx, issueIDOrKey, toCoreOptions(opts)...)
+func (s *IssueCommentService) List(ctx context.Context, issueIDOrKey string, opts ...RequestOption) ([]*Comment, error) {
+	v, err := s.base.List(ctx, issueIDOrKey, toCoreOptions(opts)...)
 	return commentsFromModel(v), convertError(err)
 }
 

--- a/issue_comment_test.go
+++ b/issue_comment_test.go
@@ -29,7 +29,7 @@ func TestIssueCommentService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Issue.Comment.All(ctx, "PRJ-1")
+				got, err := c.Issue.Comment.List(ctx, "PRJ-1")
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, 1, got[0].ID)
@@ -45,7 +45,7 @@ func TestIssueCommentService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Issue.Comment.All(ctx, "PRJ-1",
+				got, err := c.Issue.Comment.List(ctx, "PRJ-1",
 					c.Issue.Comment.Option.WithCount(20),
 					c.Issue.Comment.Option.WithOrder(backlog.OrderAsc),
 				)
@@ -56,7 +56,7 @@ func TestIssueCommentService(t *testing.T) {
 		"All/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Issue.Comment.All(ctx, "PRJ-1")
+				_, err := c.Issue.Comment.List(ctx, "PRJ-1")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/issue_comment_test.go
+++ b/issue_comment_test.go
@@ -22,7 +22,7 @@ func TestIssueCommentService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/PRJ-1/comments", req.URL.Path)
@@ -36,7 +36,7 @@ func TestIssueCommentService(t *testing.T) {
 				assert.Equal(t, 2, got[1].ID)
 			},
 		},
-		"All/with-options": {
+		"List/with-options": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues/PRJ-1/comments", req.URL.Path)

--- a/issue_comment_test.go
+++ b/issue_comment_test.go
@@ -53,7 +53,7 @@ func TestIssueCommentService(t *testing.T) {
 				assert.Len(t, got, 2)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.Comment.List(ctx, "PRJ-1")

--- a/issue_test.go
+++ b/issue_test.go
@@ -23,7 +23,7 @@ func TestIssueService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues", req.URL.Path)
@@ -37,7 +37,7 @@ func TestIssueService(t *testing.T) {
 				assert.Equal(t, 2, got[1].ID)
 			},
 		},
-		"All/with-options": {
+		"List/with-options": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/issues", req.URL.Path)

--- a/issue_test.go
+++ b/issue_test.go
@@ -30,7 +30,7 @@ func TestIssueService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Issue.All(ctx)
+				got, err := c.Issue.List(ctx)
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, 1, got[0].ID)
@@ -46,7 +46,7 @@ func TestIssueService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Issue.All(ctx,
+				got, err := c.Issue.List(ctx,
 					c.Issue.Option.WithKeyword("bug"),
 					c.Issue.Option.WithProjectIDs([]int{10, 20}),
 				)
@@ -57,7 +57,7 @@ func TestIssueService(t *testing.T) {
 		"All/error": {
 			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Issue.All(ctx)
+				_, err := c.Issue.List(ctx)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/issue_test.go
+++ b/issue_test.go
@@ -54,7 +54,7 @@ func TestIssueService(t *testing.T) {
 				assert.Len(t, got, 2)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.List(ctx)

--- a/project.go
+++ b/project.go
@@ -54,7 +54,7 @@ type ProjectService struct {
 	Option *ProjectOptionService
 }
 
-// All returns a list of projects.
+// List returns a list of projects.
 //
 // This method supports options returned by methods in "*Client.Project.Option",
 // such as:
@@ -62,8 +62,8 @@ type ProjectService struct {
 //   - WithQueryArchived
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-list
-func (s *ProjectService) All(ctx context.Context, opts ...RequestOption) ([]*Project, error) {
-	v, err := s.base.All(ctx, toCoreOptions(opts)...)
+func (s *ProjectService) List(ctx context.Context, opts ...RequestOption) ([]*Project, error) {
+	v, err := s.base.List(ctx, toCoreOptions(opts)...)
 	return projectsFromModel(v), convertError(err)
 }
 

--- a/project_customfield.go
+++ b/project_customfield.go
@@ -18,11 +18,11 @@ type ProjectCustomFieldService struct {
 	Option *ProjectCustomFieldOptionService
 }
 
-// All returns a list of custom fields in a project.
+// List returns a list of custom fields in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-custom-field-list
-func (s *ProjectCustomFieldService) All(ctx context.Context, projectIDOrKey string) ([]*CustomField, error) {
-	v, err := s.base.All(ctx, projectIDOrKey)
+func (s *ProjectCustomFieldService) List(ctx context.Context, projectIDOrKey string) ([]*CustomField, error) {
+	v, err := s.base.List(ctx, projectIDOrKey)
 	return customFieldsFromModel(v), convertError(err)
 }
 

--- a/project_customfield_test.go
+++ b/project_customfield_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestProjectCustomFieldService_All(t *testing.T) {
+func TestProjectCustomFieldService_List(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 		doFunc         func(*http.Request) (*http.Response, error)
@@ -59,7 +59,7 @@ func TestProjectCustomFieldService_All(t *testing.T) {
 			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
 			require.NoError(t, err)
 
-			fields, err := c.Project.CustomField.All(context.Background(), tc.projectIDOrKey)
+			fields, err := c.Project.CustomField.List(context.Background(), tc.projectIDOrKey)
 
 			if tc.wantErrType != nil {
 				require.Error(t, err)

--- a/project_events.go
+++ b/project_events.go
@@ -59,10 +59,10 @@ type ProjectWebhookService struct {
 	Option *ProjectWebhookOptionService
 }
 
-// All returns a list of webhooks in the project.
+// List returns a list of webhooks in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-webhooks
-func (s *ProjectWebhookService) All(ctx context.Context, projectIDOrKey string) ([]*Webhook, error) {
+func (s *ProjectWebhookService) List(ctx context.Context, projectIDOrKey string) ([]*Webhook, error) {
 	v, err := s.base.List(ctx, projectIDOrKey)
 	return webhooksFromModel(v), convertError(err)
 }

--- a/project_events.go
+++ b/project_events.go
@@ -85,7 +85,7 @@ func (s *ProjectWebhookService) Create(ctx context.Context, projectIDOrKey, name
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-webhook
 func (s *ProjectWebhookService) One(ctx context.Context, projectIDOrKey string, webhookID int) (*Webhook, error) {
-	v, err := s.base.Get(ctx, projectIDOrKey, webhookID)
+	v, err := s.base.One(ctx, projectIDOrKey, webhookID)
 	return webhookFromModel(v), convertError(err)
 }
 

--- a/project_events_test.go
+++ b/project_events_test.go
@@ -64,23 +64,23 @@ func TestProjectWebhookService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/webhooks", req.URL.Path)
 				return mock.NewJSONResponse(fixture.Webhook.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.Webhook.All(ctx, "TEST")
+				got, err := c.Project.Webhook.List(ctx, "TEST")
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, 1, got[0].ID)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.Webhook.All(ctx, "TEST")
+				_, err := c.Project.Webhook.List(ctx, "TEST")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/project_issuetype.go
+++ b/project_issuetype.go
@@ -18,11 +18,11 @@ type ProjectIssueTypeService struct {
 	Option *ProjectIssueTypeOptionService
 }
 
-// All returns a list of issue types in a project.
+// List returns a list of issue types in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-type-list
-func (s *ProjectIssueTypeService) All(ctx context.Context, projectIDOrKey string) ([]*IssueType, error) {
-	v, err := s.base.All(ctx, projectIDOrKey)
+func (s *ProjectIssueTypeService) List(ctx context.Context, projectIDOrKey string) ([]*IssueType, error) {
+	v, err := s.base.List(ctx, projectIDOrKey)
 	return issueTypesFromModel(v), convertError(err)
 }
 

--- a/project_issuetype_test.go
+++ b/project_issuetype_test.go
@@ -21,14 +21,14 @@ func TestProjectIssueTypeService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/issueTypes", req.URL.Path)
 				return mock.NewJSONResponse(fixture.IssueType.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.IssueType.All(ctx, "TEST")
+				got, err := c.Project.IssueType.List(ctx, "TEST")
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, 1, got[0].ID)
@@ -36,10 +36,10 @@ func TestProjectIssueTypeService(t *testing.T) {
 				assert.Equal(t, "#e30000", got[0].Color)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.IssueType.All(ctx, "TEST")
+				_, err := c.Project.IssueType.List(ctx, "TEST")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/project_process.go
+++ b/project_process.go
@@ -72,15 +72,15 @@ type ProjectVersionService struct {
 	Option *ProjectVersionOptionService
 }
 
-// All returns a list of versions/milestones in the project.
+// List returns a list of versions/milestones in the project.
 //
 // This method supports options returned by methods in "*Client.Project.Version.Option",
 // such as:
 //   - WithArchived
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-version-milestone-list/
-func (s *ProjectVersionService) All(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*Version, error) {
-	v, err := s.base.All(ctx, projectIDOrKey, toCoreOptions(opts)...)
+func (s *ProjectVersionService) List(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*Version, error) {
+	v, err := s.base.List(ctx, projectIDOrKey, toCoreOptions(opts)...)
 	return versionsFromModel(v), convertError(err)
 }
 

--- a/project_process.go
+++ b/project_process.go
@@ -17,11 +17,11 @@ type ProjectStatusService struct {
 	Option *ProjectStatusOptionService
 }
 
-// All returns a list of statuses in a project.
+// List returns a list of statuses in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-status-list-of-project
-func (s *ProjectStatusService) All(ctx context.Context, projectIDOrKey string) ([]*Status, error) {
-	v, err := s.base.All(ctx, projectIDOrKey)
+func (s *ProjectStatusService) List(ctx context.Context, projectIDOrKey string) ([]*Status, error) {
+	v, err := s.base.List(ctx, projectIDOrKey)
 	return statusesFromModel(v), convertError(err)
 }
 

--- a/project_process_test.go
+++ b/project_process_test.go
@@ -24,7 +24,7 @@ func TestProjectVersionService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/versions", req.URL.Path)
@@ -37,7 +37,7 @@ func TestProjectVersionService(t *testing.T) {
 				assert.Equal(t, fixture.Version.Single.ID, got[0].ID)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.Version.List(ctx, "TEST")

--- a/project_process_test.go
+++ b/project_process_test.go
@@ -31,7 +31,7 @@ func TestProjectVersionService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Version.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.Version.All(ctx, "TEST")
+				got, err := c.Project.Version.List(ctx, "TEST")
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, fixture.Version.Single.ID, got[0].ID)
@@ -40,7 +40,7 @@ func TestProjectVersionService(t *testing.T) {
 		"All/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.Version.All(ctx, "TEST")
+				_, err := c.Project.Version.List(ctx, "TEST")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/project_process_test.go
+++ b/project_process_test.go
@@ -154,14 +154,14 @@ func TestProjectStatusService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/statuses", req.URL.Path)
 				return mock.NewJSONResponse(fixture.Status.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.Status.All(ctx, "TEST")
+				got, err := c.Project.Status.List(ctx, "TEST")
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, fixture.Status.Single.ID, got[0].ID)
@@ -169,10 +169,10 @@ func TestProjectStatusService(t *testing.T) {
 				assert.Equal(t, fixture.Status.Single.Color, got[0].Color)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.Status.All(ctx, "TEST")
+				_, err := c.Project.Status.List(ctx, "TEST")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/project_structure.go
+++ b/project_structure.go
@@ -65,12 +65,12 @@ func (s *ProjectSharedFileService) List(ctx context.Context, projectIDOrKey stri
 	return sharedFilesFromModel(v), convertError(err)
 }
 
-// GetFile downloads a shared file from the project.
+// Download downloads a shared file from the project.
 // The caller is responsible for closing FileData.Body after use.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-file
-func (s *ProjectSharedFileService) GetFile(ctx context.Context, projectIDOrKey string, sharedFileID int) (*FileData, error) {
-	v, err := s.base.GetFile(ctx, projectIDOrKey, sharedFileID)
+func (s *ProjectSharedFileService) Download(ctx context.Context, projectIDOrKey string, sharedFileID int) (*FileData, error) {
+	v, err := s.base.Download(ctx, projectIDOrKey, sharedFileID)
 	return fileDataFromModel(v), convertError(err)
 }
 

--- a/project_structure.go
+++ b/project_structure.go
@@ -83,11 +83,11 @@ type ProjectUserService struct {
 	base *project.UserService
 }
 
-// All returns all users in the project.
+// List returns all users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-user-list
-func (s *ProjectUserService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*User, error) {
-	v, err := s.base.All(ctx, projectIDOrKey, excludeGroupMembers)
+func (s *ProjectUserService) List(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*User, error) {
+	v, err := s.base.List(ctx, projectIDOrKey, excludeGroupMembers)
 	return usersFromModel(v), convertError(err)
 }
 

--- a/project_structure.go
+++ b/project_structure.go
@@ -16,11 +16,11 @@ type ProjectCategoryService struct {
 	base *project.CategoryService
 }
 
-// All returns a list of categories in a project.
+// List returns a list of categories in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-category-list
-func (s *ProjectCategoryService) All(ctx context.Context, projectIDOrKey string) ([]*Category, error) {
-	v, err := s.base.All(ctx, projectIDOrKey)
+func (s *ProjectCategoryService) List(ctx context.Context, projectIDOrKey string) ([]*Category, error) {
+	v, err := s.base.List(ctx, projectIDOrKey)
 	return categoriesFromModel(v), convertError(err)
 }
 
@@ -83,11 +83,11 @@ type ProjectUserService struct {
 	base *project.UserService
 }
 
-// All returns all users in the project.
+// List returns all users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-user-list
-func (s *ProjectUserService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*User, error) {
-	v, err := s.base.All(ctx, projectIDOrKey, excludeGroupMembers)
+func (s *ProjectUserService) List(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*User, error) {
+	v, err := s.base.List(ctx, projectIDOrKey, excludeGroupMembers)
 	return usersFromModel(v), convertError(err)
 }
 
@@ -115,11 +115,11 @@ func (s *ProjectUserService) AddAdmin(ctx context.Context, projectIDOrKey string
 	return userFromModel(v), convertError(err)
 }
 
-// AdminAll returns a list of all admin users in the project.
+// AdminList returns a list of all admin users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-project-administrators
-func (s *ProjectUserService) AdminAll(ctx context.Context, projectIDOrKey string) ([]*User, error) {
-	v, err := s.base.AdminAll(ctx, projectIDOrKey)
+func (s *ProjectUserService) AdminList(ctx context.Context, projectIDOrKey string) ([]*User, error) {
+	v, err := s.base.AdminList(ctx, projectIDOrKey)
 	return usersFromModel(v), convertError(err)
 }
 

--- a/project_structure.go
+++ b/project_structure.go
@@ -83,11 +83,11 @@ type ProjectUserService struct {
 	base *project.UserService
 }
 
-// List returns all users in the project.
+// All returns all users in the project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-user-list
-func (s *ProjectUserService) List(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*User, error) {
-	v, err := s.base.List(ctx, projectIDOrKey, excludeGroupMembers)
+func (s *ProjectUserService) All(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*User, error) {
+	v, err := s.base.All(ctx, projectIDOrKey, excludeGroupMembers)
 	return usersFromModel(v), convertError(err)
 }
 

--- a/project_structure_test.go
+++ b/project_structure_test.go
@@ -156,7 +156,7 @@ func TestProjectSharedFileService(t *testing.T) {
 				assert.True(t, errors.As(err, &target))
 			},
 		},
-		"GetFile": {
+		"Download": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/files/1", req.URL.Path)
@@ -174,7 +174,7 @@ func TestProjectSharedFileService(t *testing.T) {
 				got.Body.Close()
 			},
 		},
-		"GetFile/error": {
+		"Download/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.User.Icon(ctx, 1)

--- a/project_structure_test.go
+++ b/project_structure_test.go
@@ -23,22 +23,22 @@ func TestProjectCategoryService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/categories", req.URL.Path)
 				return mock.NewJSONResponse(fixture.Category.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.Category.All(ctx, "TEST")
+				got, err := c.Project.Category.List(ctx, "TEST")
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.Category.All(ctx, "TEST")
+				_, err := c.Project.Category.List(ctx, "TEST")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))
@@ -207,22 +207,22 @@ func TestProjectUserService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/users", req.URL.Path)
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.User.All(ctx, "TEST", false)
+				got, err := c.Project.User.List(ctx, "TEST", false)
 				require.NoError(t, err)
 				assert.Len(t, got, 4)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.User.All(ctx, "TEST", false)
+				_, err := c.Project.User.List(ctx, "TEST", false)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))
@@ -300,22 +300,22 @@ func TestProjectUserService(t *testing.T) {
 				assert.True(t, errors.As(err, &target))
 			},
 		},
-		"AdminAll": {
+		"AdminList": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/administrators", req.URL.Path)
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.User.AdminAll(ctx, "TEST")
+				got, err := c.Project.User.AdminList(ctx, "TEST")
 				require.NoError(t, err)
 				assert.Len(t, got, 4)
 			},
 		},
-		"AdminAll/error": {
+		"AdminList/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.User.AdminAll(ctx, "TEST")
+				_, err := c.Project.User.AdminList(ctx, "TEST")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/project_structure_test.go
+++ b/project_structure_test.go
@@ -214,7 +214,7 @@ func TestProjectUserService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.User.All(ctx, "TEST", false)
+				got, err := c.Project.User.List(ctx, "TEST", false)
 				require.NoError(t, err)
 				assert.Len(t, got, 4)
 			},
@@ -222,7 +222,7 @@ func TestProjectUserService(t *testing.T) {
 		"All/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.User.All(ctx, "TEST", false)
+				_, err := c.Project.User.List(ctx, "TEST", false)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/project_structure_test.go
+++ b/project_structure_test.go
@@ -163,7 +163,7 @@ func TestProjectSharedFileService(t *testing.T) {
 				return mock.NewBinaryResponse("image.png", "image/png", []byte("PNG")), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.SharedFile.GetFile(ctx, "TEST", 1)
+				got, err := c.Project.SharedFile.Download(ctx, "TEST", 1)
 				require.NoError(t, err)
 				require.NotNil(t, got)
 				assert.Equal(t, "image.png", got.Filename)

--- a/project_structure_test.go
+++ b/project_structure_test.go
@@ -207,7 +207,7 @@ func TestProjectUserService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/users", req.URL.Path)
@@ -219,7 +219,7 @@ func TestProjectUserService(t *testing.T) {
 				assert.Len(t, got, 4)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.User.List(ctx, "TEST", false)

--- a/project_structure_test.go
+++ b/project_structure_test.go
@@ -207,22 +207,22 @@ func TestProjectUserService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"List": {
+		"All": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/users", req.URL.Path)
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.User.List(ctx, "TEST", false)
+				got, err := c.Project.User.All(ctx, "TEST", false)
 				require.NoError(t, err)
 				assert.Len(t, got, 4)
 			},
 		},
-		"List/error": {
+		"All/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.User.List(ctx, "TEST", false)
+				_, err := c.Project.User.All(ctx, "TEST", false)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/project_test.go
+++ b/project_test.go
@@ -23,7 +23,7 @@ func TestProjectService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects", req.URL.Path)
@@ -36,7 +36,7 @@ func TestProjectService(t *testing.T) {
 				assert.Len(t, got, 3)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Project.List(ctx)

--- a/project_test.go
+++ b/project_test.go
@@ -31,7 +31,7 @@ func TestProjectService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Project.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.All(ctx, c.Project.Option.WithArchived(true))
+				got, err := c.Project.List(ctx, c.Project.Option.WithArchived(true))
 				require.NoError(t, err)
 				assert.Len(t, got, 3)
 			},
@@ -39,7 +39,7 @@ func TestProjectService(t *testing.T) {
 		"All/error": {
 			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.All(ctx)
+				_, err := c.Project.List(ctx)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -47,7 +47,7 @@ type PullRequestService struct {
 	Star       *PullRequestStarService
 }
 
-// All returns a list of pull requests.
+// List returns a list of pull requests.
 //
 // This method supports options returned by methods in "*Client.PullRequest.Option",
 // such as:
@@ -59,8 +59,8 @@ type PullRequestService struct {
 //   - WithCount
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
-func (s *PullRequestService) All(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, opts ...RequestOption) ([]*PullRequest, error) {
-	v, err := s.base.All(ctx, projectIDOrKey, repositoryIDOrName, toCoreOptions(opts)...)
+func (s *PullRequestService) List(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, opts ...RequestOption) ([]*PullRequest, error) {
+	v, err := s.base.List(ctx, projectIDOrKey, repositoryIDOrName, toCoreOptions(opts)...)
 	return pullRequestsFromModel(v), convertError(err)
 }
 

--- a/pullrequest_comment.go
+++ b/pullrequest_comment.go
@@ -13,7 +13,7 @@ type PullRequestCommentService struct {
 	Option *PullRequestCommentOptionService
 }
 
-// All returns a list of comments on a pull request.
+// List returns a list of comments on a pull request.
 //
 // This method supports options returned by methods in "*Client.PullRequest.Comment.Option",
 // such as:
@@ -23,8 +23,8 @@ type PullRequestCommentService struct {
 //   - WithOrder
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-comment
-func (s *PullRequestCommentService) All(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, opts ...RequestOption) ([]*Comment, error) {
-	v, err := s.base.All(ctx, projectIDOrKey, repositoryIDOrName, prNumber, toCoreOptions(opts)...)
+func (s *PullRequestCommentService) List(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, opts ...RequestOption) ([]*Comment, error) {
+	v, err := s.base.List(ctx, projectIDOrKey, repositoryIDOrName, prNumber, toCoreOptions(opts)...)
 	return commentsFromModel(v), convertError(err)
 }
 

--- a/pullrequest_comment_test.go
+++ b/pullrequest_comment_test.go
@@ -53,7 +53,7 @@ func TestPullRequestCommentService(t *testing.T) {
 				assert.Len(t, got, 2)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.Comment.List(ctx, "TEST", "repo", 1)

--- a/pullrequest_comment_test.go
+++ b/pullrequest_comment_test.go
@@ -29,7 +29,7 @@ func TestPullRequestCommentService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.PullRequest.Comment.All(ctx, "TEST", "repo", 1)
+				got, err := c.PullRequest.Comment.List(ctx, "TEST", "repo", 1)
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, 1, got[0].ID)
@@ -45,7 +45,7 @@ func TestPullRequestCommentService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.PullRequest.Comment.All(ctx, "TEST", "repo", 1,
+				got, err := c.PullRequest.Comment.List(ctx, "TEST", "repo", 1,
 					c.PullRequest.Comment.Option.WithCount(20),
 					c.PullRequest.Comment.Option.WithOrder(backlog.OrderAsc),
 				)
@@ -56,7 +56,7 @@ func TestPullRequestCommentService(t *testing.T) {
 		"All/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.PullRequest.Comment.All(ctx, "TEST", "repo", 1)
+				_, err := c.PullRequest.Comment.List(ctx, "TEST", "repo", 1)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/pullrequest_comment_test.go
+++ b/pullrequest_comment_test.go
@@ -22,7 +22,7 @@ func TestPullRequestCommentService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1/comments", req.URL.Path)
@@ -36,7 +36,7 @@ func TestPullRequestCommentService(t *testing.T) {
 				assert.Equal(t, 2, got[1].ID)
 			},
 		},
-		"All/with-options": {
+		"List/with-options": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests/1/comments", req.URL.Path)

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -31,7 +31,7 @@ func TestPullRequestService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.PullRequest.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.PullRequest.All(ctx, "TEST", "repo")
+				got, err := c.PullRequest.List(ctx, "TEST", "repo")
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, 2, got[0].ID)
@@ -47,7 +47,7 @@ func TestPullRequestService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.PullRequest.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.PullRequest.All(ctx, "TEST", "repo",
+				got, err := c.PullRequest.List(ctx, "TEST", "repo",
 					c.PullRequest.Option.WithStatusIDs([]int{1, 2}),
 					c.PullRequest.Option.WithCount(10),
 				)
@@ -58,7 +58,7 @@ func TestPullRequestService(t *testing.T) {
 		"All/error": {
 			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.PullRequest.All(ctx, "TEST", "repo")
+				_, err := c.PullRequest.List(ctx, "TEST", "repo")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -24,7 +24,7 @@ func TestPullRequestService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests", req.URL.Path)
@@ -38,7 +38,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Equal(t, 3, got[1].ID)
 			},
 		},
-		"All/with-options": {
+		"List/with-options": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests", req.URL.Path)
@@ -55,7 +55,7 @@ func TestPullRequestService(t *testing.T) {
 				assert.Len(t, got, 2)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.List(ctx, "TEST", "repo")

--- a/repository.go
+++ b/repository.go
@@ -34,11 +34,11 @@ type RepositoryService struct {
 	base *repository.Service
 }
 
-// All returns a list of Git repositories in a project.
+// List returns a list of Git repositories in a project.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-git-repositories
-func (s *RepositoryService) All(ctx context.Context, projectIDOrKey string) ([]*Repository, error) {
-	v, err := s.base.All(ctx, projectIDOrKey)
+func (s *RepositoryService) List(ctx context.Context, projectIDOrKey string) ([]*Repository, error) {
+	v, err := s.base.List(ctx, projectIDOrKey)
 	return repositoriesFromModel(v), convertError(err)
 }
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -21,14 +21,14 @@ func TestRepositoryService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/git/repositories", req.URL.Path)
 				return mock.NewJSONResponse(fixture.Repository.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Repository.All(ctx, "TEST")
+				got, err := c.Repository.List(ctx, "TEST")
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 				assert.Equal(t, 5, got[0].ID)
@@ -37,10 +37,10 @@ func TestRepositoryService(t *testing.T) {
 				assert.Equal(t, "bar", got[1].Name)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Repository.All(ctx, "TEST")
+				_, err := c.Repository.List(ctx, "TEST")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/space.go
+++ b/space.go
@@ -67,11 +67,11 @@ type SpaceService struct {
 	Attachment *SpaceAttachmentService
 }
 
-// One returns information about your space.
+// Info returns information about your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-space
-func (s *SpaceService) One(ctx context.Context) (*Space, error) {
-	v, err := s.base.One(ctx)
+func (s *SpaceService) Info(ctx context.Context) (*Space, error) {
+	v, err := s.base.Info(ctx)
 	return spaceFromModel(v), convertError(err)
 }
 

--- a/space.go
+++ b/space.go
@@ -128,11 +128,11 @@ func (s *SpaceActivityService) List(ctx context.Context, opts ...RequestOption) 
 	return activitiesFromModel(v), convertError(err)
 }
 
-// Get returns a single activity by its ID.
+// One returns a single activity by its ID.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-activity
-func (s *SpaceActivityService) Get(ctx context.Context, activityID int) (*Activity, error) {
-	v, err := s.base.Get(ctx, activityID)
+func (s *SpaceActivityService) One(ctx context.Context, activityID int) (*Activity, error) {
+	v, err := s.base.One(ctx, activityID)
 	return activityFromModel(v), convertError(err)
 }
 

--- a/space_test.go
+++ b/space_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestSpaceService_One(t *testing.T) {
+func TestSpaceService_Info(t *testing.T) {
 	ctx := context.Background()
 
 	cases := map[string]struct {
@@ -43,7 +43,7 @@ func TestSpaceService_One(t *testing.T) {
 			c, err := backlog.NewClient("https://example.backlog.com", "token", backlog.WithDoer(&mockDoer{do: tc.doFunc}))
 			require.NoError(t, err)
 
-			got, err := c.Space.One(ctx)
+			got, err := c.Space.Info(ctx)
 
 			if tc.wantErr {
 				require.Error(t, err)

--- a/space_test.go
+++ b/space_test.go
@@ -234,30 +234,30 @@ func TestSpaceActivityService(t *testing.T) {
 				assert.True(t, errors.As(err, &target))
 			},
 		},
-		"Get": {
+		"One": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/activities/3153", req.URL.Path)
 				return mock.NewJSONResponse(fixture.Activity.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Space.Activity.Get(ctx, 3153)
+				got, err := c.Space.Activity.One(ctx, 3153)
 				require.NoError(t, err)
 				require.NotNil(t, got)
 				assert.Equal(t, 3153, got.ID)
 				assert.Equal(t, 2, got.Type)
 			},
 		},
-		"Get/error-invalid-id": {
+		"One/error-invalid-id": {
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Space.Activity.Get(ctx, 0)
+				_, err := c.Space.Activity.One(ctx, 0)
 				require.Error(t, err)
 			},
 		},
-		"Get/error-api": {
+		"One/error-api": {
 			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Space.Activity.Get(ctx, 1)
+				_, err := c.Space.Activity.One(ctx, 1)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/user.go
+++ b/user.go
@@ -32,11 +32,11 @@ type UserService struct {
 	Option *UserOptionService
 }
 
-// All returns all users in your space.
+// List returns all users in your space.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-user-list
-func (s *UserService) All(ctx context.Context) ([]*User, error) {
-	v, err := s.base.All(ctx)
+func (s *UserService) List(ctx context.Context) ([]*User, error) {
+	v, err := s.base.List(ctx)
 	return usersFromModel(v), convertError(err)
 }
 

--- a/user.go
+++ b/user.go
@@ -48,11 +48,11 @@ func (s *UserService) One(ctx context.Context, id int) (*User, error) {
 	return userFromModel(v), convertError(err)
 }
 
-// Own returns your own user.
+// Me returns your own user.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-own-user
-func (s *UserService) Own(ctx context.Context) (*User, error) {
-	v, err := s.base.Own(ctx)
+func (s *UserService) Me(ctx context.Context) (*User, error) {
+	v, err := s.base.Me(ctx)
 	return userFromModel(v), convertError(err)
 }
 

--- a/user_test.go
+++ b/user_test.go
@@ -25,22 +25,22 @@ func TestUserService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users", req.URL.Path)
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.User.All(ctx)
+				got, err := c.User.List(ctx)
 				require.NoError(t, err)
 				assert.Len(t, got, 4)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.User.All(ctx)
+				_, err := c.User.List(ctx)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/user_test.go
+++ b/user_test.go
@@ -67,22 +67,22 @@ func TestUserService(t *testing.T) {
 				assert.True(t, errors.As(err, &target))
 			},
 		},
-		"Own": {
+		"Me": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/users/myself", req.URL.Path)
 				return mock.NewJSONResponse(fixture.User.SingleJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.User.Own(ctx)
+				got, err := c.User.Me(ctx)
 				require.NoError(t, err)
 				assert.Equal(t, "admin", got.UserID)
 			},
 		},
-		"Own/error": {
+		"Me/error": {
 			doFunc: newAuthErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.User.Own(ctx)
+				_, err := c.User.Me(ctx)
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/wiki.go
+++ b/wiki.go
@@ -54,15 +54,15 @@ type WikiService struct {
 	Option *WikiOptionService
 }
 
-// All returns a list of all wiki pages in the project.
+// List returns a list of all wiki pages in the project.
 //
 // This method supports options returned by methods in "*Client.Wiki.Option",
 // such as:
 //   - WithKeyword
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-list
-func (s *WikiService) All(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*Wiki, error) {
-	v, err := s.base.All(ctx, projectIDOrKey, toCoreOptions(opts)...)
+func (s *WikiService) List(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*Wiki, error) {
+	v, err := s.base.List(ctx, projectIDOrKey, toCoreOptions(opts)...)
 	return wikisFromModel(v), convertError(err)
 }
 

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -32,7 +32,7 @@ func TestWikiService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Wiki.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Wiki.All(ctx, "TEST", c.Wiki.Option.WithKeyword("backlog"))
+				got, err := c.Wiki.List(ctx, "TEST", c.Wiki.Option.WithKeyword("backlog"))
 				require.NoError(t, err)
 				assert.Len(t, got, 2)
 			},
@@ -40,7 +40,7 @@ func TestWikiService(t *testing.T) {
 		"All/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Wiki.All(ctx, "TEST")
+				_, err := c.Wiki.List(ctx, "TEST")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -24,7 +24,7 @@ func TestWikiService(t *testing.T) {
 		doFunc func(req *http.Request) (*http.Response, error)
 		call   func(t *testing.T, c *backlog.Client)
 	}{
-		"All": {
+		"List": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/wikis", req.URL.Path)
@@ -37,7 +37,7 @@ func TestWikiService(t *testing.T) {
 				assert.Len(t, got, 2)
 			},
 		},
-		"All/error": {
+		"List/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Wiki.List(ctx, "TEST")


### PR DESCRIPTION
## Summary

Consolidate all breaking API renames into a single release.

**Naming rules:**
- `One` on a singleton resource → `Info` (there is no "one of many" to select)
- All collection-returning methods → `List` (consistent, future-proof regardless of filter support)
- File download methods → `Download` (consistent across all attachment/file services)
- `RecentlyViewedService`: `ListXxx` → `XxxList` (noun-first is more natural for this service)

## Changes

### Space.One → Space.Info

`Space.One` implies selecting one from many, but a space is always a single resource.

- Rename `SpaceService.One` → `SpaceService.Info`
- Update all callers (examples, tests, etc.)

### All → List (all collection-returning methods)

All methods returning a collection are renamed to `List` for consistency and future-proofing — even those currently without filter options may gain filters later.

| Method | Notes |
|---|---|
| `WikiService.All` → `WikiService.List` | |
| `IssueService.All` → `IssueService.List` | |
| `IssueCommentService.All` → `IssueCommentService.List` | |
| `PullRequestService.All` → `PullRequestService.List` | |
| `PullRequestCommentService.All` → `PullRequestCommentService.List` | |
| `ProjectService.All` → `ProjectService.List` | |
| `ProjectCategoryService.All` → `ProjectCategoryService.List` | |
| `ProjectCustomFieldService.All` → `ProjectCustomFieldService.List` | |
| `ProjectIssueTypeService.All` → `ProjectIssueTypeService.List` | |
| `ProjectStatusService.All` → `ProjectStatusService.List` | |
| `ProjectUserService.All` → `ProjectUserService.List` | |
| `ProjectUserService.AdminAll` → `ProjectUserService.AdminList` | |
| `ProjectVersionService.All` → `ProjectVersionService.List` | |
| `ProjectWebhookService.All` → `ProjectWebhookService.List` | |
| `RepositoryService.All` → `RepositoryService.List` | |
| `UserService.All` → `UserService.List` | |

Internal `internal/domain/*/` service methods renamed accordingly.

### GetFile → Download

- `ProjectSharedFileService.GetFile` → `ProjectSharedFileService.Download`

### SpaceActivityService.Get → One

Single-resource fetch methods are named `One` throughout the codebase.

- Rename `SpaceActivityService.Get` → `SpaceActivityService.One`

### UserService.Own → Me

`Me` is more idiomatic for "return the authenticated user".

- Rename `UserService.Own` → `UserService.Me`

### RecentlyViewedService: ListXxx → XxxList

- `RecentlyViewedService.ListIssues` → `RecentlyViewedService.IssueList`
- `RecentlyViewedService.ListProjects` → `RecentlyViewedService.ProjectList`
- `RecentlyViewedService.ListWikis` → `RecentlyViewedService.WikiList`

`AddIssue` / `AddWiki` are unchanged (verb-first is natural for mutation methods).

### Internal: ProjectVersionService base.Add → base.Create

Public API is already `Create`; align the internal method name for consistency. No public API change.

BREAKING CHANGE: Multiple public API methods have been renamed. Replace all collection-returning `All` methods with `List` (e.g. `Wiki.All` → `Wiki.List`, `Issue.All` → `Issue.List`), `SpaceService.One` with `SpaceService.Info`, `SpaceActivityService.Get` with `SpaceActivityService.One`, `ProjectSharedFileService.GetFile` with `ProjectSharedFileService.Download`, `UserService.Own` with `UserService.Me`, `ProjectUserService.AdminAll` with `ProjectUserService.AdminList`, and `RecentlyViewedService.ListIssues/ListProjects/ListWikis` with `IssueList/ProjectList/WikiList`.

Closes #359