### PR TITLE
feat: add IssueStatus and PullRequestStatus ID constants

### DIFF
--- a/const.go
+++ b/const.go
@@ -114,3 +114,19 @@ func (r Role) String() string {
 		return fmt.Sprintf("unknown Role type %d", r)
 	}
 }
+
+// Issue status ID constants for use with [IssueOptionService.WithStatusIDs].
+const (
+	IssueStatusOpen       = 1
+	IssueStatusInProgress = 2
+	IssueStatusResolved   = 3
+	IssueStatusClosed     = 4
+)
+
+// Pull request status ID constants for use with [PullRequestOptionService.WithStatusIDs].
+const (
+	PullRequestStatusOpen   = 1
+	PullRequestStatusClosed = 2
+	PullRequestStatusMerged = 3
+	PullRequestStatusDraft  = 4
+)

--- a/example_option_test.go
+++ b/example_option_test.go
@@ -205,7 +205,7 @@ func ExamplePullRequestOptionService() {
 		context.Background(),
 		"TEST",
 		"myrepo",
-		c.PullRequest.Option.WithStatusIDs([]int{1}),
+		c.PullRequest.Option.WithStatusIDs([]int{backlog.PullRequestStatusOpen}),
 		c.PullRequest.Option.WithCount(50),
 	)
 	fmt.Printf("Count: %d, ID: %d, Summary: %s\n", len(prs), prs[0].ID, prs[0].Summary)

--- a/examples/pr_list/main.go
+++ b/examples/pr_list/main.go
@@ -10,13 +10,12 @@ import (
 	"github.com/nattokin/go-backlog"
 )
 
-// prStatusIDs maps status name to Backlog API status IDs.
-// 1=Open, 2=Closed, 3=Merged, 4=Draft
+// prStatusIDs maps status name to Backlog pull request status ID constants.
 var prStatusIDs = map[string]int{
-	"open":   1,
-	"closed": 2,
-	"merged": 3,
-	"draft":  4,
+	"open":   backlog.PullRequestStatusOpen,
+	"closed": backlog.PullRequestStatusClosed,
+	"merged": backlog.PullRequestStatusMerged,
+	"draft":  backlog.PullRequestStatusDraft,
 }
 
 func main() {

--- a/issue_option_test.go
+++ b/issue_option_test.go
@@ -66,7 +66,7 @@ func TestIssueOptionService(t *testing.T) {
 		"WithStartDateSince":    {option: s.WithStartDateSince(date), wantKey: core.ParamStartDateSince.Value()},
 		"WithStartDateUntil":    {option: s.WithStartDateUntil(date), wantKey: core.ParamStartDateUntil.Value()},
 		"WithStatusID":          {option: s.WithStatusID(1), wantKey: core.ParamStatusID.Value()},
-		"WithStatusIDs":         {option: s.WithStatusIDs([]int{1}), wantKey: core.ParamStatusIDs.Value()},
+		"WithStatusIDs":         {option: s.WithStatusIDs([]int{backlog.IssueStatusOpen}), wantKey: core.ParamStatusIDs.Value()},
 		"WithSummary":           {option: s.WithSummary("summary"), wantKey: core.ParamSummary.Value()},
 		"WithUpdatedSince":      {option: s.WithUpdatedSince(date), wantKey: core.ParamUpdatedSince.Value()},
 		"WithUpdatedUntil":      {option: s.WithUpdatedUntil(date), wantKey: core.ParamUpdatedUntil.Value()},

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -48,7 +48,7 @@ func TestPullRequestService(t *testing.T) {
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.List(ctx, "TEST", "repo",
-					c.PullRequest.Option.WithStatusIDs([]int{1, 2}),
+					c.PullRequest.Option.WithStatusIDs([]int{backlog.PullRequestStatusOpen, backlog.PullRequestStatusClosed}),
 					c.PullRequest.Option.WithCount(10),
 				)
 				require.NoError(t, err)
@@ -85,7 +85,7 @@ func TestPullRequestService(t *testing.T) {
 			},
 			call: func(t *testing.T, c *backlog.Client) {
 				got, err := c.PullRequest.Count(ctx, "TEST", "repo",
-					c.PullRequest.Option.WithStatusIDs([]int{1}),
+					c.PullRequest.Option.WithStatusIDs([]int{backlog.PullRequestStatusOpen}),
 				)
 				require.NoError(t, err)
 				assert.Equal(t, 3, got)
@@ -400,7 +400,7 @@ func TestPullRequestOptionService(t *testing.T) {
 		"WithIssueIDs":        {option: s.WithIssueIDs([]int{1}), wantKey: core.ParamIssueIDs.Value()},
 		"WithNotifiedUserIDs": {option: s.WithNotifiedUserIDs([]int{1}), wantKey: core.ParamNotifiedUserIDs.Value()},
 		"WithOffset":          {option: s.WithOffset(0), wantKey: core.ParamOffset.Value()},
-		"WithStatusIDs":       {option: s.WithStatusIDs([]int{1}), wantKey: core.ParamStatusIDs.Value()},
+		"WithStatusIDs":       {option: s.WithStatusIDs([]int{backlog.PullRequestStatusOpen}), wantKey: core.ParamStatusIDs.Value()},
 		"WithSummary":         {option: s.WithSummary("summary"), wantKey: core.ParamSummary.Value()},
 	}
 


### PR DESCRIPTION
## Summary

Add untyped int constants for issue and pull request default status IDs. These statuses are non-deletable with fixed IDs, making them safe to define as constants. Issue and pull request statuses are defined in separate blocks because they use different names for the same IDs (e.g. issue ID=3 is "Resolved", PR ID=3 is "Merged").

## Changes

- Add `IssueStatusOpen`, `IssueStatusInProgress`, `IssueStatusResolved`, `IssueStatusClosed` constants to `const.go`
- Add `PullRequestStatusOpen`, `PullRequestStatusClosed`, `PullRequestStatusMerged`, `PullRequestStatusDraft` constants to `const.go`
- Update `ExamplePullRequestOptionService` in `example_option_test.go` to use `PullRequestStatusOpen`
- Update `examples/pr_list/main.go` to use the new `PullRequestStatus*` constants instead of raw integer literals
- Update `issue_option_test.go` to use `IssueStatusOpen` in `WithStatusIDs` test case
- Update `pullrequest_test.go` to use `PullRequestStatus*` constants in all `WithStatusIDs` usages

Closes #363