### PR TITLE
refactor!: change ProjectUserService.List to accept variadic options

### DIFF
--- a/example_project_test.go
+++ b/example_project_test.go
@@ -348,7 +348,24 @@ func ExampleProjectUserService_List() {
 		backlog.WithDoer(doerUserList),
 	)
 
-	users, _ := c.Project.User.List(context.Background(), "TEST", false)
+	users, _ := c.Project.User.List(context.Background(), "TEST")
+	fmt.Printf("ID: %d, UserID: %s\n", users[0].ID, users[0].UserID)
+	// Output:
+	// ID: 1, UserID: admin
+}
+
+func ExampleProjectUserService_List_excludeGroupMembers() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerUserList),
+	)
+
+	users, _ := c.Project.User.List(
+		context.Background(),
+		"TEST",
+		c.Project.User.Option.WithExcludeGroupMembers(true),
+	)
 	fmt.Printf("ID: %d, UserID: %s\n", users[0].ID, users[0].UserID)
 	// Output:
 	// ID: 1, UserID: admin

--- a/internal/core/option.go
+++ b/internal/core/option.go
@@ -33,6 +33,7 @@ const (
 	ParamDueDateSince                      APIParamOptionType = "dueDateSince"
 	ParamDueDateUntil                      APIParamOptionType = "dueDateUntil"
 	ParamEstimatedHours                    APIParamOptionType = "estimatedHours"
+	ParamExcludeGroupMembers               APIParamOptionType = "excludeGroupMembers"
 	ParamHasDueDate                        APIParamOptionType = "hasDueDate"
 	ParamHookURL                           APIParamOptionType = "hookUrl"
 	ParamIDs                               APIParamOptionType = "id[]"

--- a/internal/core/option_bool.go
+++ b/internal/core/option_bool.go
@@ -37,6 +37,12 @@ func (s *OptionService) WithChartEnabled(enabled bool) RequestOption {
 	return boolOption(ParamChartEnabled, enabled)
 }
 
+// WithExcludeGroupMembers sets `excludeGroupMembers`.
+// When true, users who joined the project only via group membership are excluded from the result.
+func (s *OptionService) WithExcludeGroupMembers(enabled bool) RequestOption {
+	return boolOption(ParamExcludeGroupMembers, enabled)
+}
+
 // WithHasDueDate sets `hasDueDate`.
 // Note: Setting this to true is not supported by the Backlog API and will result in an error.
 func (s *OptionService) WithHasDueDate(enabled bool) RequestOption {

--- a/internal/domain/project/service_context_test.go
+++ b/internal/domain/project/service_context_test.go
@@ -184,7 +184,7 @@ func Test_contextPropagation(t *testing.T) {
 		{"UserService.List", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := project.NewUserService(m)
-			s.List(ctx, "TEST", false) //nolint:errcheck
+			s.List(ctx, "TEST") //nolint:errcheck
 		}},
 		{"UserService.Add", func(t *testing.T, m *core.Method) {
 			m.Post = makeMockFn(t)

--- a/internal/domain/project/service_user.go
+++ b/internal/domain/project/service_user.go
@@ -62,6 +62,10 @@ func deleteUser(ctx context.Context, m *core.Method, spath string, userID int) (
 	return &v, nil
 }
 
+var validUserListOptions = []core.APIParamOptionType{
+	core.ParamExcludeGroupMembers,
+}
+
 // UserService handles project user-related Backlog API calls.
 type UserService struct {
 	method *core.Method
@@ -69,14 +73,20 @@ type UserService struct {
 
 // List returns a list of users in the project.
 //
+// This method supports options returned by methods in "*Client.Project.User.Option",
+// such as:
+//   - WithExcludeGroupMembers
+//
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-user-list
-func (s *UserService) List(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*model.User, error) {
+func (s *UserService) List(ctx context.Context, projectIDOrKey string, opts ...core.RequestOption) ([]*model.User, error) {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return nil, err
 	}
 
 	query := url.Values{}
-	query.Set("excludeGroupMembers", strconv.FormatBool(excludeGroupMembers))
+	if err := core.ApplyOptions(query, validUserListOptions, opts...); err != nil {
+		return nil, err
+	}
 
 	spath := path.Join("projects", projectIDOrKey, "users")
 	return getUserList(ctx, s.method, spath, query)

--- a/internal/domain/project/service_user_test.go
+++ b/internal/domain/project/service_user_test.go
@@ -18,27 +18,28 @@ import (
 )
 
 func TestProjectUserService_List(t *testing.T) {
+	opt := &core.OptionService{}
+
 	cases := map[string]struct {
-		projectKey          string
-		excludeGroupMembers bool
+		projectKey string
+		opts       []core.RequestOption
 
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
 		wantErrType error
 	}{
-		"success-projectKey-valid": {
-			projectKey:          "TEST",
-			excludeGroupMembers: false,
+		"success-no-options": {
+			projectKey: "TEST",
 
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/users", spath)
-				assert.Equal(t, "false", query.Get("excludeGroupMembers"))
+				assert.Empty(t, query.Get("excludeGroupMembers"))
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 		},
 		"success-excludeGroupMembers-true": {
-			projectKey:          "TEST2",
-			excludeGroupMembers: true,
+			projectKey: "TEST2",
+			opts:       []core.RequestOption{opt.WithExcludeGroupMembers(true)},
 
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST2/users", spath)
@@ -47,14 +48,20 @@ func TestProjectUserService_List(t *testing.T) {
 			},
 		},
 		"success-excludeGroupMembers-false": {
-			projectKey:          "TEST3",
-			excludeGroupMembers: false,
+			projectKey: "TEST3",
+			opts:       []core.RequestOption{opt.WithExcludeGroupMembers(false)},
 
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST3/users", spath)
 				assert.Equal(t, "false", query.Get("excludeGroupMembers"))
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
+		},
+		"error-invalid-option": {
+			projectKey: "TEST",
+			opts:       []core.RequestOption{opt.WithArchived(true)},
+
+			wantErrType: &core.InvalidOptionKeyError{},
 		},
 		"error-validation-projectKey-empty": {
 			projectKey: "",
@@ -66,7 +73,6 @@ func TestProjectUserService_List(t *testing.T) {
 
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "projects/TEST/users", spath)
-				assert.Equal(t, "false", query.Get("excludeGroupMembers"))
 				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
 
@@ -84,7 +90,7 @@ func TestProjectUserService_List(t *testing.T) {
 			}
 			s := project.NewUserService(method)
 
-			users, err := s.List(context.Background(), tc.projectKey, tc.excludeGroupMembers)
+			users, err := s.List(context.Background(), tc.projectKey, tc.opts...)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)

--- a/project_structure.go
+++ b/project_structure.go
@@ -81,13 +81,19 @@ func (s *ProjectSharedFileService) Download(ctx context.Context, projectIDOrKey 
 // ProjectUserService has methods for user of project.
 type ProjectUserService struct {
 	base *project.UserService
+
+	Option *ProjectUserOptionService
 }
 
 // List returns all users in the project.
 //
+// This method supports options returned by methods in "*Client.Project.User.Option",
+// such as:
+//   - WithExcludeGroupMembers
+//
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-project-user-list
-func (s *ProjectUserService) List(ctx context.Context, projectIDOrKey string, excludeGroupMembers bool) ([]*User, error) {
-	v, err := s.base.List(ctx, projectIDOrKey, excludeGroupMembers)
+func (s *ProjectUserService) List(ctx context.Context, projectIDOrKey string, opts ...RequestOption) ([]*User, error) {
+	v, err := s.base.List(ctx, projectIDOrKey, toCoreOptions(opts)...)
 	return usersFromModel(v), convertError(err)
 }
 
@@ -132,6 +138,21 @@ func (s *ProjectUserService) DeleteAdmin(ctx context.Context, projectIDOrKey str
 }
 
 // ──────────────────────────────────────────────────────────────
+//  ProjectUserOptionService
+// ──────────────────────────────────────────────────────────────
+
+// ProjectUserOptionService provides a domain-specific set of option builders
+// for operations within the ProjectUserService.
+type ProjectUserOptionService struct {
+	base *core.OptionService
+}
+
+// WithExcludeGroupMembers sets whether to exclude users who joined only via group membership.
+func (s *ProjectUserOptionService) WithExcludeGroupMembers(enabled bool) RequestOption {
+	return s.base.WithExcludeGroupMembers(enabled)
+}
+
+// ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
@@ -147,8 +168,15 @@ func newProjectSharedFileService(method *core.Method) *ProjectSharedFileService 
 	}
 }
 
-func newProjectUserService(method *core.Method, _ *core.OptionService) *ProjectUserService {
+func newProjectUserService(method *core.Method, option *core.OptionService) *ProjectUserService {
 	return &ProjectUserService{
-		base: project.NewUserService(method),
+		base:   project.NewUserService(method),
+		Option: newProjectUserOptionService(option),
+	}
+}
+
+func newProjectUserOptionService(option *core.OptionService) *ProjectUserOptionService {
+	return &ProjectUserOptionService{
+		base: option,
 	}
 }

--- a/project_structure_test.go
+++ b/project_structure_test.go
@@ -211,10 +211,24 @@ func TestProjectUserService(t *testing.T) {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
 				assert.Equal(t, "/api/v2/projects/TEST/users", req.URL.Path)
+				assert.Empty(t, req.URL.Query().Get("excludeGroupMembers"))
 				return mock.NewJSONResponse(fixture.User.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
-				got, err := c.Project.User.List(ctx, "TEST", false)
+				got, err := c.Project.User.List(ctx, "TEST")
+				require.NoError(t, err)
+				assert.Len(t, got, 4)
+			},
+		},
+		"List/with-option": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/users", req.URL.Path)
+				assert.Equal(t, "true", req.URL.Query().Get("excludeGroupMembers"))
+				return mock.NewJSONResponse(fixture.User.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				got, err := c.Project.User.List(ctx, "TEST", c.Project.User.Option.WithExcludeGroupMembers(true))
 				require.NoError(t, err)
 				assert.Len(t, got, 4)
 			},
@@ -222,7 +236,7 @@ func TestProjectUserService(t *testing.T) {
 		"List/error": {
 			doFunc: newNotFoundDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Project.User.List(ctx, "TEST", false)
+				_, err := c.Project.User.List(ctx, "TEST")
 				require.Error(t, err)
 				var target *backlog.APIResponseError
 				assert.True(t, errors.As(err, &target))


### PR DESCRIPTION
## Summary

`ProjectUserService.List` (and the internal `project.UserService.List`) previously required `excludeGroupMembers bool` as a mandatory positional argument. Since the Backlog API treats this parameter as optional, this change aligns the method with the option-based design used across all other endpoints.

## Changes

- Add `ParamExcludeGroupMembers` constant to `internal/core/option.go`
- Add `WithExcludeGroupMembers(bool)` to `internal/core/option_bool.go`
- Change `project.UserService.List` to accept `...core.RequestOption` and apply options via `ApplyOptions`; add `validUserListOptions` whitelist
- Add `ProjectUserOptionService` with `WithExcludeGroupMembers` to `project_structure.go`; wire it into `newProjectUserService`
- Update `ProjectUserService.List` signature to `...RequestOption`
- Update all tests to reflect the new signatures; add `error-invalid-option` case to internal test; add `List/with-option` case to root-package test
- Update Example tests: `ExampleProjectUserService_List` no longer passes `false`; add `ExampleProjectUserService_List_excludeGroupMembers` to document the option

BREAKING CHANGE: `ProjectUserService.List` and internal `project.UserService.List` signatures changed from `List(ctx, projectIDOrKey, excludeGroupMembers bool)` to `List(ctx, projectIDOrKey, opts ...RequestOption)`.

Closes #