### PR TITLE
refactor!: remove unused public type DiskUsageBase

### DIFF
--- a/models.go
+++ b/models.go
@@ -80,16 +80,6 @@ type CustomFieldItem struct {
 	DisplayOrder int
 }
 
-// DiskUsageBase represents the disk usage breakdown by storage type.
-type DiskUsageBase struct {
-	Issue      int
-	Wiki       int
-	File       int
-	Subversion int
-	Git        int
-	GitLFS     int
-}
-
 // FileData represents a downloaded binary file with its metadata.
 // Body must be closed by the caller after use.
 type FileData struct {


### PR DESCRIPTION
## Summary

Remove `DiskUsageBase` from `models.go`. This type was defined as a public type but never used anywhere in the root package — `DiskUsageProject` and `DiskUsageSpace` in `space.go` each declare their fields independently without embedding it, making `DiskUsageBase` dead code in the public API surface.

## Changes

- Remove `DiskUsageBase` struct from `models.go`

BREAKING CHANGE: `DiskUsageBase` is removed from the public API.

Closes #370