### PR TITLE
fix!: rename WatchingItem.ResourceAlreadyRead to AlreadyRead with correct JSON tag

### DIFF
--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -193,12 +193,12 @@ type Version struct {
 
 // WatchingItem represents an entry in a user's watching list.
 type WatchingItem struct {
-	ID                  int       `json:"id,omitempty"`
-	ResourceAlreadyRead bool      `json:"resourceAlreadyRead,omitempty"`
-	Note                string    `json:"note,omitempty"`
-	Type                string    `json:"type,omitempty"`
-	Issue               *Issue    `json:"issue,omitempty"`
-	LastContentUpdated  time.Time `json:"lastContentUpdated,omitempty"`
-	Created             time.Time `json:"created,omitempty"`
-	Updated             time.Time `json:"updated,omitempty"`
+	ID                 int       `json:"id,omitempty"`
+	AlreadyRead        bool      `json:"alreadyRead,omitempty"`
+	Note               string    `json:"note,omitempty"`
+	Type               string    `json:"type,omitempty"`
+	Issue              *Issue    `json:"issue,omitempty"`
+	LastContentUpdated time.Time `json:"lastContentUpdated,omitempty"`
+	Created            time.Time `json:"created,omitempty"`
+	Updated            time.Time `json:"updated,omitempty"`
 }

--- a/models.go
+++ b/models.go
@@ -204,14 +204,14 @@ type Version struct {
 
 // WatchingItem represents an item in a user's watching list.
 type WatchingItem struct {
-	ID                  int
-	ResourceAlreadyRead bool
-	Note                string
-	Type                string
-	Issue               *Issue
-	LastContentUpdated  Timestamp
-	Created             Timestamp
-	Updated             Timestamp
+	ID                 int
+	AlreadyRead        bool
+	Note               string
+	Type               string
+	Issue              *Issue
+	LastContentUpdated Timestamp
+	Created            Timestamp
+	Updated            Timestamp
 }
 
 // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`WatchingItem.ResourceAlreadyRead` had an incorrect JSON tag `json:"resourceAlreadyRead"`, which is a request query parameter for Count Watching, not a response field. The Backlog API response returns `alreadyRead` for watching endpoints (as confirmed by backlog4j's `WatchJSONImpl`). The field always decoded as `false` because the JSON key never matched, silently misleading callers.

## Changes

- Rename `WatchingItem.ResourceAlreadyRead bool` → `AlreadyRead bool` with tag `json:"alreadyRead"` in `internal/model/common.go`
- Rename `WatchingItem.ResourceAlreadyRead bool` → `AlreadyRead bool` in `models.go`

BREAKING CHANGE: `WatchingItem.ResourceAlreadyRead` is removed; use `WatchingItem.AlreadyRead` instead.

Closes #371