### PR TITLE
feat: add missing User field to Notification model

### DIFF
--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -126,6 +126,7 @@ type Notification struct {
 	PullRequest         *PullRequest `json:"pullRequest,omitempty"`
 	PullRequestComment  *Comment     `json:"pullRequestComment,omitempty"`
 	Sender              *User        `json:"sender,omitempty"`
+	User                *User        `json:"user,omitempty"`
 	Created             time.Time    `json:"created,omitempty"`
 }
 

--- a/internal/testutil/fixture/testdata_activity.go
+++ b/internal/testutil/fixture/testdata_activity.go
@@ -192,6 +192,14 @@ var Activity = activityFixtures{
 					ID:          25,
 					AlreadyRead: false,
 					Reason:      2,
+					User: &backlog.User{
+						ID:          5686,
+						UserID:      "takada",
+						Name:        "takada",
+						RoleType:    backlog.RoleNormalUser,
+						Lang:        "ja",
+						MailAddress: "takada@nulab.example",
+					},
 				},
 			},
 			CreatedUser: &backlog.User{

--- a/models.go
+++ b/models.go
@@ -137,6 +137,7 @@ type Notification struct {
 	PullRequest         *PullRequest
 	PullRequestComment  *Comment
 	Sender              *User
+	User                *User
 	Created             Timestamp
 }
 
@@ -421,6 +422,7 @@ func notificationFromModel(m *model.Notification) *Notification {
 		PullRequest:         pullRequestFromModel(m.PullRequest),
 		PullRequestComment:  commentFromModel(m.PullRequestComment),
 		Sender:              userFromModel(m.Sender),
+		User:                userFromModel(m.User),
 		Created:             Timestamp{m.Created},
 	}
 }

--- a/models_test.go
+++ b/models_test.go
@@ -306,6 +306,34 @@ func Test_issueFromModel(t *testing.T) {
 	}
 }
 
+func Test_notificationFromModel(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	user := &model.User{ID: 1, UserID: "admin", Name: "admin", RoleType: 1, Lang: "ja", MailAddress: "admin@example.com"}
+	wantUser := &User{ID: 1, UserID: "admin", Name: "admin", RoleType: RoleAdministrator, Lang: "ja", MailAddress: "admin@example.com"}
+
+	input := &model.Notification{
+		ID:                  10,
+		AlreadyRead:         false,
+		Reason:              2,
+		ResourceAlreadyRead: true,
+		Sender:              user,
+		User:                user,
+		Created:             created,
+	}
+	want := &Notification{
+		ID:                  10,
+		AlreadyRead:         false,
+		Reason:              2,
+		ResourceAlreadyRead: true,
+		Sender:              wantUser,
+		User:                wantUser,
+		Created:             Timestamp{created},
+	}
+	assert.Equal(t, want, notificationFromModel(input))
+}
+
 func Test_pullRequestFromModel(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Add the missing `user` field to the `Notification` model. The Backlog API response for notification endpoints includes a `user` field (present in backlog4j's `NotificationJSONImpl`), but it was silently dropped during JSON decoding in go-backlog.

## Changes

- Add `User *User \`json:"user,omitempty"\`` to `internal/model/common.go` `Notification` struct
- Add `User *User` to the root-package `Notification` struct in `models.go`
- Update `notificationFromModel` to map `m.User` via `userFromModel`
- Add `Test_notificationFromModel` to `models_test.go` covering `User` and `Sender` field conversion
- Update `Activity` fixture to include `User` in the `Notification` expected value (the `ListJSON` already contained the `user` field, so the Go struct was mismatched)

Closes #372