### PR TITLE
feat: add MergeCommit field to PullRequest model

### DIFF
--- a/internal/model/repository.go
+++ b/internal/model/repository.go
@@ -17,6 +17,7 @@ type PullRequest struct {
 	Issue        *Issue        `json:"issue,omitempty"`
 	BaseCommit   string        `json:"baseCommit,omitempty"`
 	BranchCommit string        `json:"branchCommit,omitempty"`
+	MergeCommit  string        `json:"mergeCommit,omitempty"`
 	CloseAt      time.Time     `json:"closeAt,omitempty"`
 	MergeAt      time.Time     `json:"mergeAt,omitempty"`
 	CreatedUser  *User         `json:"createdUser,omitempty"`

--- a/internal/testutil/fixture/testdata_pullrequest.go
+++ b/internal/testutil/fixture/testdata_pullrequest.go
@@ -29,6 +29,7 @@ var PullRequest = pullRequestFixtures{
     "issue": null,
     "baseCommit": null,
     "branchCommit": null,
+    "mergeCommit": "abc123def456",
     "closeAt": null,
     "mergeAt": null,
     "createdUser": {
@@ -63,6 +64,7 @@ var PullRequest = pullRequestFixtures{
 		Base:         "main",
 		Branch:       "feature/foo",
 		Status:       &backlog.Status{ID: 1, Name: "Open"},
+		MergeCommit:  "abc123def456",
 		CreatedUser: &backlog.User{
 			ID:          1,
 			UserID:      "admin",
@@ -101,6 +103,7 @@ var PullRequest = pullRequestFixtures{
         "issue": null,
         "baseCommit": null,
         "branchCommit": null,
+        "mergeCommit": "abc123def456",
         "closeAt": null,
         "mergeAt": null,
         "createdUser": {
@@ -177,6 +180,7 @@ var PullRequest = pullRequestFixtures{
 			Base:         "main",
 			Branch:       "feature/foo",
 			Status:       &backlog.Status{ID: 1, Name: "Open"},
+			MergeCommit:  "abc123def456",
 			CreatedUser: &backlog.User{
 				ID:          1,
 				UserID:      "admin",

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -23,6 +23,7 @@ type PullRequest struct {
 	Issue        *Issue
 	BaseCommit   string
 	BranchCommit string
+	MergeCommit  string
 	CloseAt      Timestamp
 	MergeAt      Timestamp
 	CreatedUser  *User
@@ -311,6 +312,7 @@ func pullRequestFromModel(m *model.PullRequest) *PullRequest {
 		Issue:        issueFromModel(m.Issue),
 		BaseCommit:   m.BaseCommit,
 		BranchCommit: m.BranchCommit,
+		MergeCommit:  m.MergeCommit,
 		CloseAt:      Timestamp{m.CloseAt},
 		MergeAt:      Timestamp{m.MergeAt},
 		CreatedUser:  userFromModel(m.CreatedUser),


### PR DESCRIPTION
## Summary

Add the missing `MergeCommit` field to the `PullRequest` model. The Backlog API response includes a `mergeCommit` field (present in backlog4j's `PullRequestJSONImpl`) that was silently dropped during JSON decoding.

## Changes

- Add `MergeCommit string \`json:"mergeCommit,omitempty"\`` to `internal/model/repository.go` `PullRequest` struct
- Add `MergeCommit string` to the root-package `PullRequest` struct in `pullrequest.go`
- Update `pullRequestFromModel` conversion helper to map the new field
- Update `testdata_pullrequest.go` fixture to include `mergeCommit` in JSON and expected structs

Closes #374