### PR TITLE
feat: add attachmentInfo, attributeInfo, notificationInfo fields to ChangeLog model

### DIFF
--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -14,6 +14,23 @@ type Attachment struct {
 	Created     time.Time `json:"created,omitempty"`
 }
 
+// AttachmentInfo represents information about an attachment involved in a change log entry.
+type AttachmentInfo struct {
+	ID   int    `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// AttributeInfo represents information about a custom attribute involved in a change log entry.
+type AttributeInfo struct {
+	ID     int    `json:"id,omitempty"`
+	TypeID string `json:"typeId,omitempty"`
+}
+
+// NotificationInfo represents information about a notification involved in a change log entry.
+type NotificationInfo struct {
+	Type string `json:"type,omitempty"`
+}
+
 // Category represents a project category.
 type Category struct {
 	ID           int    `json:"id,omitempty"`
@@ -23,9 +40,12 @@ type Category struct {
 
 // ChangeLog represents a history of changes made to an issue.
 type ChangeLog struct {
-	Field         string `json:"field,omitempty"`
-	NewValue      string `json:"newValue,omitempty"`
-	OriginalValue string `json:"originalValue,omitempty"`
+	Field            string            `json:"field,omitempty"`
+	NewValue         string            `json:"newValue,omitempty"`
+	OriginalValue    string            `json:"originalValue,omitempty"`
+	AttachmentInfo   *AttachmentInfo   `json:"attachmentInfo,omitempty"`
+	AttributeInfo    *AttributeInfo    `json:"attributeInfo,omitempty"`
+	NotificationInfo *NotificationInfo `json:"notificationInfo,omitempty"`
 }
 
 // Comment represents a comment on an issue or pull request.

--- a/models.go
+++ b/models.go
@@ -44,9 +44,9 @@ type Category struct {
 
 // ChangeLog represents a history of changes made to an issue.
 type ChangeLog struct {
-	Field         string
-	NewValue      string
-	OriginalValue string
+	Field          string
+	NewValue       string
+	OriginalValue  string
 	AttachmentInfo *struct {
 		ID   int
 		Name string

--- a/models.go
+++ b/models.go
@@ -47,6 +47,17 @@ type ChangeLog struct {
 	Field         string
 	NewValue      string
 	OriginalValue string
+	AttachmentInfo *struct {
+		ID   int
+		Name string
+	}
+	AttributeInfo *struct {
+		ID     int
+		TypeID string
+	}
+	NotificationInfo *struct {
+		Type string
+	}
 }
 
 // Comment represents a comment on an issue or pull request.
@@ -285,11 +296,37 @@ func changeLogFromModel(m *model.ChangeLog) *ChangeLog {
 	if m == nil {
 		return nil
 	}
-	return &ChangeLog{
+	out := &ChangeLog{
 		Field:         m.Field,
 		NewValue:      m.NewValue,
 		OriginalValue: m.OriginalValue,
 	}
+	if m.AttachmentInfo != nil {
+		out.AttachmentInfo = &struct {
+			ID   int
+			Name string
+		}{
+			ID:   m.AttachmentInfo.ID,
+			Name: m.AttachmentInfo.Name,
+		}
+	}
+	if m.AttributeInfo != nil {
+		out.AttributeInfo = &struct {
+			ID     int
+			TypeID string
+		}{
+			ID:     m.AttributeInfo.ID,
+			TypeID: m.AttributeInfo.TypeID,
+		}
+	}
+	if m.NotificationInfo != nil {
+		out.NotificationInfo = &struct {
+			Type string
+		}{
+			Type: m.NotificationInfo.Type,
+		}
+	}
+	return out
 }
 
 func starFromModel(m *model.Star) *Star {

--- a/models_test.go
+++ b/models_test.go
@@ -12,9 +12,101 @@ import (
 func Test_changeLogFromModel(t *testing.T) {
 	t.Parallel()
 
-	input := &model.ChangeLog{Field: "status", NewValue: "4", OriginalValue: "1"}
-	want := &ChangeLog{Field: "status", NewValue: "4", OriginalValue: "1"}
-	assert.Equal(t, want, changeLogFromModel(input))
+	cases := map[string]struct {
+		input *model.ChangeLog
+		want  *ChangeLog
+	}{
+		"basic_fields_only": {
+			input: &model.ChangeLog{Field: "status", NewValue: "4", OriginalValue: "1"},
+			want:  &ChangeLog{Field: "status", NewValue: "4", OriginalValue: "1"},
+		},
+		"with_attachment_info": {
+			input: &model.ChangeLog{
+				Field:          "attachment",
+				AttachmentInfo: &model.AttachmentInfo{ID: 10, Name: "file.txt"},
+			},
+			want: &ChangeLog{
+				Field: "attachment",
+				AttachmentInfo: &struct {
+					ID   int
+					Name string
+				}{ID: 10, Name: "file.txt"},
+			},
+		},
+		"with_attribute_info": {
+			input: &model.ChangeLog{
+				Field:         "attribute",
+				AttributeInfo: &model.AttributeInfo{ID: 5, TypeID: "text"},
+			},
+			want: &ChangeLog{
+				Field: "attribute",
+				AttributeInfo: &struct {
+					ID     int
+					TypeID string
+				}{ID: 5, TypeID: "text"},
+			},
+		},
+		"with_notification_info": {
+			input: &model.ChangeLog{
+				Field:            "notification",
+				NotificationInfo: &model.NotificationInfo{Type: "issueAssigned"},
+			},
+			want: &ChangeLog{
+				Field: "notification",
+				NotificationInfo: &struct {
+					Type string
+				}{Type: "issueAssigned"},
+			},
+		},
+		"with_all_info_fields": {
+			input: &model.ChangeLog{
+				Field:            "status",
+				NewValue:         "4",
+				OriginalValue:    "1",
+				AttachmentInfo:   &model.AttachmentInfo{ID: 10, Name: "file.txt"},
+				AttributeInfo:    &model.AttributeInfo{ID: 5, TypeID: "text"},
+				NotificationInfo: &model.NotificationInfo{Type: "issueAssigned"},
+			},
+			want: &ChangeLog{
+				Field:         "status",
+				NewValue:      "4",
+				OriginalValue: "1",
+				AttachmentInfo: &struct {
+					ID   int
+					Name string
+				}{ID: 10, Name: "file.txt"},
+				AttributeInfo: &struct {
+					ID     int
+					TypeID string
+				}{ID: 5, TypeID: "text"},
+				NotificationInfo: &struct {
+					Type string
+				}{Type: "issueAssigned"},
+			},
+		},
+		"nil_info_fields_remain_nil": {
+			input: &model.ChangeLog{
+				Field:            "status",
+				AttachmentInfo:   nil,
+				AttributeInfo:    nil,
+				NotificationInfo: nil,
+			},
+			want: &ChangeLog{
+				Field:            "status",
+				AttachmentInfo:   nil,
+				AttributeInfo:    nil,
+				NotificationInfo: nil,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, changeLogFromModel(tc.input))
+		})
+	}
 }
 
 func Test_customFieldFromModel(t *testing.T) {


### PR DESCRIPTION
## Summary

Add three fields to the `ChangeLog` model that are present in Backlog API responses but were previously dropped during JSON decoding.

## Changes

- Add `AttachmentInfo`, `AttributeInfo`, `NotificationInfo` named structs to `internal/model/common.go`
- Add corresponding fields to `internal/model/common.go` `ChangeLog` struct
- Add `AttachmentInfo`, `AttributeInfo`, `NotificationInfo` fields to the root-package `ChangeLog` struct using anonymous structs to avoid polluting the public API surface
- Update `changeLogFromModel` to copy the three new fields individually with nil guards
- Expand `Test_changeLogFromModel` to cover all three new fields (each info field individually, all together, and nil passthrough)

Closes #373