### PR TITLE
refactor: rename WatchingItem to Watching

### DIFF
--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -212,8 +212,8 @@ type Version struct {
 	DisplayOrder   int    `json:"displayOrder,omitempty"`
 }
 
-// WatchingItem represents an entry in a user's watching list.
-type WatchingItem struct {
+// Watching represents an entry in a user's watching list.
+type Watching struct {
 	ID                 int       `json:"id,omitempty"`
 	AlreadyRead        bool      `json:"alreadyRead,omitempty"`
 	Note               string    `json:"note,omitempty"`

--- a/models.go
+++ b/models.go
@@ -214,8 +214,8 @@ type Version struct {
 	DisplayOrder   int
 }
 
-// WatchingItem represents an item in a user's watching list.
-type WatchingItem struct {
+// Watching represents an item in a user's watching list.
+type Watching struct {
 	ID                 int
 	AlreadyRead        bool
 	Note               string


### PR DESCRIPTION
## Summary

Rename `WatchingItem` to `Watching` in both the internal model and the root package to align with the Backlog REST API resource name (`/watchings`).

## Changes

- `internal/model/common.go`: `WatchingItem` → `Watching`
- `models.go`: `WatchingItem` → `Watching`