### PR TITLE
feat: add IssueService.All with iterator-based pagination

### DIFF
--- a/internal/domain/issue/json_testdata_test.go
+++ b/internal/domain/issue/json_testdata_test.go
@@ -1,0 +1,66 @@
+package issue_test
+
+// issueLastPageJSON is a single-element array used to simulate
+// the last page of a paginated response in All tests.
+const issueLastPageJSON = `
+[
+    {
+        "id": 3,
+        "projectId": 10,
+        "issueKey": "PRJ-3",
+        "keyId": 3,
+        "issueType": {
+            "id": 2,
+            "projectId": 10,
+            "name": "Bug",
+            "color": "#990000",
+            "displayOrder": 0
+        },
+        "summary": "last issue",
+        "description": "",
+        "resolutions": null,
+        "priority": {
+            "id": 3,
+            "name": "Normal"
+        },
+        "status": {
+            "id": 1,
+            "projectId": 10,
+            "name": "Open",
+            "color": "#ed8077",
+            "displayOrder": 1000
+        },
+        "assignee": null,
+        "category": [],
+        "versions": [],
+        "milestone": [],
+        "startDate": null,
+        "dueDate": null,
+        "estimatedHours": null,
+        "actualHours": null,
+        "parentIssueId": null,
+        "createdUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "admin@example.com"
+        },
+        "created": "2024-01-12T10:00:00Z",
+        "updatedUser": {
+            "id": 1,
+            "userId": "admin",
+            "name": "admin",
+            "roleType": 1,
+            "lang": "ja",
+            "mailAddress": "admin@example.com"
+        },
+        "updated": "2024-01-12T10:00:00Z",
+        "customFields": [],
+        "attachments": [],
+        "sharedFiles": [],
+        "stars": []
+    }
+]
+`

--- a/internal/domain/issue/service.go
+++ b/internal/domain/issue/service.go
@@ -3,6 +3,7 @@ package issue
 
 import (
 	"context"
+	"iter"
 	"net/url"
 	"path"
 	"strconv"
@@ -68,6 +69,23 @@ func (s *Service) List(ctx context.Context, opts ...core.RequestOption) ([]*mode
 	}
 
 	return v, nil
+}
+
+// All returns an iterator that lazily fetches all issues with automatic pagination.
+//
+// perPage controls how many issues are fetched per API call (1-100).
+// Iteration stops automatically when all issues have been returned.
+// The caller must not pass WithCount or WithOffset in opts; those are managed internally.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-list
+func (s *Service) All(ctx context.Context, perPage int, opts ...core.RequestOption) iter.Seq2[*model.Issue, error] {
+	o := &core.OptionService{}
+	return core.AllSeq(ctx, perPage, func(ctx context.Context, offset int) ([]*model.Issue, error) {
+		return s.List(ctx, append(opts,
+			o.WithCount(perPage),
+			o.WithOffset(offset),
+		)...)
+	})
 }
 
 // Count returns the total count of issues matching the given filters.

--- a/internal/domain/issue/service_test.go
+++ b/internal/domain/issue/service_test.go
@@ -1,11 +1,14 @@
 package issue_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -171,6 +174,105 @@ func TestIssueService_List(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIssueService_All(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("multi-page", func(t *testing.T) {
+		t.Parallel()
+
+		// page 1: full page (perPage=2), page 2: 1 item (signals last page)
+		var callCount atomic.Int32
+		method := mock.NewMethod(t)
+		method.Get = func(_ context.Context, _ string, query url.Values) (*http.Response, error) {
+			n := callCount.Add(1)
+			assert.Equal(t, "2", query.Get("count"))
+			switch n {
+			case 1:
+				assert.Equal(t, "0", query.Get("offset"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString(fixture.Issue.ListJSON)),
+				}, nil
+			case 2:
+				assert.Equal(t, "2", query.Get("offset"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString(issueLastPageJSON)),
+				}, nil
+			default:
+				t.Errorf("unexpected request #%d", n)
+				return nil, nil
+			}
+		}
+
+		s := issue.NewService(method)
+		var got []int
+		for iss, err := range s.All(ctx, 2) {
+			require.NoError(t, err)
+			got = append(got, iss.ID)
+		}
+
+		assert.Equal(t, int32(2), callCount.Load())
+		assert.Equal(t, []int{1, 2, 3}, got)
+	})
+
+	t.Run("break", func(t *testing.T) {
+		t.Parallel()
+
+		var callCount atomic.Int32
+		method := mock.NewMethod(t)
+		method.Get = func(_ context.Context, _ string, _ url.Values) (*http.Response, error) {
+			n := callCount.Add(1)
+			if n > 1 {
+				t.Errorf("unexpected request #%d after break", n)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(fixture.Issue.ListJSON)),
+			}, nil
+		}
+
+		s := issue.NewService(method)
+		var got []int
+		for iss, err := range s.All(ctx, 2) {
+			require.NoError(t, err)
+			got = append(got, iss.ID)
+			break
+		}
+
+		assert.Equal(t, int32(1), callCount.Load())
+		assert.Len(t, got, 1)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		method := mock.NewMethod(t)
+		method.Get = func(_ context.Context, _ string, _ url.Values) (*http.Response, error) {
+			return nil, errors.New("network error")
+		}
+
+		s := issue.NewService(method)
+		for iss, err := range s.All(ctx, 10) {
+			assert.Nil(t, iss)
+			require.Error(t, err)
+			break
+		}
+	})
+
+	t.Run("error-invalid-count", func(t *testing.T) {
+		t.Parallel()
+
+		s := issue.NewService(mock.NewMethod(t))
+		for iss, err := range s.All(ctx, 0) {
+			assert.Nil(t, iss)
+			require.Error(t, err)
+			assert.IsType(t, &core.ValidationError{}, err)
+			break
+		}
+	})
 }
 
 func TestIssueService_Count(t *testing.T) {
@@ -774,6 +876,13 @@ func Test_contextPropagation(t *testing.T) {
 			m.Get = makeMockFn(t)
 			s := issue.NewService(m)
 			s.List(ctx) //nolint:errcheck
+		}},
+		{"Service.All", func(t *testing.T, m *core.Method) {
+			m.Get = makeMockFn(t)
+			s := issue.NewService(m)
+			for range s.All(ctx, 10) {
+				break
+			}
 		}},
 		{"Service.Count", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)

--- a/issue.go
+++ b/issue.go
@@ -2,6 +2,7 @@ package backlog
 
 import (
 	"context"
+	"iter"
 
 	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/domain/issue"
@@ -118,6 +119,53 @@ type IssueService struct {
 func (s *IssueService) List(ctx context.Context, opts ...RequestOption) ([]*Issue, error) {
 	v, err := s.base.List(ctx, toCoreOptions(opts)...)
 	return issuesFromModel(v), convertError(err)
+}
+
+// All returns an iterator that lazily fetches all issues with automatic pagination.
+//
+// perPage controls how many issues are fetched per API call (1-100).
+// Iteration stops automatically when all issues have been returned.
+// The caller must not pass WithCount or WithOffset in opts; those are managed internally.
+//
+// This method supports filter options returned by methods in "*Client.Issue.Option",
+// such as:
+//   - WithProjectIDs
+//   - WithIssueTypeIDs
+//   - WithCategoryIDs
+//   - WithVersionIDs
+//   - WithMilestoneIDs
+//   - WithStatusIDs
+//   - WithPriorityIDs
+//   - WithAssigneeIDs
+//   - WithCreatedUserIDs
+//   - WithResolutionIDs
+//   - WithParentChild
+//   - WithAttachment
+//   - WithSharedFile
+//   - WithIssueSort
+//   - WithOrder
+//   - WithCreatedSince
+//   - WithCreatedUntil
+//   - WithUpdatedSince
+//   - WithUpdatedUntil
+//   - WithStartDateSince
+//   - WithStartDateUntil
+//   - WithDueDateSince
+//   - WithDueDateUntil
+//   - WithHasDueDate
+//   - WithIDs
+//   - WithParentIssueIDs
+//   - WithKeyword
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-list
+func (s *IssueService) All(ctx context.Context, perPage int, opts ...RequestOption) iter.Seq2[*Issue, error] {
+	return func(yield func(*Issue, error) bool) {
+		for v, err := range s.base.All(ctx, perPage, toCoreOptions(opts)...) {
+			if !yield(issueFromModel(v), convertError(err)) {
+				return
+			}
+		}
+	}
 }
 
 // Count returns the total count of issues matching the given filters.

--- a/issue_test.go
+++ b/issue_test.go
@@ -63,6 +63,40 @@ func TestIssueService(t *testing.T) {
 				assert.True(t, errors.As(err, &target))
 			},
 		},
+		// All: verifies that count/offset are sent correctly, model conversion works,
+		// and convertError propagates. Pagination logic and break/error cases are
+		// covered in internal/domain/issue tests.
+		"All": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues", req.URL.Path)
+				assert.Equal(t, "100", req.URL.Query().Get("count"))
+				assert.Equal(t, "0", req.URL.Query().Get("offset"))
+				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				var got []*backlog.Issue
+				for iss, err := range c.Issue.All(ctx, 100) {
+					require.NoError(t, err)
+					got = append(got, iss)
+				}
+				assert.Len(t, got, 2)
+				assert.Equal(t, 1, got[0].ID)
+				assert.Equal(t, 2, got[1].ID)
+			},
+		},
+		"All/error": {
+			doFunc: newInternalServerErrorDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				for iss, err := range c.Issue.All(ctx, 10) {
+					assert.Nil(t, iss)
+					require.Error(t, err)
+					var target *backlog.APIResponseError
+					assert.True(t, errors.As(err, &target))
+					break
+				}
+			},
+		},
 		"Count": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)


### PR DESCRIPTION
## Summary

Add `IssueService.All` which returns an `iter.Seq2[*Issue, error]` iterator that automatically handles offset-based pagination, allowing callers to range over all issues without manual pagination logic.

## Changes

- Add `Service.All(ctx, perPage, opts...)` in `internal/domain/issue/service.go`, which uses `core.AllSeq` to implement pagination logic
- Add `IssueService.All(ctx, perPage, opts...)` in `issue.go` as a thin wrapper that iterates over `internal/issue.Service.All` and applies `issueFromModel` / `convertError` per element
- Add `TestIssueService_All` in `internal/domain/issue/service_test.go` covering multi-page iteration, early `break`, network error, and validation error
- Extract last-page JSON fixture to `internal/domain/issue/json_testdata_test.go` with pretty-printed JSON
- Add `\"Service.All\"` case to `Test_contextPropagation` in `internal/domain/issue/service_test.go`
- Add `\"All\"` and `\"All/error\"` cases to `TestIssueService` in `issue_test.go`

## Design Notes

- `perPage` is the second argument (after `ctx`) to make the pagination intent prominent; it is not a `RequestOption` because it controls pagination, not filtering
- Pagination logic lives in `internal/domain/issue` so that multi-page, `break`, and error test cases don't inflate root-package test files
- Root `All` is a thin iterator wrapper: `for v, err := range s.base.All(...) { yield(issueFromModel(v), convertError(err)) }`
- Reuses `core.AllSeq` introduced in #384; no new generic infrastructure needed
- `AllSeq` stops when the returned page length is less than `perPage`, detecting the last page without an extra request

Part of #93