### PR TITLE
docs: add ExampleIssueService_All and ExamplePullRequestService_All

### DIFF
--- a/example_issue_test.go
+++ b/example_issue_test.go
@@ -20,6 +20,25 @@ func ExampleIssueService_List() {
 	// Count: 2, ID: 1, Summary: First issue
 }
 
+func ExampleIssueService_All() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerIssueList),
+	)
+
+	var ids []int
+	for issue, err := range c.Issue.All(context.Background(), 100) {
+		if err != nil {
+			break
+		}
+		ids = append(ids, issue.ID)
+	}
+	fmt.Printf("Count: %d, IDs: %v\n", len(ids), ids)
+	// Output:
+	// Count: 2, IDs: [1 2]
+}
+
 func ExampleIssueService_Count() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",

--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -20,6 +20,25 @@ func ExamplePullRequestService_List() {
 	// Count: 2, ID: 2, Summary: test PR
 }
 
+func ExamplePullRequestService_All() {
+	c, _ := backlog.NewClient(
+		"https://example.backlog.com",
+		"token",
+		backlog.WithDoer(doerPullRequestList),
+	)
+
+	var ids []int
+	for pr, err := range c.PullRequest.All(context.Background(), 100, "TEST", "myrepo") {
+		if err != nil {
+			break
+		}
+		ids = append(ids, pr.ID)
+	}
+	fmt.Printf("Count: %d, IDs: %v\n", len(ids), ids)
+	// Output:
+	// Count: 2, IDs: [2 3]
+}
+
 func ExamplePullRequestService_Count() {
 	c, _ := backlog.NewClient(
 		"https://example.backlog.com",


### PR DESCRIPTION
## Summary

Add `ExampleXxx` tests for the two iterator methods introduced in #384 and #385.

## Changes

- Add `ExampleIssueService_All` to `example_issue_test.go`
- Add `ExamplePullRequestService_All` to `example_pullrequest_test.go`

Both examples use the existing `doerIssueList` / `doerPullRequestList` doers with `perPage=100`. Since the fixture returns 2 items (fewer than 100), `AllSeq` terminates after the first page without an extra request, keeping the example simple and self-contained.

Part of #93