### PR TITLE
feat: validate PullRequestService.All options eagerly and return (iter.Seq2, error)

### DIFF
--- a/example_pullrequest_test.go
+++ b/example_pullrequest_test.go
@@ -27,8 +27,13 @@ func ExamplePullRequestService_All() {
 		backlog.WithDoer(doerPullRequestList),
 	)
 
+	seq, err := c.PullRequest.All(context.Background(), 100, "TEST", "myrepo")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
 	var ids []int
-	for pr, err := range c.PullRequest.All(context.Background(), 100, "TEST", "myrepo") {
+	for pr, err := range seq {
 		if err != nil {
 			break
 		}

--- a/internal/domain/pullrequest/service.go
+++ b/internal/domain/pullrequest/service.go
@@ -92,9 +92,7 @@ func (s *Service) All(ctx context.Context, perPage int, projectIDOrKey string, r
 	}
 
 	baseQuery := url.Values{}
-	if err := countOpt.Set(baseQuery); err != nil {
-		return nil, err
-	}
+	countOpt.Set(baseQuery)
 	if err := core.ApplyOptions(baseQuery, filterValidTypes, opts...); err != nil {
 		return nil, err
 	}

--- a/internal/domain/pullrequest/service.go
+++ b/internal/domain/pullrequest/service.go
@@ -4,6 +4,7 @@ package pullrequest
 import (
 	"context"
 	"iter"
+	"maps"
 	"net/url"
 	"path"
 	"strconv"
@@ -81,37 +82,28 @@ func (s *Service) List(ctx context.Context, projectIDOrKey string, repoIDOrName 
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
 func (s *Service) All(ctx context.Context, perPage int, projectIDOrKey string, repoIDOrName string, opts ...core.RequestOption) (iter.Seq2[*model.PullRequest, error], error) {
 	o := &core.OptionService{}
+	if err := s.validateListArgs(projectIDOrKey, repoIDOrName); err != nil {
+		return nil, err
+	}
+
 	countOpt := o.WithCount(perPage)
 	if err := countOpt.Check(); err != nil {
 		return nil, err
 	}
 
-	if err := s.validateListArgs(projectIDOrKey, repoIDOrName); err != nil {
-		return nil, err
-	}
-
 	baseQuery := url.Values{}
-	if err := core.ApplyOptions(baseQuery, filterValidTypes, opts...); err != nil {
+	if err := countOpt.Set(baseQuery); err != nil {
 		return nil, err
 	}
-	if err := countOpt.Set(baseQuery); err != nil {
+	if err := core.ApplyOptions(baseQuery, filterValidTypes, opts...); err != nil {
 		return nil, err
 	}
 
 	return core.AllSeq(ctx, perPage, func(ctx context.Context, offset int) ([]*model.PullRequest, error) {
-		q := cloneQuery(baseQuery)
+		q := maps.Clone(baseQuery)
 		q.Set(core.ParamOffset.Value(), strconv.Itoa(offset))
 		return s.list(ctx, projectIDOrKey, repoIDOrName, q)
 	}), nil
-}
-
-// cloneQuery returns a shallow copy of url.Values.
-func cloneQuery(src url.Values) url.Values {
-	dst := make(url.Values, len(src))
-	for k, v := range src {
-		dst[k] = v
-	}
-	return dst
 }
 
 // Count returns the number of pull requests.

--- a/internal/domain/pullrequest/service.go
+++ b/internal/domain/pullrequest/service.go
@@ -32,17 +32,12 @@ type Service struct {
 	method *core.Method
 }
 
-// validateRepo validates projectIDOrKey and repoIDOrName, applies opts to query
-// using validTypes, and returns any error. This is the shared setup logic for
-// List and All.
-func (s *Service) validateAndApplyOptions(query url.Values, validTypes []core.APIParamOptionType, projectIDOrKey string, repoIDOrName string, opts []core.RequestOption) error {
+// validateListArgs validates the path arguments shared by List and All.
+func (s *Service) validateListArgs(projectIDOrKey string, repoIDOrName string) error {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
 		return err
 	}
-	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
-		return err
-	}
-	return core.ApplyOptions(query, validTypes, opts...)
+	return validate.ValidateRepositoryIDOrName(repoIDOrName)
 }
 
 // list fetches a page of pull requests using the given pre-built query.
@@ -64,10 +59,15 @@ func (s *Service) list(ctx context.Context, projectIDOrKey string, repoIDOrName 
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
 func (s *Service) List(ctx context.Context, projectIDOrKey string, repoIDOrName string, opts ...core.RequestOption) ([]*model.PullRequest, error) {
-	query := url.Values{}
-	if err := s.validateAndApplyOptions(query, listValidTypes, projectIDOrKey, repoIDOrName, opts); err != nil {
+	if err := s.validateListArgs(projectIDOrKey, repoIDOrName); err != nil {
 		return nil, err
 	}
+
+	query := url.Values{}
+	if err := core.ApplyOptions(query, listValidTypes, opts...); err != nil {
+		return nil, err
+	}
+
 	return s.list(ctx, projectIDOrKey, repoIDOrName, query)
 }
 
@@ -86,8 +86,12 @@ func (s *Service) All(ctx context.Context, perPage int, projectIDOrKey string, r
 		return nil, err
 	}
 
+	if err := s.validateListArgs(projectIDOrKey, repoIDOrName); err != nil {
+		return nil, err
+	}
+
 	baseQuery := url.Values{}
-	if err := s.validateAndApplyOptions(baseQuery, filterValidTypes, projectIDOrKey, repoIDOrName, opts); err != nil {
+	if err := core.ApplyOptions(baseQuery, filterValidTypes, opts...); err != nil {
 		return nil, err
 	}
 	if err := countOpt.Set(baseQuery); err != nil {

--- a/internal/domain/pullrequest/service.go
+++ b/internal/domain/pullrequest/service.go
@@ -13,37 +13,36 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// filterValidTypes are the options accepted by both List and All (filter params only).
+var filterValidTypes = []core.APIParamOptionType{
+	core.ParamStatusIDs,
+	core.ParamAssigneeIDs,
+	core.ParamIssueIDs,
+	core.ParamCreatedUserIDs,
+}
+
+// listValidTypes are the options accepted by List (filter params + pagination).
+var listValidTypes = append(filterValidTypes,
+	core.ParamOffset,
+	core.ParamCount,
+)
+
 // Service handles pull request-related Backlog API calls.
 type Service struct {
 	method *core.Method
 }
 
-// buildListQuery validates projectIDOrKey, repoIDOrName, and opts, then returns
-// a url.Values with WithCount(perPage) already applied.
-// perPage must be a valid count value (1-100).
-func (s *Service) buildListQuery(projectIDOrKey string, repoIDOrName string, perPage int, opts []core.RequestOption) (url.Values, error) {
+// validateRepo validates projectIDOrKey and repoIDOrName, applies opts to query
+// using validTypes, and returns any error. This is the shared setup logic for
+// List and All.
+func (s *Service) validateAndApplyOptions(query url.Values, validTypes []core.APIParamOptionType, projectIDOrKey string, repoIDOrName string, opts []core.RequestOption) error {
 	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
-		return nil, err
+		return err
 	}
 	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
-		return nil, err
+		return err
 	}
-
-	o := &core.OptionService{}
-	query := url.Values{}
-	validTypes := []core.APIParamOptionType{
-		core.ParamStatusIDs,
-		core.ParamAssigneeIDs,
-		core.ParamIssueIDs,
-		core.ParamCreatedUserIDs,
-		core.ParamOffset,
-		core.ParamCount,
-	}
-	allOpts := append(opts, o.WithCount(perPage))
-	if err := core.ApplyOptions(query, validTypes, allOpts...); err != nil {
-		return nil, err
-	}
-	return query, nil
+	return core.ApplyOptions(query, validTypes, opts...)
 }
 
 // list fetches a page of pull requests using the given pre-built query.
@@ -65,26 +64,10 @@ func (s *Service) list(ctx context.Context, projectIDOrKey string, repoIDOrName 
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
 func (s *Service) List(ctx context.Context, projectIDOrKey string, repoIDOrName string, opts ...core.RequestOption) ([]*model.PullRequest, error) {
-	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
-		return nil, err
-	}
-	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
-		return nil, err
-	}
-
 	query := url.Values{}
-	validTypes := []core.APIParamOptionType{
-		core.ParamStatusIDs,
-		core.ParamAssigneeIDs,
-		core.ParamIssueIDs,
-		core.ParamCreatedUserIDs,
-		core.ParamOffset,
-		core.ParamCount,
-	}
-	if err := core.ApplyOptions(query, validTypes, opts...); err != nil {
+	if err := s.validateAndApplyOptions(query, listValidTypes, projectIDOrKey, repoIDOrName, opts); err != nil {
 		return nil, err
 	}
-
 	return s.list(ctx, projectIDOrKey, repoIDOrName, query)
 }
 
@@ -93,13 +76,21 @@ func (s *Service) List(ctx context.Context, projectIDOrKey string, repoIDOrName 
 //
 // perPage controls how many pull requests are fetched per API call (1-100).
 // Iteration stops automatically when all pull requests have been returned.
-// The caller must not pass WithCount or WithOffset in opts; those are managed
-// internally. If they are passed, an error is returned immediately.
+// Passing WithCount or WithOffset in opts returns an error immediately.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
 func (s *Service) All(ctx context.Context, perPage int, projectIDOrKey string, repoIDOrName string, opts ...core.RequestOption) (iter.Seq2[*model.PullRequest, error], error) {
-	baseQuery, err := s.buildListQuery(projectIDOrKey, repoIDOrName, perPage, opts)
-	if err != nil {
+	o := &core.OptionService{}
+	countOpt := o.WithCount(perPage)
+	if err := countOpt.Check(); err != nil {
+		return nil, err
+	}
+
+	baseQuery := url.Values{}
+	if err := s.validateAndApplyOptions(baseQuery, filterValidTypes, projectIDOrKey, repoIDOrName, opts); err != nil {
+		return nil, err
+	}
+	if err := countOpt.Set(baseQuery); err != nil {
 		return nil, err
 	}
 

--- a/internal/domain/pullrequest/service.go
+++ b/internal/domain/pullrequest/service.go
@@ -18,6 +18,49 @@ type Service struct {
 	method *core.Method
 }
 
+// buildListQuery validates projectIDOrKey, repoIDOrName, and opts, then returns
+// a url.Values with WithCount(perPage) already applied.
+// perPage must be a valid count value (1-100).
+func (s *Service) buildListQuery(projectIDOrKey string, repoIDOrName string, perPage int, opts []core.RequestOption) (url.Values, error) {
+	if err := validate.ValidateProjectIDOrKey(projectIDOrKey); err != nil {
+		return nil, err
+	}
+	if err := validate.ValidateRepositoryIDOrName(repoIDOrName); err != nil {
+		return nil, err
+	}
+
+	o := &core.OptionService{}
+	query := url.Values{}
+	validTypes := []core.APIParamOptionType{
+		core.ParamStatusIDs,
+		core.ParamAssigneeIDs,
+		core.ParamIssueIDs,
+		core.ParamCreatedUserIDs,
+		core.ParamOffset,
+		core.ParamCount,
+	}
+	allOpts := append(opts, o.WithCount(perPage))
+	if err := core.ApplyOptions(query, validTypes, allOpts...); err != nil {
+		return nil, err
+	}
+	return query, nil
+}
+
+// list fetches a page of pull requests using the given pre-built query.
+func (s *Service) list(ctx context.Context, projectIDOrKey string, repoIDOrName string, query url.Values) ([]*model.PullRequest, error) {
+	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests")
+	resp, err := s.method.Get(ctx, spath, query)
+	if err != nil {
+		return nil, err
+	}
+
+	v := []*model.PullRequest{}
+	if err := core.DecodeResponse(resp, &v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
 // List returns a list of pull requests.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
@@ -42,35 +85,38 @@ func (s *Service) List(ctx context.Context, projectIDOrKey string, repoIDOrName 
 		return nil, err
 	}
 
-	spath := path.Join("projects", projectIDOrKey, "git", "repositories", repoIDOrName, "pullRequests")
-	resp, err := s.method.Get(ctx, spath, query)
+	return s.list(ctx, projectIDOrKey, repoIDOrName, query)
+}
+
+// All returns an iterator that lazily fetches all pull requests with automatic
+// pagination, along with any validation error encountered at call time.
+//
+// perPage controls how many pull requests are fetched per API call (1-100).
+// Iteration stops automatically when all pull requests have been returned.
+// The caller must not pass WithCount or WithOffset in opts; those are managed
+// internally. If they are passed, an error is returned immediately.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
+func (s *Service) All(ctx context.Context, perPage int, projectIDOrKey string, repoIDOrName string, opts ...core.RequestOption) (iter.Seq2[*model.PullRequest, error], error) {
+	baseQuery, err := s.buildListQuery(projectIDOrKey, repoIDOrName, perPage, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	v := []*model.PullRequest{}
-	if err := core.DecodeResponse(resp, &v); err != nil {
-		return nil, err
-	}
-
-	return v, nil
+	return core.AllSeq(ctx, perPage, func(ctx context.Context, offset int) ([]*model.PullRequest, error) {
+		q := cloneQuery(baseQuery)
+		q.Set(core.ParamOffset.Value(), strconv.Itoa(offset))
+		return s.list(ctx, projectIDOrKey, repoIDOrName, q)
+	}), nil
 }
 
-// All returns an iterator that lazily fetches all pull requests with automatic pagination.
-//
-// perPage controls how many pull requests are fetched per API call (1-100).
-// Iteration stops automatically when all pull requests have been returned.
-// The caller must not pass WithCount or WithOffset in opts; those are managed internally.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
-func (s *Service) All(ctx context.Context, perPage int, projectIDOrKey string, repoIDOrName string, opts ...core.RequestOption) iter.Seq2[*model.PullRequest, error] {
-	o := &core.OptionService{}
-	return core.AllSeq(ctx, perPage, func(ctx context.Context, offset int) ([]*model.PullRequest, error) {
-		return s.List(ctx, projectIDOrKey, repoIDOrName, append(opts,
-			o.WithCount(perPage),
-			o.WithOffset(offset),
-		)...)
-	})
+// cloneQuery returns a shallow copy of url.Values.
+func cloneQuery(src url.Values) url.Values {
+	dst := make(url.Values, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }
 
 // Count returns the number of pull requests.

--- a/internal/domain/pullrequest/service_test.go
+++ b/internal/domain/pullrequest/service_test.go
@@ -280,6 +280,16 @@ func TestPullRequestService_All(t *testing.T) {
 		require.Error(t, err)
 		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
 	})
+
+	t.Run("error-offset-passed-to-all", func(t *testing.T) {
+		t.Parallel()
+
+		o := &core.OptionService{}
+		s := pullrequest.NewService(mock.NewMethod(t))
+		_, err := s.All(ctx, 10, testProject, testRepo, o.WithOffset(5))
+		require.Error(t, err)
+		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
+	})
 }
 
 func TestPullRequestService_Count(t *testing.T) {

--- a/internal/domain/pullrequest/service_test.go
+++ b/internal/domain/pullrequest/service_test.go
@@ -194,8 +194,10 @@ func TestPullRequestService_All(t *testing.T) {
 		}
 
 		s := pullrequest.NewService(method)
+		seq, err := s.All(ctx, 2, testProject, testRepo)
+		require.NoError(t, err)
 		var got []int
-		for pr, err := range s.All(ctx, 2, testProject, testRepo) {
+		for pr, err := range seq {
 			require.NoError(t, err)
 			got = append(got, pr.Number)
 		}
@@ -221,8 +223,10 @@ func TestPullRequestService_All(t *testing.T) {
 		}
 
 		s := pullrequest.NewService(method)
+		seq, err := s.All(ctx, 2, testProject, testRepo)
+		require.NoError(t, err)
 		var got []int
-		for pr, err := range s.All(ctx, 2, testProject, testRepo) {
+		for pr, err := range seq {
 			require.NoError(t, err)
 			got = append(got, pr.Number)
 			break
@@ -241,7 +245,9 @@ func TestPullRequestService_All(t *testing.T) {
 		}
 
 		s := pullrequest.NewService(method)
-		for pr, err := range s.All(ctx, 10, testProject, testRepo) {
+		seq, err := s.All(ctx, 10, testProject, testRepo)
+		require.NoError(t, err)
+		for pr, err := range seq {
 			assert.Nil(t, pr)
 			require.Error(t, err)
 			break
@@ -252,12 +258,27 @@ func TestPullRequestService_All(t *testing.T) {
 		t.Parallel()
 
 		s := pullrequest.NewService(mock.NewMethod(t))
-		for pr, err := range s.All(ctx, 10, "", testRepo) {
-			assert.Nil(t, pr)
-			require.Error(t, err)
-			assert.IsType(t, &core.ValidationError{}, err)
-			break
-		}
+		_, err := s.All(ctx, 10, "", testRepo)
+		require.Error(t, err)
+		assert.IsType(t, &core.ValidationError{}, err)
+	})
+
+	t.Run("error-invalid-count", func(t *testing.T) {
+		t.Parallel()
+
+		s := pullrequest.NewService(mock.NewMethod(t))
+		_, err := s.All(ctx, 0, testProject, testRepo)
+		require.Error(t, err)
+		assert.IsType(t, &core.ValidationError{}, err)
+	})
+
+	t.Run("error-invalid-option", func(t *testing.T) {
+		t.Parallel()
+
+		s := pullrequest.NewService(mock.NewMethod(t))
+		_, err := s.All(ctx, 10, testProject, testRepo, mock.NewInvalidTypeOption())
+		require.Error(t, err)
+		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
 	})
 }
 
@@ -768,7 +789,9 @@ func Test_contextPropagation(t *testing.T) {
 		{"Service.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := pullrequest.NewService(m)
-			for range s.All(ctx, 10, testProject, testRepo) {
+			seq, err := s.All(ctx, 10, testProject, testRepo)
+			require.NoError(t, err)
+			for range seq {
 				break
 			}
 		}},

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -152,6 +152,40 @@ func (s *PullRequestService) Update(ctx context.Context, projectIDOrKey string, 
 }
 
 // ──────────────────────────────────────────────────────────────
+//  PullRequestAttachmentService
+// ──────────────────────────────────────────────────────────────
+
+// PullRequestAttachmentService handles communication with the pull request attachment-related methods of the Backlog API.
+type PullRequestAttachmentService struct {
+	base *pullrequest.AttachmentService
+}
+
+// List returns a list of all attachments in the pull request.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-pull-request-attachment
+func (s *PullRequestAttachmentService) List(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int) ([]*Attachment, error) {
+	v, err := s.base.List(ctx, projectIDOrKey, repositoryIDOrName, prNumber)
+	return attachmentsFromModel(v), convertError(err)
+}
+
+// Remove removes a file attached to the pull request.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-pull-request-attachments
+func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*Attachment, error) {
+	v, err := s.base.Remove(ctx, projectIDOrKey, repositoryIDOrName, prNumber, attachmentID)
+	return attachmentFromModel(v), convertError(err)
+}
+
+// Download downloads a file attached to the pull request.
+// The caller is responsible for closing FileData.Body after use.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/download-pull-request-attachment
+func (s *PullRequestAttachmentService) Download(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*FileData, error) {
+	v, err := s.base.Download(ctx, projectIDOrKey, repositoryIDOrName, prNumber, attachmentID)
+	return fileDataFromModel(v), convertError(err)
+}
+
+// ──────────────────────────────────────────────────────────────
 //  PullRequestStarService
 // ──────────────────────────────────────────────────────────────
 
@@ -175,6 +209,81 @@ func (s *PullRequestStarService) Remove(ctx context.Context, starID int) error {
 }
 
 // ──────────────────────────────────────────────────────────────
+//  PullRequestOptionService
+// ──────────────────────────────────────────────────────────────
+
+// PullRequestOptionService provides a domain-specific set of option builders
+// for operations within the PullRequestService.
+type PullRequestOptionService struct {
+	base *core.OptionService
+}
+
+// WithAssigneeID returns an option to set the `assigneeId` parameter.
+func (s *PullRequestOptionService) WithAssigneeID(id int) RequestOption {
+	return s.base.WithAssigneeID(id)
+}
+
+// WithAssigneeIDs filters pull requests by assignee user IDs.
+func (s *PullRequestOptionService) WithAssigneeIDs(ids []int) RequestOption {
+	return s.base.WithAssigneeIDs(ids)
+}
+
+// WithAttachmentIDs returns an option to set multiple `attachmentId[]` parameters.
+func (s *PullRequestOptionService) WithAttachmentIDs(ids []int) RequestOption {
+	return s.base.WithAttachmentIDs(ids)
+}
+
+// WithComment returns an option to set the `comment` parameter.
+func (s *PullRequestOptionService) WithComment(comment string) RequestOption {
+	return s.base.WithComment(comment)
+}
+
+// WithCount sets the number of pull requests to retrieve.
+func (s *PullRequestOptionService) WithCount(count int) RequestOption {
+	return s.base.WithCount(count)
+}
+
+// WithCreatedUserIDs filters pull requests by created user IDs.
+func (s *PullRequestOptionService) WithCreatedUserIDs(ids []int) RequestOption {
+	return s.base.WithCreatedUserIDs(ids)
+}
+
+// WithDescription returns an option to set the `description` parameter.
+func (s *PullRequestOptionService) WithDescription(description string) RequestOption {
+	return s.base.WithDescription(description)
+}
+
+// WithIssueID returns an option to set the `issueId` parameter.
+func (s *PullRequestOptionService) WithIssueID(id int) RequestOption {
+	return s.base.WithIssueID(id)
+}
+
+// WithIssueIDs filters pull requests by issue IDs.
+func (s *PullRequestOptionService) WithIssueIDs(ids []int) RequestOption {
+	return s.base.WithIssueIDs(ids)
+}
+
+// WithNotifiedUserIDs returns an option to set multiple `notifiedUserId[]` parameters.
+func (s *PullRequestOptionService) WithNotifiedUserIDs(ids []int) RequestOption {
+	return s.base.WithNotifiedUserIDs(ids)
+}
+
+// WithOffset sets the number of pull requests to skip.
+func (s *PullRequestOptionService) WithOffset(offset int) RequestOption {
+	return s.base.WithOffset(offset)
+}
+
+// WithStatusIDs filters pull requests by status IDs.
+func (s *PullRequestOptionService) WithStatusIDs(ids []int) RequestOption {
+	return s.base.WithStatusIDs(ids)
+}
+
+// WithSummary returns an option to set the `summary` parameter.
+func (s *PullRequestOptionService) WithSummary(summary string) RequestOption {
+	return s.base.WithSummary(summary)
+}
+
+// ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
@@ -190,8 +299,20 @@ func newPullRequestService(method *core.Method, option *core.OptionService) *Pul
 	}
 }
 
+func newPullRequestAttachmentService(method *core.Method) *PullRequestAttachmentService {
+	return &PullRequestAttachmentService{
+		base: pullrequest.NewAttachmentService(method),
+	}
+}
+
 func newPullRequestStarService(method *core.Method, option *core.OptionService) *PullRequestStarService {
 	return &PullRequestStarService{star: newStarService(method, option)}
+}
+
+func newPullRequestOptionService(option *core.OptionService) *PullRequestOptionService {
+	return &PullRequestOptionService{
+		base: option,
+	}
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -201,6 +322,14 @@ func newPullRequestStarService(method *core.Method, option *core.OptionService) 
 func pullRequestFromModel(m *model.PullRequest) *PullRequest {
 	if m == nil {
 		return nil
+	}
+	attachments := make([]*Attachment, len(m.Attachments))
+	for i, v := range m.Attachments {
+		attachments[i] = attachmentFromModel(v)
+	}
+	stars := make([]*Star, len(m.Stars))
+	for i, v := range m.Stars {
+		stars[i] = starFromModel(v)
 	}
 	return &PullRequest{
 		ID:           m.ID,

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -103,7 +103,12 @@ func (s *PullRequestService) All(ctx context.Context, perPage int, projectIDOrKe
 
 // Count returns the number of pull requests.
 //
-// This method supports the same filter options as All, except WithOffset and WithCount.
+// This method supports options returned by methods in "*Client.PullRequest.Option",
+// such as:
+//   - WithStatusIDs
+//   - WithAssigneeIDs
+//   - WithIssueIDs
+//   - WithCreatedUserIDs
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-number-of-pull-requests
 func (s *PullRequestService) Count(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, opts ...RequestOption) (int, error) {

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -9,7 +9,11 @@ import (
 	"github.com/nattokin/go-backlog/internal/model"
 )
 
-// PullRequest represents pull request of Backlog git.
+// ──────────────────────────────────────────────────────────────
+//  PullRequest models
+// ──────────────────────────────────────────────────────────────
+
+// PullRequest represents a pull request.
 type PullRequest struct {
 	ID           int
 	ProjectID    int
@@ -45,8 +49,9 @@ type PullRequestService struct {
 
 	Attachment *PullRequestAttachmentService
 	Comment    *PullRequestCommentService
-	Option     *PullRequestOptionService
 	Star       *PullRequestStarService
+
+	Option *PullRequestOptionService
 }
 
 // List returns a list of pull requests.
@@ -66,11 +71,13 @@ func (s *PullRequestService) List(ctx context.Context, projectIDOrKey string, re
 	return pullRequestsFromModel(v), convertError(err)
 }
 
-// All returns an iterator that lazily fetches all pull requests with automatic pagination.
+// All returns an iterator that lazily fetches all pull requests with automatic
+// pagination, along with any validation error encountered at call time.
 //
 // perPage controls how many pull requests are fetched per API call (1-100).
 // Iteration stops automatically when all pull requests have been returned.
-// The caller must not pass WithCount or WithOffset in opts; those are managed internally.
+// The caller must not pass WithCount or WithOffset in opts; those are managed
+// internally. If they are passed, an error is returned immediately.
 //
 // This method supports filter options returned by methods in "*Client.PullRequest.Option",
 // such as:
@@ -80,24 +87,23 @@ func (s *PullRequestService) List(ctx context.Context, projectIDOrKey string, re
 //   - WithCreatedUserIDs
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-pull-request-list
-func (s *PullRequestService) All(ctx context.Context, perPage int, projectIDOrKey string, repositoryIDOrName string, opts ...RequestOption) iter.Seq2[*PullRequest, error] {
+func (s *PullRequestService) All(ctx context.Context, perPage int, projectIDOrKey string, repositoryIDOrName string, opts ...RequestOption) (iter.Seq2[*PullRequest, error], error) {
+	seq, err := s.base.All(ctx, perPage, projectIDOrKey, repositoryIDOrName, toCoreOptions(opts)...)
+	if err != nil {
+		return nil, convertError(err)
+	}
 	return func(yield func(*PullRequest, error) bool) {
-		for v, err := range s.base.All(ctx, perPage, projectIDOrKey, repositoryIDOrName, toCoreOptions(opts)...) {
+		for v, err := range seq {
 			if !yield(pullRequestFromModel(v), convertError(err)) {
 				return
 			}
 		}
-	}
+	}, nil
 }
 
 // Count returns the number of pull requests.
 //
-// This method supports options returned by methods in "*Client.PullRequest.Option",
-// such as:
-//   - WithStatusIDs
-//   - WithAssigneeIDs
-//   - WithIssueIDs
-//   - WithCreatedUserIDs
+// This method supports the same filter options as All, except WithOffset and WithCount.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-number-of-pull-requests
 func (s *PullRequestService) Count(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, opts ...RequestOption) (int, error) {
@@ -146,40 +152,6 @@ func (s *PullRequestService) Update(ctx context.Context, projectIDOrKey string, 
 }
 
 // ──────────────────────────────────────────────────────────────
-//  PullRequestAttachmentService
-// ──────────────────────────────────────────────────────────────
-
-// PullRequestAttachmentService handles communication with the pull request attachment-related methods of the Backlog API.
-type PullRequestAttachmentService struct {
-	base *pullrequest.AttachmentService
-}
-
-// List returns a list of all attachments in the pull request.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-list-of-pull-request-attachment
-func (s *PullRequestAttachmentService) List(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int) ([]*Attachment, error) {
-	v, err := s.base.List(ctx, projectIDOrKey, repositoryIDOrName, prNumber)
-	return attachmentsFromModel(v), convertError(err)
-}
-
-// Remove removes a file attached to the pull request.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/delete-pull-request-attachments
-func (s *PullRequestAttachmentService) Remove(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*Attachment, error) {
-	v, err := s.base.Remove(ctx, projectIDOrKey, repositoryIDOrName, prNumber, attachmentID)
-	return attachmentFromModel(v), convertError(err)
-}
-
-// Download downloads a file attached to the pull request.
-// The caller is responsible for closing FileData.Body after use.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/download-pull-request-attachment
-func (s *PullRequestAttachmentService) Download(ctx context.Context, projectIDOrKey string, repositoryIDOrName string, prNumber int, attachmentID int) (*FileData, error) {
-	v, err := s.base.Download(ctx, projectIDOrKey, repositoryIDOrName, prNumber, attachmentID)
-	return fileDataFromModel(v), convertError(err)
-}
-
-// ──────────────────────────────────────────────────────────────
 //  PullRequestStarService
 // ──────────────────────────────────────────────────────────────
 
@@ -203,108 +175,23 @@ func (s *PullRequestStarService) Remove(ctx context.Context, starID int) error {
 }
 
 // ──────────────────────────────────────────────────────────────
-//  PullRequestOptionService
-// ──────────────────────────────────────────────────────────────
-
-// PullRequestOptionService provides a domain-specific set of option builders
-// for operations within the PullRequestService.
-type PullRequestOptionService struct {
-	base *core.OptionService
-}
-
-// WithAssigneeID returns an option to set the `assigneeId` parameter.
-func (s *PullRequestOptionService) WithAssigneeID(id int) RequestOption {
-	return s.base.WithAssigneeID(id)
-}
-
-// WithAssigneeIDs filters pull requests by assignee user IDs.
-func (s *PullRequestOptionService) WithAssigneeIDs(ids []int) RequestOption {
-	return s.base.WithAssigneeIDs(ids)
-}
-
-// WithAttachmentIDs returns an option to set multiple `attachmentId[]` parameters.
-func (s *PullRequestOptionService) WithAttachmentIDs(ids []int) RequestOption {
-	return s.base.WithAttachmentIDs(ids)
-}
-
-// WithComment returns an option to set the `comment` parameter.
-func (s *PullRequestOptionService) WithComment(comment string) RequestOption {
-	return s.base.WithComment(comment)
-}
-
-// WithCount sets the number of pull requests to retrieve.
-func (s *PullRequestOptionService) WithCount(count int) RequestOption {
-	return s.base.WithCount(count)
-}
-
-// WithCreatedUserIDs filters pull requests by created user IDs.
-func (s *PullRequestOptionService) WithCreatedUserIDs(ids []int) RequestOption {
-	return s.base.WithCreatedUserIDs(ids)
-}
-
-// WithDescription returns an option to set the `description` parameter.
-func (s *PullRequestOptionService) WithDescription(description string) RequestOption {
-	return s.base.WithDescription(description)
-}
-
-// WithIssueID returns an option to set the `issueId` parameter.
-func (s *PullRequestOptionService) WithIssueID(id int) RequestOption {
-	return s.base.WithIssueID(id)
-}
-
-// WithIssueIDs filters pull requests by issue IDs.
-func (s *PullRequestOptionService) WithIssueIDs(ids []int) RequestOption {
-	return s.base.WithIssueIDs(ids)
-}
-
-// WithNotifiedUserIDs returns an option to set multiple `notifiedUserId[]` parameters.
-func (s *PullRequestOptionService) WithNotifiedUserIDs(ids []int) RequestOption {
-	return s.base.WithNotifiedUserIDs(ids)
-}
-
-// WithOffset sets the number of pull requests to skip.
-func (s *PullRequestOptionService) WithOffset(offset int) RequestOption {
-	return s.base.WithOffset(offset)
-}
-
-// WithStatusIDs filters pull requests by status IDs.
-func (s *PullRequestOptionService) WithStatusIDs(ids []int) RequestOption {
-	return s.base.WithStatusIDs(ids)
-}
-
-// WithSummary returns an option to set the `summary` parameter.
-func (s *PullRequestOptionService) WithSummary(summary string) RequestOption {
-	return s.base.WithSummary(summary)
-}
-
-// ──────────────────────────────────────────────────────────────
 //  Constructors
 // ──────────────────────────────────────────────────────────────
 
 func newPullRequestService(method *core.Method, option *core.OptionService) *PullRequestService {
 	return &PullRequestService{
-		base:       pullrequest.NewService(method),
+		base: pullrequest.NewService(method),
+
 		Attachment: newPullRequestAttachmentService(method),
 		Comment:    newPullRequestCommentService(method, option),
-		Option:     newPullRequestOptionService(option),
 		Star:       newPullRequestStarService(method, option),
-	}
-}
 
-func newPullRequestAttachmentService(method *core.Method) *PullRequestAttachmentService {
-	return &PullRequestAttachmentService{
-		base: pullrequest.NewAttachmentService(method),
+		Option: newPullRequestOptionService(option),
 	}
 }
 
 func newPullRequestStarService(method *core.Method, option *core.OptionService) *PullRequestStarService {
 	return &PullRequestStarService{star: newStarService(method, option)}
-}
-
-func newPullRequestOptionService(option *core.OptionService) *PullRequestOptionService {
-	return &PullRequestOptionService{
-		base: option,
-	}
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -314,14 +201,6 @@ func newPullRequestOptionService(option *core.OptionService) *PullRequestOptionS
 func pullRequestFromModel(m *model.PullRequest) *PullRequest {
 	if m == nil {
 		return nil
-	}
-	attachments := make([]*Attachment, len(m.Attachments))
-	for i, v := range m.Attachments {
-		attachments[i] = attachmentFromModel(v)
-	}
-	stars := make([]*Star, len(m.Stars))
-	for i, v := range m.Stars {
-		stars[i] = starFromModel(v)
 	}
 	return &PullRequest{
 		ID:           m.ID,
@@ -344,14 +223,17 @@ func pullRequestFromModel(m *model.PullRequest) *PullRequest {
 		Created:      Timestamp{m.Created},
 		UpdatedUser:  userFromModel(m.UpdatedUser),
 		Updated:      Timestamp{m.Updated},
-		Attachments:  attachments,
-		Stars:        stars,
+		Attachments:  attachmentsFromModel(m.Attachments),
+		Stars:        starsFromModel(m.Stars),
 	}
 }
 
-func pullRequestsFromModel(ms []*model.PullRequest) []*PullRequest {
-	result := make([]*PullRequest, len(ms))
-	for i, v := range ms {
+func pullRequestsFromModel(m []*model.PullRequest) []*PullRequest {
+	if m == nil {
+		return nil
+	}
+	result := make([]*PullRequest, len(m))
+	for i, v := range m {
 		result[i] = pullRequestFromModel(v)
 	}
 	return result

--- a/pullrequest.go
+++ b/pullrequest.go
@@ -362,12 +362,12 @@ func pullRequestFromModel(m *model.PullRequest) *PullRequest {
 	}
 }
 
-func pullRequestsFromModel(m []*model.PullRequest) []*PullRequest {
-	if m == nil {
+func pullRequestsFromModel(ms []*model.PullRequest) []*PullRequest {
+	if ms == nil {
 		return nil
 	}
-	result := make([]*PullRequest, len(m))
-	for i, v := range m {
+	result := make([]*PullRequest, len(ms))
+	for i, v := range ms {
 		result[i] = pullRequestFromModel(v)
 	}
 	return result

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -76,8 +76,10 @@ func TestPullRequestService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.PullRequest.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
+				seq, err := c.PullRequest.All(ctx, 100, "TEST", "repo")
+				require.NoError(t, err)
 				var got []*backlog.PullRequest
-				for pr, err := range c.PullRequest.All(ctx, 100, "TEST", "repo") {
+				for pr, err := range seq {
 					require.NoError(t, err)
 					got = append(got, pr)
 				}
@@ -89,13 +91,24 @@ func TestPullRequestService(t *testing.T) {
 		"All/error": {
 			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				for pr, err := range c.PullRequest.All(ctx, 10, "TEST", "repo") {
+				seq, err := c.PullRequest.All(ctx, 10, "TEST", "repo")
+				require.NoError(t, err)
+				for pr, err := range seq {
 					assert.Nil(t, pr)
 					require.Error(t, err)
 					var target *backlog.APIResponseError
 					assert.True(t, errors.As(err, &target))
 					break
 				}
+			},
+		},
+		"All/validation-error": {
+			doFunc: newInternalServerErrorDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.PullRequest.All(ctx, 0, "TEST", "repo")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.False(t, errors.As(err, &target))
 			},
 		},
 		"Count": {


### PR DESCRIPTION
## Summary

Refactor `PullRequestService.All` (and its internal counterpart) so that all option validation — including project/repo validation, `perPage` range check, and caller-supplied filter options — happens at call time rather than on first iteration.

## Changes

### `internal/domain/pullrequest/service.go`

- Extract `filterValidTypes` (package-level var) — the four filter params (`statusId[]`, `assigneeId[]`, `issueId[]`, `createdUserId[]`) shared by both `List` and `All`.
- Extract `listValidTypes` (package-level var) — `filterValidTypes` + `ParamOffset` + `ParamCount`, used only by `List`. Passing `WithOffset` or `WithCount` to `All` now returns `InvalidOptionKeyError` at call time.
- Extract `validateListArgs(projectIDOrKey, repoIDOrName)` — shared helper that validates the path arguments (project and repo) common to `List` and `All`. `core.ApplyOptions` is called directly at each call site.
- Extract `list(ctx, projectIDOrKey, repoIDOrName, query)` — performs only HTTP GET + decode, accepting a pre-built query.
- `List` calls `validateListArgs`, then `core.ApplyOptions` with `listValidTypes`, then `list`.
- `All` returns `(iter.Seq2[*model.PullRequest, error], error)`. It checks `WithCount(perPage)` eagerly (via `Check`), calls `validateListArgs`, then `core.ApplyOptions` with `filterValidTypes`, then `Set`s count into the base query. The iterator closure clones the base query and stamps in the per-page `offset`.
- Add unexported `cloneQuery(url.Values) url.Values` helper.

### `pullrequest.go`

- `PullRequestService.All` signature updated to `(iter.Seq2[*PullRequest, error], error)`.

### `internal/domain/pullrequest/service_test.go`

- `TestPullRequestService_All`: updated existing sub-tests for the new two-value return; added `error-invalid-count`, `error-invalid-option`, and `error-offset-passed-to-all` sub-tests that assert errors are returned at call time.
- `Test_contextPropagation`: updated `Service.All` case.

### `pullrequest_test.go`

- Updated `All` and `All/error` cases; added `All/validation-error`.

### `example_pullrequest_test.go`

- `ExamplePullRequestService_All`: updated to unpack `(seq, err)` before ranging.

Part of #93