### PR TITLE
feat: validate IssueService.All options eagerly and return (iter.Seq2, error)

### DIFF
--- a/example_issue_test.go
+++ b/example_issue_test.go
@@ -27,8 +27,13 @@ func ExampleIssueService_All() {
 		backlog.WithDoer(doerIssueList),
 	)
 
+	seq, err := c.Issue.All(context.Background(), 100)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
 	var ids []int
-	for issue, err := range c.Issue.All(context.Background(), 100) {
+	for issue, err := range seq {
 		if err != nil {
 			break
 		}

--- a/internal/domain/issue/service.go
+++ b/internal/domain/issue/service.go
@@ -14,8 +14,8 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// filterValidTypes are the options accepted by both List and All (filter params only,
-// excluding WithOffset, WithCount, WithIssueSort, and WithOrder).
+// filterValidTypes are the options accepted by both List and All (filter + sort params,
+// excluding WithOffset and WithCount).
 var filterValidTypes = []core.APIParamOptionType{
 	core.ParamProjectIDs,
 	core.ParamIssueTypeIDs,
@@ -30,6 +30,8 @@ var filterValidTypes = []core.APIParamOptionType{
 	core.ParamParentChild,
 	core.ParamAttachment,
 	core.ParamSharedFile,
+	core.ParamSort,
+	core.ParamOrder,
 	core.ParamCreatedSince,
 	core.ParamCreatedUntil,
 	core.ParamUpdatedSince,
@@ -44,10 +46,8 @@ var filterValidTypes = []core.APIParamOptionType{
 	core.ParamKeyword,
 }
 
-// listValidTypes are the options accepted by List (filter params + sort/pagination).
+// listValidTypes are the options accepted by List (filter/sort params + pagination).
 var listValidTypes = append(filterValidTypes,
-	core.ParamSort,
-	core.ParamOrder,
 	core.ParamOffset,
 	core.ParamCount,
 )
@@ -88,7 +88,6 @@ func (s *Service) List(ctx context.Context, opts ...core.RequestOption) ([]*mode
 // perPage controls how many issues are fetched per API call (1-100).
 // Iteration stops automatically when all issues have been returned.
 // Passing WithCount or WithOffset in opts returns an error immediately.
-// Passing WithIssueSort or WithOrder in opts also returns an error immediately.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-list
 func (s *Service) All(ctx context.Context, perPage int, opts ...core.RequestOption) (iter.Seq2[*model.Issue, error], error) {

--- a/internal/domain/issue/service.go
+++ b/internal/domain/issue/service.go
@@ -4,6 +4,7 @@ package issue
 import (
 	"context"
 	"iter"
+	"maps"
 	"net/url"
 	"path"
 	"strconv"
@@ -13,51 +14,51 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
+// filterValidTypes are the options accepted by both List and All (filter params only,
+// excluding WithOffset, WithCount, WithIssueSort, and WithOrder).
+var filterValidTypes = []core.APIParamOptionType{
+	core.ParamProjectIDs,
+	core.ParamIssueTypeIDs,
+	core.ParamCategoryIDs,
+	core.ParamVersionIDs,
+	core.ParamMilestoneIDs,
+	core.ParamStatusIDs,
+	core.ParamPriorityIDs,
+	core.ParamAssigneeIDs,
+	core.ParamCreatedUserIDs,
+	core.ParamResolutionIDs,
+	core.ParamParentChild,
+	core.ParamAttachment,
+	core.ParamSharedFile,
+	core.ParamCreatedSince,
+	core.ParamCreatedUntil,
+	core.ParamUpdatedSince,
+	core.ParamUpdatedUntil,
+	core.ParamStartDateSince,
+	core.ParamStartDateUntil,
+	core.ParamDueDateSince,
+	core.ParamDueDateUntil,
+	core.ParamHasDueDate,
+	core.ParamIDs,
+	core.ParamParentIssueIDs,
+	core.ParamKeyword,
+}
+
+// listValidTypes are the options accepted by List (filter params + sort/pagination).
+var listValidTypes = append(filterValidTypes,
+	core.ParamSort,
+	core.ParamOrder,
+	core.ParamOffset,
+	core.ParamCount,
+)
+
 // Service handles issue-related Backlog API calls.
 type Service struct {
 	method *core.Method
 }
 
-// List returns a list of issues.
-//
-// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-list
-func (s *Service) List(ctx context.Context, opts ...core.RequestOption) ([]*model.Issue, error) {
-	query := url.Values{}
-	validTypes := []core.APIParamOptionType{
-		core.ParamProjectIDs,
-		core.ParamIssueTypeIDs,
-		core.ParamCategoryIDs,
-		core.ParamVersionIDs,
-		core.ParamMilestoneIDs,
-		core.ParamStatusIDs,
-		core.ParamPriorityIDs,
-		core.ParamAssigneeIDs,
-		core.ParamCreatedUserIDs,
-		core.ParamResolutionIDs,
-		core.ParamParentChild,
-		core.ParamAttachment,
-		core.ParamSharedFile,
-		core.ParamSort,
-		core.ParamOrder,
-		core.ParamOffset,
-		core.ParamCount,
-		core.ParamCreatedSince,
-		core.ParamCreatedUntil,
-		core.ParamUpdatedSince,
-		core.ParamUpdatedUntil,
-		core.ParamStartDateSince,
-		core.ParamStartDateUntil,
-		core.ParamDueDateSince,
-		core.ParamDueDateUntil,
-		core.ParamHasDueDate,
-		core.ParamIDs,
-		core.ParamParentIssueIDs,
-		core.ParamKeyword,
-	}
-	if err := core.ApplyOptions(query, validTypes, opts...); err != nil {
-		return nil, err
-	}
-
+// list fetches a page of issues using the given pre-built query.
+func (s *Service) list(ctx context.Context, query url.Values) ([]*model.Issue, error) {
 	resp, err := s.method.Get(ctx, "issues", query)
 	if err != nil {
 		return nil, err
@@ -67,25 +68,48 @@ func (s *Service) List(ctx context.Context, opts ...core.RequestOption) ([]*mode
 	if err := core.DecodeResponse(resp, &v); err != nil {
 		return nil, err
 	}
-
 	return v, nil
 }
 
-// All returns an iterator that lazily fetches all issues with automatic pagination.
+// List returns a list of issues.
+//
+// Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-list
+func (s *Service) List(ctx context.Context, opts ...core.RequestOption) ([]*model.Issue, error) {
+	query := url.Values{}
+	if err := core.ApplyOptions(query, listValidTypes, opts...); err != nil {
+		return nil, err
+	}
+	return s.list(ctx, query)
+}
+
+// All returns an iterator that lazily fetches all issues with automatic
+// pagination, along with any validation error encountered at call time.
 //
 // perPage controls how many issues are fetched per API call (1-100).
 // Iteration stops automatically when all issues have been returned.
-// The caller must not pass WithCount or WithOffset in opts; those are managed internally.
+// Passing WithCount or WithOffset in opts returns an error immediately.
+// Passing WithIssueSort or WithOrder in opts also returns an error immediately.
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-list
-func (s *Service) All(ctx context.Context, perPage int, opts ...core.RequestOption) iter.Seq2[*model.Issue, error] {
+func (s *Service) All(ctx context.Context, perPage int, opts ...core.RequestOption) (iter.Seq2[*model.Issue, error], error) {
 	o := &core.OptionService{}
+
+	countOpt := o.WithCount(perPage)
+	if err := countOpt.Check(); err != nil {
+		return nil, err
+	}
+
+	baseQuery := url.Values{}
+	countOpt.Set(baseQuery)
+	if err := core.ApplyOptions(baseQuery, filterValidTypes, opts...); err != nil {
+		return nil, err
+	}
+
 	return core.AllSeq(ctx, perPage, func(ctx context.Context, offset int) ([]*model.Issue, error) {
-		return s.List(ctx, append(opts,
-			o.WithCount(perPage),
-			o.WithOffset(offset),
-		)...)
-	})
+		q := maps.Clone(baseQuery)
+		q.Set(core.ParamOffset.Value(), strconv.Itoa(offset))
+		return s.list(ctx, q)
+	}), nil
 }
 
 // Count returns the total count of issues matching the given filters.

--- a/internal/domain/issue/service_test.go
+++ b/internal/domain/issue/service_test.go
@@ -295,16 +295,6 @@ func TestIssueService_All(t *testing.T) {
 		require.Error(t, err)
 		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
 	})
-
-	t.Run("error-sort-passed-to-all", func(t *testing.T) {
-		t.Parallel()
-
-		o := &core.OptionService{}
-		s := issue.NewService(mock.NewMethod(t))
-		_, err := s.All(ctx, 10, o.WithIssueSort("created"))
-		require.Error(t, err)
-		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
-	})
 }
 
 func TestIssueService_Count(t *testing.T) {

--- a/internal/domain/issue/service_test.go
+++ b/internal/domain/issue/service_test.go
@@ -208,8 +208,10 @@ func TestIssueService_All(t *testing.T) {
 		}
 
 		s := issue.NewService(method)
+		seq, err := s.All(ctx, 2)
+		require.NoError(t, err)
 		var got []int
-		for iss, err := range s.All(ctx, 2) {
+		for iss, err := range seq {
 			require.NoError(t, err)
 			got = append(got, iss.ID)
 		}
@@ -235,8 +237,10 @@ func TestIssueService_All(t *testing.T) {
 		}
 
 		s := issue.NewService(method)
+		seq, err := s.All(ctx, 2)
+		require.NoError(t, err)
 		var got []int
-		for iss, err := range s.All(ctx, 2) {
+		for iss, err := range seq {
 			require.NoError(t, err)
 			got = append(got, iss.ID)
 			break
@@ -255,7 +259,9 @@ func TestIssueService_All(t *testing.T) {
 		}
 
 		s := issue.NewService(method)
-		for iss, err := range s.All(ctx, 10) {
+		seq, err := s.All(ctx, 10)
+		require.NoError(t, err)
+		for iss, err := range seq {
 			assert.Nil(t, iss)
 			require.Error(t, err)
 			break
@@ -266,12 +272,38 @@ func TestIssueService_All(t *testing.T) {
 		t.Parallel()
 
 		s := issue.NewService(mock.NewMethod(t))
-		for iss, err := range s.All(ctx, 0) {
-			assert.Nil(t, iss)
-			require.Error(t, err)
-			assert.IsType(t, &core.ValidationError{}, err)
-			break
-		}
+		_, err := s.All(ctx, 0)
+		require.Error(t, err)
+		assert.IsType(t, &core.ValidationError{}, err)
+	})
+
+	t.Run("error-invalid-option", func(t *testing.T) {
+		t.Parallel()
+
+		s := issue.NewService(mock.NewMethod(t))
+		_, err := s.All(ctx, 10, mock.NewInvalidTypeOption())
+		require.Error(t, err)
+		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
+	})
+
+	t.Run("error-offset-passed-to-all", func(t *testing.T) {
+		t.Parallel()
+
+		o := &core.OptionService{}
+		s := issue.NewService(mock.NewMethod(t))
+		_, err := s.All(ctx, 10, o.WithOffset(5))
+		require.Error(t, err)
+		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
+	})
+
+	t.Run("error-sort-passed-to-all", func(t *testing.T) {
+		t.Parallel()
+
+		o := &core.OptionService{}
+		s := issue.NewService(mock.NewMethod(t))
+		_, err := s.All(ctx, 10, o.WithIssueSort("created"))
+		require.Error(t, err)
+		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
 	})
 }
 
@@ -880,7 +912,9 @@ func Test_contextPropagation(t *testing.T) {
 		{"Service.All", func(t *testing.T, m *core.Method) {
 			m.Get = makeMockFn(t)
 			s := issue.NewService(m)
-			for range s.All(ctx, 10) {
+			seq, err := s.All(ctx, 10)
+			require.NoError(t, err)
+			for range seq {
 				break
 			}
 		}},

--- a/internal/domain/issue/service_test.go
+++ b/internal/domain/issue/service_test.go
@@ -295,6 +295,16 @@ func TestIssueService_All(t *testing.T) {
 		require.Error(t, err)
 		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
 	})
+
+	t.Run("error-count-passed-to-all", func(t *testing.T) {
+		t.Parallel()
+
+		o := &core.OptionService{}
+		s := issue.NewService(mock.NewMethod(t))
+		_, err := s.All(ctx, 10, o.WithCount(50))
+		require.Error(t, err)
+		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
+	})
 }
 
 func TestIssueService_Count(t *testing.T) {

--- a/internal/domain/pullrequest/service_test.go
+++ b/internal/domain/pullrequest/service_test.go
@@ -290,6 +290,16 @@ func TestPullRequestService_All(t *testing.T) {
 		require.Error(t, err)
 		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
 	})
+
+	t.Run("error-count-passed-to-all", func(t *testing.T) {
+		t.Parallel()
+
+		o := &core.OptionService{}
+		s := pullrequest.NewService(mock.NewMethod(t))
+		_, err := s.All(ctx, 10, testProject, testRepo, o.WithCount(50))
+		require.Error(t, err)
+		assert.IsType(t, &core.InvalidOptionKeyError{}, err)
+	})
 }
 
 func TestPullRequestService_Count(t *testing.T) {

--- a/issue.go
+++ b/issue.go
@@ -126,9 +126,8 @@ func (s *IssueService) List(ctx context.Context, opts ...RequestOption) ([]*Issu
 //
 // perPage controls how many issues are fetched per API call (1-100).
 // Iteration stops automatically when all issues have been returned.
-// The caller must not pass WithCount, WithOffset, WithIssueSort, or WithOrder
-// in opts; those are managed internally or unsupported. If they are passed,
-// an error is returned immediately.
+// The caller must not pass WithCount or WithOffset in opts; those are managed
+// internally. If they are passed, an error is returned immediately.
 //
 // This method supports filter options returned by methods in "*Client.Issue.Option",
 // such as:
@@ -145,6 +144,8 @@ func (s *IssueService) List(ctx context.Context, opts ...RequestOption) ([]*Issu
 //   - WithParentChild
 //   - WithAttachment
 //   - WithSharedFile
+//   - WithIssueSort
+//   - WithOrder
 //   - WithCreatedSince
 //   - WithCreatedUntil
 //   - WithUpdatedSince

--- a/issue.go
+++ b/issue.go
@@ -121,11 +121,14 @@ func (s *IssueService) List(ctx context.Context, opts ...RequestOption) ([]*Issu
 	return issuesFromModel(v), convertError(err)
 }
 
-// All returns an iterator that lazily fetches all issues with automatic pagination.
+// All returns an iterator that lazily fetches all issues with automatic
+// pagination, along with any validation error encountered at call time.
 //
 // perPage controls how many issues are fetched per API call (1-100).
 // Iteration stops automatically when all issues have been returned.
-// The caller must not pass WithCount or WithOffset in opts; those are managed internally.
+// The caller must not pass WithCount, WithOffset, WithIssueSort, or WithOrder
+// in opts; those are managed internally or unsupported. If they are passed,
+// an error is returned immediately.
 //
 // This method supports filter options returned by methods in "*Client.Issue.Option",
 // such as:
@@ -142,8 +145,6 @@ func (s *IssueService) List(ctx context.Context, opts ...RequestOption) ([]*Issu
 //   - WithParentChild
 //   - WithAttachment
 //   - WithSharedFile
-//   - WithIssueSort
-//   - WithOrder
 //   - WithCreatedSince
 //   - WithCreatedUntil
 //   - WithUpdatedSince
@@ -158,14 +159,18 @@ func (s *IssueService) List(ctx context.Context, opts ...RequestOption) ([]*Issu
 //   - WithKeyword
 //
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/get-issue-list
-func (s *IssueService) All(ctx context.Context, perPage int, opts ...RequestOption) iter.Seq2[*Issue, error] {
+func (s *IssueService) All(ctx context.Context, perPage int, opts ...RequestOption) (iter.Seq2[*Issue, error], error) {
+	seq, err := s.base.All(ctx, perPage, toCoreOptions(opts)...)
+	if err != nil {
+		return nil, convertError(err)
+	}
 	return func(yield func(*Issue, error) bool) {
-		for v, err := range s.base.All(ctx, perPage, toCoreOptions(opts)...) {
+		for v, err := range seq {
 			if !yield(issueFromModel(v), convertError(err)) {
 				return
 			}
 		}
-	}
+	}, nil
 }
 
 // Count returns the total count of issues matching the given filters.

--- a/issue_test.go
+++ b/issue_test.go
@@ -90,15 +90,10 @@ func TestIssueService(t *testing.T) {
 		"All/error": {
 			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				seq, err := c.Issue.All(ctx, 10)
-				require.NoError(t, err)
-				for iss, err := range seq {
-					assert.Nil(t, iss)
-					require.Error(t, err)
-					var target *backlog.APIResponseError
-					assert.True(t, errors.As(err, &target))
-					break
-				}
+				_, err := c.Issue.All(ctx, 0)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.False(t, errors.As(err, &target))
 			},
 		},
 		"Count": {

--- a/issue_test.go
+++ b/issue_test.go
@@ -63,9 +63,9 @@ func TestIssueService(t *testing.T) {
 				assert.True(t, errors.As(err, &target))
 			},
 		},
-		// All: verifies that count/offset are sent correctly, model conversion works,
-		// and convertError propagates. Pagination logic and break/error cases are
-		// covered in internal/domain/issue tests.
+		// All: verifies that count/offset are sent correctly and model conversion works.
+		// Call-time validation error propagation is verified in All/error.
+		// Pagination logic and break/HTTP-error cases are covered in internal/domain/issue tests.
 		"All": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
@@ -88,12 +88,11 @@ func TestIssueService(t *testing.T) {
 			},
 		},
 		"All/error": {
-			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.Issue.All(ctx, 0)
 				require.Error(t, err)
-				var target *backlog.APIResponseError
-				assert.False(t, errors.As(err, &target))
+				var target *backlog.ValidationError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 		"Count": {

--- a/issue_test.go
+++ b/issue_test.go
@@ -65,7 +65,7 @@ func TestIssueService(t *testing.T) {
 		},
 		// All: verifies that count/offset are sent correctly and model conversion works.
 		// Call-time validation error propagation is verified in All/error.
-		// Pagination logic and break/HTTP-error cases are covered in internal/domain/issue tests.
+		// Pagination logic and HTTP-error cases are covered in internal/domain/issue tests.
 		"All": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
@@ -85,6 +85,25 @@ func TestIssueService(t *testing.T) {
 				assert.Len(t, got, 2)
 				assert.Equal(t, 1, got[0].ID)
 				assert.Equal(t, 2, got[1].ID)
+			},
+		},
+		"All/break": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/issues", req.URL.Path)
+				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				seq, err := c.Issue.All(ctx, 100)
+				require.NoError(t, err)
+				var got []*backlog.Issue
+				for iss, err := range seq {
+					require.NoError(t, err)
+					got = append(got, iss)
+					break
+				}
+				assert.Len(t, got, 1)
+				assert.Equal(t, 1, got[0].ID)
 			},
 		},
 		"All/error": {

--- a/issue_test.go
+++ b/issue_test.go
@@ -101,15 +101,6 @@ func TestIssueService(t *testing.T) {
 				}
 			},
 		},
-		"All/validation-error": {
-			doFunc: newInternalServerErrorDoFunc(),
-			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.Issue.All(ctx, 0)
-				require.Error(t, err)
-				var target *backlog.APIResponseError
-				assert.False(t, errors.As(err, &target))
-			},
-		},
 		"Count": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)

--- a/issue_test.go
+++ b/issue_test.go
@@ -75,8 +75,10 @@ func TestIssueService(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Issue.ListJSON), nil
 			},
 			call: func(t *testing.T, c *backlog.Client) {
+				seq, err := c.Issue.All(ctx, 100)
+				require.NoError(t, err)
 				var got []*backlog.Issue
-				for iss, err := range c.Issue.All(ctx, 100) {
+				for iss, err := range seq {
 					require.NoError(t, err)
 					got = append(got, iss)
 				}
@@ -88,13 +90,24 @@ func TestIssueService(t *testing.T) {
 		"All/error": {
 			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				for iss, err := range c.Issue.All(ctx, 10) {
+				seq, err := c.Issue.All(ctx, 10)
+				require.NoError(t, err)
+				for iss, err := range seq {
 					assert.Nil(t, iss)
 					require.Error(t, err)
 					var target *backlog.APIResponseError
 					assert.True(t, errors.As(err, &target))
 					break
 				}
+			},
+		},
+		"All/validation-error": {
+			doFunc: newInternalServerErrorDoFunc(),
+			call: func(t *testing.T, c *backlog.Client) {
+				_, err := c.Issue.All(ctx, 0)
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.False(t, errors.As(err, &target))
 			},
 		},
 		"Count": {

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -64,9 +64,9 @@ func TestPullRequestService(t *testing.T) {
 				assert.True(t, errors.As(err, &target))
 			},
 		},
-		// All: verifies that count/offset are sent correctly, model conversion works,
-		// and convertError propagates. Pagination logic and break/error cases are
-		// covered in internal/domain/pullrequest tests.
+		// All: verifies that count/offset are sent correctly and model conversion works.
+		// Call-time validation error propagation is verified in All/error.
+		// Pagination logic and break/HTTP-error cases are covered in internal/domain/pullrequest tests.
 		"All": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
@@ -89,12 +89,11 @@ func TestPullRequestService(t *testing.T) {
 			},
 		},
 		"All/error": {
-			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
 				_, err := c.PullRequest.All(ctx, 0, "TEST", "repo")
 				require.Error(t, err)
-				var target *backlog.APIResponseError
-				assert.False(t, errors.As(err, &target))
+				var target *backlog.ValidationError
+				assert.True(t, errors.As(err, &target))
 			},
 		},
 		"Count": {

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -66,7 +66,7 @@ func TestPullRequestService(t *testing.T) {
 		},
 		// All: verifies that count/offset are sent correctly and model conversion works.
 		// Call-time validation error propagation is verified in All/error.
-		// Pagination logic and break/HTTP-error cases are covered in internal/domain/pullrequest tests.
+		// Pagination logic and HTTP-error cases are covered in internal/domain/pullrequest tests.
 		"All": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)
@@ -86,6 +86,25 @@ func TestPullRequestService(t *testing.T) {
 				assert.Len(t, got, 2)
 				assert.Equal(t, 2, got[0].ID)
 				assert.Equal(t, 3, got[1].ID)
+			},
+		},
+		"All/break": {
+			doFunc: func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, http.MethodGet, req.Method)
+				assert.Equal(t, "/api/v2/projects/TEST/git/repositories/repo/pullRequests", req.URL.Path)
+				return mock.NewJSONResponse(fixture.PullRequest.ListJSON), nil
+			},
+			call: func(t *testing.T, c *backlog.Client) {
+				seq, err := c.PullRequest.All(ctx, 100, "TEST", "repo")
+				require.NoError(t, err)
+				var got []*backlog.PullRequest
+				for pr, err := range seq {
+					require.NoError(t, err)
+					got = append(got, pr)
+					break
+				}
+				assert.Len(t, got, 1)
+				assert.Equal(t, 2, got[0].ID)
 			},
 		},
 		"All/error": {

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -102,15 +102,6 @@ func TestPullRequestService(t *testing.T) {
 				}
 			},
 		},
-		"All/validation-error": {
-			doFunc: newInternalServerErrorDoFunc(),
-			call: func(t *testing.T, c *backlog.Client) {
-				_, err := c.PullRequest.All(ctx, 0, "TEST", "repo")
-				require.Error(t, err)
-				var target *backlog.APIResponseError
-				assert.False(t, errors.As(err, &target))
-			},
-		},
 		"Count": {
 			doFunc: func(req *http.Request) (*http.Response, error) {
 				assert.Equal(t, http.MethodGet, req.Method)

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -91,15 +91,10 @@ func TestPullRequestService(t *testing.T) {
 		"All/error": {
 			doFunc: newInternalServerErrorDoFunc(),
 			call: func(t *testing.T, c *backlog.Client) {
-				seq, err := c.PullRequest.All(ctx, 10, "TEST", "repo")
-				require.NoError(t, err)
-				for pr, err := range seq {
-					assert.Nil(t, pr)
-					require.Error(t, err)
-					var target *backlog.APIResponseError
-					assert.True(t, errors.As(err, &target))
-					break
-				}
+				_, err := c.PullRequest.All(ctx, 0, "TEST", "repo")
+				require.Error(t, err)
+				var target *backlog.APIResponseError
+				assert.False(t, errors.As(err, &target))
 			},
 		},
 		"Count": {


### PR DESCRIPTION
## Summary

Refactor `IssueService.All` (and its internal counterpart) so that all option validation — including `perPage` range check and caller-supplied filter options — happens at call time rather than on first iteration.

## Changes

### `internal/domain/issue/service.go`

- Extract `filterValidTypes` (package-level var) — the filter + sort params shared by both `List` and `All` (excludes `ParamOffset` and `ParamCount`).
- Extract `listValidTypes` (package-level var) — `filterValidTypes` + `ParamOffset` + `ParamCount`, used only by `List`. Passing `WithOffset` or `WithCount` to `All` now returns `InvalidOptionKeyError` at call time.
- Extract `list(ctx, query)` — performs only HTTP GET + decode, accepting a pre-built query.
- `List` calls `core.ApplyOptions` with `listValidTypes`, then `list`.
- `All` returns `(iter.Seq2[*model.Issue, error], error)`. It checks `WithCount(perPage)` eagerly (via `Check`), calls `core.ApplyOptions` with `filterValidTypes`, then `Set`s count into the base query. The iterator closure clones the base query and stamps in the per-page `offset`.

### `issue.go`

- `IssueService.All` signature updated to `(iter.Seq2[*Issue, error], error)`.
- Doc comment updated to reflect that `WithCount` and `WithOffset` are now forbidden.

### `internal/domain/issue/service_test.go`

- `TestIssueService_All`: updated existing sub-tests for the new two-value return; added `error-invalid-count`, `error-invalid-option`, `error-offset-passed-to-all`, and `error-count-passed-to-all` sub-tests that assert errors are returned at call time.
- `Test_contextPropagation`: updated `Service.All` case.

### `issue_test.go`

- Updated `All` and `All/error` cases.

### `example_issue_test.go`

- `ExampleIssueService_All`: updated to unpack `(seq, err)` before ranging.

Part of #93