### PR TITLE
refactor: split comment_service_crud_test.go from comment_service_test.go

### DIFF
--- a/internal/domain/issue/comment_service_crud_test.go
+++ b/internal/domain/issue/comment_service_crud_test.go
@@ -17,305 +17,65 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestCommentService_List(t *testing.T) {
+func TestCommentService_Add(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
 		issueIDOrKey string
+		content      string
 		opts         []core.RequestOption
-
-		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
-
-		wantErrType error
-		wantIDs     []int
-	}{
-		"success-no-options": {
-			issueIDOrKey: "PRJ-1",
-			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				assert.Equal(t, "issues/PRJ-1/comments", spath)
-				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
-			},
-			wantIDs: []int{1, 2},
-		},
-		"success-by-numeric-id": {
-			issueIDOrKey: "1",
-			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				assert.Equal(t, "issues/1/comments", spath)
-				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
-			},
-			wantIDs: []int{1, 2},
-		},
-		"success-with-count-and-order": {
-			issueIDOrKey: "PRJ-1",
-			opts: []core.RequestOption{
-				o.WithCount(20),
-				o.WithOrder("asc"),
-			},
-			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				assert.Equal(t, "issues/PRJ-1/comments", spath)
-				assert.Equal(t, "20", query.Get("count"))
-				assert.Equal(t, "asc", query.Get("order"))
-				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
-			},
-			wantIDs: []int{1, 2},
-		},
-		"success-with-minID-maxID": {
-			issueIDOrKey: "PRJ-1",
-			opts: []core.RequestOption{
-				o.WithMinID(10),
-				o.WithMaxID(100),
-			},
-			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				assert.Equal(t, "issues/PRJ-1/comments", spath)
-				assert.Equal(t, "10", query.Get("minId"))
-				assert.Equal(t, "100", query.Get("maxId"))
-				return mock.NewJSONResponse(fixture.Comment.ListJSON), nil
-			},
-			wantIDs: []int{1, 2},
-		},
-		"error-empty-issueIDOrKey": {
-			issueIDOrKey: "",
-			wantErrType:  &core.ValidationError{},
-		},
-		"error-zero-issueIDOrKey": {
-			issueIDOrKey: "0",
-			wantErrType:  &core.ValidationError{},
-		},
-		"error-option-invalid-type": {
-			issueIDOrKey: "PRJ-1",
-			opts:         []core.RequestOption{mock.NewInvalidTypeOption()},
-			wantErrType:  &core.InvalidOptionKeyError{},
-		},
-		"error-client-network": {
-			issueIDOrKey: "PRJ-1",
-			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return nil, errors.New("network error")
-			},
-			wantErrType: errors.New(""),
-		},
-		"error-response-invalid-json": {
-			issueIDOrKey: "PRJ-1",
-			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return mock.NewJSONResponse(fixture.InvalidJSON), nil
-			},
-			wantErrType: &json.SyntaxError{},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			method := mock.NewMethod(t)
-			if tc.mockGetFn != nil {
-				method.Get = tc.mockGetFn
-			}
-
-			s := issue.NewCommentService(method)
-
-			got, err := s.List(context.Background(), tc.issueIDOrKey, tc.opts...)
-
-			if tc.wantErrType != nil {
-				assert.Error(t, err)
-				assert.Nil(t, got)
-				assert.IsType(t, tc.wantErrType, err)
-				return
-			}
-
-			require.NoError(t, err)
-			require.NotNil(t, got)
-			assert.Len(t, got, len(tc.wantIDs))
-			for i := range got {
-				assert.Equal(t, tc.wantIDs[i], got[i].ID)
-			}
-		})
-	}
-}
-
-func TestCommentService_Count(t *testing.T) {
-	cases := map[string]struct {
-		issueIDOrKey string
-
-		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
-
-		wantErrType error
-		wantCount   int
-	}{
-		"success": {
-			issueIDOrKey: "PRJ-1",
-			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				assert.Equal(t, "issues/PRJ-1/comments/count", spath)
-				return mock.NewJSONResponse(`{"count":7}`), nil
-			},
-			wantCount: 7,
-		},
-		"error-empty-issueIDOrKey": {
-			issueIDOrKey: "",
-			wantErrType:  &core.ValidationError{},
-		},
-		"error-zero-issueIDOrKey": {
-			issueIDOrKey: "0",
-			wantErrType:  &core.ValidationError{},
-		},
-		"error-client-network": {
-			issueIDOrKey: "PRJ-1",
-			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return nil, errors.New("network error")
-			},
-			wantErrType: errors.New(""),
-		},
-		"error-response-invalid-json": {
-			issueIDOrKey: "PRJ-1",
-			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return mock.NewJSONResponse(fixture.InvalidJSON), nil
-			},
-			wantErrType: &json.SyntaxError{},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			method := mock.NewMethod(t)
-			if tc.mockGetFn != nil {
-				method.Get = tc.mockGetFn
-			}
-
-			s := issue.NewCommentService(method)
-
-			count, err := s.Count(context.Background(), tc.issueIDOrKey)
-
-			if tc.wantErrType != nil {
-				assert.Error(t, err)
-				assert.Zero(t, count)
-				assert.IsType(t, tc.wantErrType, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, tc.wantCount, count)
-		})
-	}
-}
-
-func TestCommentService_Notifications(t *testing.T) {
-	cases := map[string]struct {
-		issueIDOrKey string
-		commentID    int
-
-		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
-
-		wantErrType error
-		wantLen     int
-	}{
-		"success": {
-			issueIDOrKey: "PRJ-1",
-			commentID:    42,
-			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				assert.Equal(t, "issues/PRJ-1/comments/42/notifications", spath)
-				return mock.NewJSONResponse(`[{"id":1},{"id":2}]`), nil
-			},
-			wantLen: 2,
-		},
-		"error-empty-issueIDOrKey": {
-			issueIDOrKey: "",
-			commentID:    1,
-			wantErrType:  &core.ValidationError{},
-		},
-		"error-invalid-commentID": {
-			issueIDOrKey: "PRJ-1",
-			commentID:    0,
-			wantErrType:  &core.ValidationError{},
-		},
-		"error-client-network": {
-			issueIDOrKey: "PRJ-1",
-			commentID:    42,
-			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
-				return nil, errors.New("network error")
-			},
-			wantErrType: errors.New(""),
-		},
-		"error-response-invalid-json": {
-			issueIDOrKey: "PRJ-1",
-			commentID:    42,
-			mockGetFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				return mock.NewJSONResponse(fixture.InvalidJSON), nil
-			},
-			wantErrType: &json.SyntaxError{},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			method := mock.NewMethod(t)
-			if tc.mockGetFn != nil {
-				method.Get = tc.mockGetFn
-			}
-
-			s := issue.NewCommentService(method)
-
-			got, err := s.Notifications(context.Background(), tc.issueIDOrKey, tc.commentID)
-
-			if tc.wantErrType != nil {
-				assert.Error(t, err)
-				assert.Nil(t, got)
-				assert.IsType(t, tc.wantErrType, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Len(t, got, tc.wantLen)
-		})
-	}
-}
-
-func TestCommentService_Notify(t *testing.T) {
-	cases := map[string]struct {
-		issueIDOrKey string
-		commentID    int
-		userIDs      []int
 
 		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 
 		wantErrType error
 		wantID      int
 	}{
-		"success": {
+		"success-required-only": {
 			issueIDOrKey: "PRJ-1",
-			commentID:    42,
-			userIDs:      []int{5, 6},
+			content:      "This is a comment.",
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
-				assert.Equal(t, "issues/PRJ-1/comments/42/notifications", spath)
+				assert.Equal(t, "issues/PRJ-1/comments", spath)
+				assert.Equal(t, "This is a comment.", form.Get("content"))
+				return mock.NewCreatedJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			wantID: 1,
+		},
+		"success-with-notifiedUserIDs": {
+			issueIDOrKey: "PRJ-1",
+			content:      "Notifying users.",
+			opts:         []core.RequestOption{o.WithNotifiedUserIDs([]int{5, 6})},
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments", spath)
+				assert.Equal(t, "Notifying users.", form.Get("content"))
 				assert.Equal(t, []string{"5", "6"}, form["notifiedUserId[]"])
-				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
+				return mock.NewCreatedJSONResponse(fixture.Comment.SingleJSON), nil
 			},
 			wantID: 1,
 		},
 		"error-empty-issueIDOrKey": {
 			issueIDOrKey: "",
-			commentID:    1,
-			userIDs:      []int{5},
+			content:      "x",
 			wantErrType:  &core.ValidationError{},
 		},
-		"error-invalid-commentID": {
-			issueIDOrKey: "PRJ-1",
-			commentID:    0,
-			userIDs:      []int{5},
+		"error-zero-issueIDOrKey": {
+			issueIDOrKey: "0",
+			content:      "x",
 			wantErrType:  &core.ValidationError{},
 		},
-		"error-invalid-userID": {
+		"error-empty-content": {
 			issueIDOrKey: "PRJ-1",
-			commentID:    42,
-			userIDs:      []int{0},
+			content:      "",
 			wantErrType:  &core.ValidationError{},
+		},
+		"error-option-invalid-type": {
+			issueIDOrKey: "PRJ-1",
+			content:      "x",
+			opts:         []core.RequestOption{mock.NewInvalidTypeOption()},
+			wantErrType:  &core.InvalidOptionKeyError{},
 		},
 		"error-client-network": {
 			issueIDOrKey: "PRJ-1",
-			commentID:    42,
-			userIDs:      []int{5},
+			content:      "x",
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return nil, errors.New("network error")
 			},
@@ -323,8 +83,7 @@ func TestCommentService_Notify(t *testing.T) {
 		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
-			commentID:    42,
-			userIDs:      []int{5},
+			content:      "x",
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
 				return mock.NewJSONResponse(fixture.InvalidJSON), nil
 			},
@@ -343,7 +102,242 @@ func TestCommentService_Notify(t *testing.T) {
 
 			s := issue.NewCommentService(method)
 
-			got, err := s.Notify(context.Background(), tc.issueIDOrKey, tc.commentID, tc.userIDs)
+			got, err := s.Add(context.Background(), tc.issueIDOrKey, tc.content, tc.opts...)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}
+
+func TestCommentService_One(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+		commentID    int
+
+		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantID      int
+	}{
+		"success": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments/42", spath)
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			wantID: 1,
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			commentID:    1,
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-invalid-commentID": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    0,
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockGetFn != nil {
+				method.Get = tc.mockGetFn
+			}
+
+			s := issue.NewCommentService(method)
+
+			got, err := s.One(context.Background(), tc.issueIDOrKey, tc.commentID)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}
+
+func TestCommentService_Delete(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+		commentID    int
+
+		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantID      int
+	}{
+		"success": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments/42", spath)
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			wantID: 1,
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			commentID:    1,
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-invalid-commentID": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    0,
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockDeleteFn != nil {
+				method.Delete = tc.mockDeleteFn
+			}
+
+			s := issue.NewCommentService(method)
+
+			got, err := s.Delete(context.Background(), tc.issueIDOrKey, tc.commentID)
+
+			if tc.wantErrType != nil {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+				assert.IsType(t, tc.wantErrType, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}
+
+func TestCommentService_Update(t *testing.T) {
+	cases := map[string]struct {
+		issueIDOrKey string
+		commentID    int
+		content      string
+
+		mockPatchFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+
+		wantErrType error
+		wantID      int
+	}{
+		"success": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			content:      "Updated content.",
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				assert.Equal(t, "issues/PRJ-1/comments/42", spath)
+				assert.Equal(t, "Updated content.", form.Get("content"))
+				return mock.NewJSONResponse(fixture.Comment.SingleJSON), nil
+			},
+			wantID: 1,
+		},
+		"error-empty-issueIDOrKey": {
+			issueIDOrKey: "",
+			commentID:    1,
+			content:      "x",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-invalid-commentID": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    0,
+			content:      "x",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-empty-comment": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    1,
+			content:      "",
+			wantErrType:  &core.ValidationError{},
+		},
+		"error-client-network": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			content:      "x",
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+			wantErrType: errors.New(""),
+		},
+		"error-response-invalid-json": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			content:      "x",
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return mock.NewJSONResponse(fixture.InvalidJSON), nil
+			},
+			wantErrType: &json.SyntaxError{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			method := mock.NewMethod(t)
+			if tc.mockPatchFn != nil {
+				method.Patch = tc.mockPatchFn
+			}
+
+			s := issue.NewCommentService(method)
+
+			got, err := s.Update(context.Background(), tc.issueIDOrKey, tc.commentID, tc.content)
 
 			if tc.wantErrType != nil {
 				assert.Error(t, err)


### PR DESCRIPTION
## Summary

`issue/comment_service_test.go` was 696 lines. Extract CRUD operation tests into `comment_service_crud_test.go` to reduce file size.

`comment_service_test.go` retains `List`, `Count`, `Notifications`, and `Notify`.

## Changes

- Add `internal/domain/issue/comment_service_crud_test.go` with `TestCommentService_Add`, `TestCommentService_One`, `TestCommentService_Delete`, `TestCommentService_Update`
- Remove the above from `comment_service_test.go`