### PR TITLE
feat: validate mailAddress using net/mail.ParseAddress

### DIFF
--- a/internal/core/option_string.go
+++ b/internal/core/option_string.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"net/mail"
 	"net/url"
 )
 
@@ -73,8 +74,17 @@ func (s *OptionService) WithIssueSort(sort string) RequestOption {
 }
 
 func (s *OptionService) WithMailAddress(mailAddress string) RequestOption {
-	// ToDo: validate mailAddress (Note: The validation remains as simple not-empty check)
-	return nonEmptyStringOption(ParamMailAddress, mailAddress)
+	return &APIParamOption{
+		Type: ParamMailAddress,
+		CheckFunc: func() error {
+			addr, err := mail.ParseAddress(mailAddress)
+			if err != nil || addr.Address != mailAddress {
+				return NewValidationError(fmt.Sprintf("mailAddress %q is not a valid email address", mailAddress))
+			}
+			return nil
+		},
+		SetFunc: setStringFunc(ParamMailAddress, mailAddress),
+	}
 }
 
 func (s *OptionService) WithName(name string) RequestOption {

--- a/internal/core/option_string_test.go
+++ b/internal/core/option_string_test.go
@@ -109,6 +109,26 @@ func TestOptionService_string(t *testing.T) {
 			key:       core.ParamMailAddress.Value(),
 			wantValue: "test@example.com",
 		},
+		"WithMailAddress-valid-plus": {
+			option:    o.WithMailAddress("user+tag@example.co.jp"),
+			key:       core.ParamMailAddress.Value(),
+			wantValue: "user+tag@example.co.jp",
+		},
+		"WithMailAddress-invalid-no-at": {
+			option:  o.WithMailAddress("notanemail"),
+			key:     core.ParamMailAddress.Value(),
+			wantErr: true,
+		},
+		"WithMailAddress-invalid-display-name": {
+			option:  o.WithMailAddress("John Doe <john@example.com>"),
+			key:     core.ParamMailAddress.Value(),
+			wantErr: true,
+		},
+		"WithMailAddress-invalid-angle-bracket": {
+			option:  o.WithMailAddress("<john@example.com>"),
+			key:     core.ParamMailAddress.Value(),
+			wantErr: true,
+		},
 		"WithName-empty": {
 			option:  o.WithName(""),
 			key:     core.ParamName.Value(),

--- a/internal/domain/user/service_crud_test.go
+++ b/internal/domain/user/service_crud_test.go
@@ -129,7 +129,7 @@ func TestUserService_Add(t *testing.T) {
 			userID:      "userID",
 			password:    "password",
 			name:        "name",
-			mailAddress: "mailAdress",
+			mailAddress: "error@example.com",
 			roleType:    1,
 
 			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {


### PR DESCRIPTION
## Summary

Implement email address validation for `WithMailAddress` using `net/mail.ParseAddress` from the standard library (no external dependencies).

## Changes

- Replace the `// ToDo` no-op in `WithMailAddress` with a `CheckFunc` that calls `mail.ParseAddress` and verifies `addr.Address == mailAddress`
- This rejects display-name forms (`John Doe <john@example.com>`), angle-bracket-only forms (`<john@example.com>`), and obviously malformed strings, while accepting plain RFC-compliant addresses (`user+tag@example.co.jp`)
- Add test cases: `valid-plus`, `invalid-no-at`, `invalid-display-name`, `invalid-angle-bracket`

Closes #92