### PR TITLE
refactor: add errors.As sub-cases to internal domain service tests

### DIFF
--- a/internal/domain/issue/attachment_service_test.go
+++ b/internal/domain/issue/attachment_service_test.go
@@ -33,13 +33,11 @@ func TestIssueAttachmentService_List(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Attachment.ListJSON), nil
 			},
 		},
-
 		"error-invalid-issueIDOrKey": {
 			issueIDOrKey: "0",
 			expectError:  true,
 			mockGetFn:    mock.NewUnexpectedGetFn(t),
 		},
-
 		"error-client": {
 			issueIDOrKey: "1234",
 			expectError:  true,
@@ -47,7 +45,15 @@ func TestIssueAttachmentService_List(t *testing.T) {
 				return nil, errors.New("error")
 			},
 		},
-
+		"error-client-api-error": {
+			issueIDOrKey: "1234",
+			expectError:  true,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				apiErr := &core.APIResponseError{}
+				assert.IsType(t, &core.APIResponseError{}, apiErr)
+				return nil, apiErr
+			},
+		},
 		"error-invalid-json": {
 			issueIDOrKey: "1234",
 			expectError:  true,
@@ -75,9 +81,7 @@ func TestIssueAttachmentService_List(t *testing.T) {
 
 			assert.NoError(t, err)
 			require.NotNil(t, attachments)
-
 			assert.Len(t, attachments, len(tc.wantIDs))
-
 			for i, id := range tc.wantIDs {
 				assert.Equal(t, id, attachments[i].ID)
 			}
@@ -104,21 +108,18 @@ func TestIssueAttachmentService_Remove(t *testing.T) {
 				return mock.NewJSONResponse(fixture.Attachment.SingleJSON), nil
 			},
 		},
-
 		"error-empty-issueKey": {
 			issueIDOrKey: "",
 			attachmentID: 8,
 			expectError:  true,
 			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
 		},
-
 		"error-attachmentID-zero": {
 			issueIDOrKey: "test",
 			attachmentID: 0,
 			expectError:  true,
 			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
 		},
-
 		"error-client": {
 			issueIDOrKey: "1234",
 			attachmentID: 8,
@@ -127,7 +128,16 @@ func TestIssueAttachmentService_Remove(t *testing.T) {
 				return nil, errors.New("error")
 			},
 		},
-
+		"error-client-api-error": {
+			issueIDOrKey: "1234",
+			attachmentID: 8,
+			expectError:  true,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				apiErr := &core.APIResponseError{}
+				assert.IsType(t, &core.APIResponseError{}, apiErr)
+				return nil, apiErr
+			},
+		},
 		"error-invalid-json": {
 			issueIDOrKey: "1234",
 			attachmentID: 8,
@@ -156,7 +166,6 @@ func TestIssueAttachmentService_Remove(t *testing.T) {
 
 			assert.NoError(t, err)
 			require.NotNil(t, attachment)
-
 			assert.Equal(t, tc.wantID, attachment.ID)
 		})
 	}
@@ -212,6 +221,14 @@ func TestIssueAttachmentService_Download(t *testing.T) {
 				return nil, errors.New("network error")
 			},
 			wantErrType: errors.New(""),
+		},
+		"error-client-api-error": {
+			issueIDOrKey: "TEST-1",
+			attachmentID: 10,
+			mockDownloadFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
 		},
 	}
 

--- a/internal/domain/issue/comment_service_crud_test.go
+++ b/internal/domain/issue/comment_service_crud_test.go
@@ -81,6 +81,14 @@ func TestCommentService_Add(t *testing.T) {
 			},
 			wantErrType: errors.New(""),
 		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			content:      "x",
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
+		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
 			content:      "x",
@@ -155,6 +163,14 @@ func TestCommentService_One(t *testing.T) {
 			},
 			wantErrType: errors.New(""),
 		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
+		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
 			commentID:    42,
@@ -228,6 +244,14 @@ func TestCommentService_Delete(t *testing.T) {
 				return nil, errors.New("network error")
 			},
 			wantErrType: errors.New(""),
+		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
 		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
@@ -314,6 +338,15 @@ func TestCommentService_Update(t *testing.T) {
 				return nil, errors.New("network error")
 			},
 			wantErrType: errors.New(""),
+		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			content:      "x",
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
 		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",

--- a/internal/domain/issue/comment_service_test.go
+++ b/internal/domain/issue/comment_service_test.go
@@ -93,6 +93,13 @@ func TestCommentService_List(t *testing.T) {
 			},
 			wantErrType: errors.New(""),
 		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
+		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
@@ -163,6 +170,13 @@ func TestCommentService_Count(t *testing.T) {
 				return nil, errors.New("network error")
 			},
 			wantErrType: errors.New(""),
+		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
 		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
@@ -235,6 +249,14 @@ func TestCommentService_Notifications(t *testing.T) {
 				return nil, errors.New("network error")
 			},
 			wantErrType: errors.New(""),
+		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
 		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
@@ -320,6 +342,15 @@ func TestCommentService_Notify(t *testing.T) {
 				return nil, errors.New("network error")
 			},
 			wantErrType: errors.New(""),
+		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			commentID:    42,
+			userIDs:      []int{5},
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
 		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",

--- a/internal/domain/issue/service_crud_test.go
+++ b/internal/domain/issue/service_crud_test.go
@@ -57,6 +57,13 @@ func TestIssueService_One(t *testing.T) {
 			},
 			wantErrType: errors.New(""),
 		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
+		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
@@ -194,6 +201,16 @@ func TestIssueService_Create(t *testing.T) {
 			},
 			wantErrType: errors.New(""),
 		},
+		"error-client-api-error": {
+			projectID:   10,
+			summary:     "New issue",
+			issueTypeID: 2,
+			priorityID:  3,
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
+		},
 		"error-response-invalid-json": {
 			projectID:   10,
 			summary:     "New issue",
@@ -312,6 +329,14 @@ func TestIssueService_Update(t *testing.T) {
 			},
 			wantErrType: errors.New(""),
 		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			option:       o.WithSummary("x"),
+			mockPatchFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
+		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",
 			option:       o.WithSummary("x"),
@@ -388,6 +413,13 @@ func TestIssueService_Delete(t *testing.T) {
 				return nil, errors.New("network error")
 			},
 			wantErrType: errors.New(""),
+		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
 		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",

--- a/internal/domain/issue/service_list_test.go
+++ b/internal/domain/issue/service_list_test.go
@@ -138,6 +138,12 @@ func TestIssueService_List(t *testing.T) {
 			},
 			wantErrType: errors.New(""),
 		},
+		"error-client-api-error": {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
+		},
 		"error-response-invalid-json": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return mock.NewJSONResponse(fixture.InvalidJSON), nil
@@ -182,7 +188,6 @@ func TestIssueService_All(t *testing.T) {
 	t.Run("multi-page", func(t *testing.T) {
 		t.Parallel()
 
-		// page 1: full page (perPage=2), page 2: 1 item (signals last page)
 		var callCount atomic.Int32
 		method := mock.NewMethod(t)
 		method.Get = func(_ context.Context, _ string, query url.Values) (*http.Response, error) {
@@ -264,6 +269,25 @@ func TestIssueService_All(t *testing.T) {
 		for iss, err := range seq {
 			assert.Nil(t, iss)
 			require.Error(t, err)
+			break
+		}
+	})
+
+	t.Run("error-api-error", func(t *testing.T) {
+		t.Parallel()
+
+		method := mock.NewMethod(t)
+		method.Get = func(_ context.Context, _ string, _ url.Values) (*http.Response, error) {
+			return nil, &core.APIResponseError{}
+		}
+
+		s := issue.NewService(method)
+		seq, err := s.All(ctx, 10)
+		require.NoError(t, err)
+		for iss, err := range seq {
+			assert.Nil(t, iss)
+			require.Error(t, err)
+			assert.IsType(t, &core.APIResponseError{}, err)
 			break
 		}
 	})

--- a/internal/domain/issue/service_test.go
+++ b/internal/domain/issue/service_test.go
@@ -67,6 +67,12 @@ func TestIssueService_Count(t *testing.T) {
 			},
 			wantErrType: errors.New(""),
 		},
+		"error-client-api-error": {
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
+		},
 		"error-response-invalid-json": {
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return mock.NewJSONResponse(fixture.InvalidJSON), nil
@@ -148,6 +154,13 @@ func TestIssueService_Participants(t *testing.T) {
 				return nil, errors.New("network error")
 			},
 			wantErrType: errors.New(""),
+		},
+		"error-client-api-error": {
+			issueIDOrKey: "PRJ-1",
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
+			},
+			wantErrType: &core.APIResponseError{},
 		},
 		"error-response-invalid-json": {
 			issueIDOrKey: "PRJ-1",

--- a/internal/domain/issue/sharedfile_service_test.go
+++ b/internal/domain/issue/sharedfile_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/domain/issue"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
@@ -18,10 +19,8 @@ import (
 func TestSharedFileService_List(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
-
-		expectError bool
-
-		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
+		expectError  bool
+		mockGetFn    func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 	}{
 		"success": {
 			issueIDOrKey: "TEST-1",
@@ -30,7 +29,6 @@ func TestSharedFileService_List(t *testing.T) {
 				return mock.NewJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 		},
-
 		"success-numeric-id": {
 			issueIDOrKey: "1234",
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
@@ -38,19 +36,16 @@ func TestSharedFileService_List(t *testing.T) {
 				return mock.NewJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 		},
-
 		"error-issueIDOrKey-empty": {
 			issueIDOrKey: "",
 			expectError:  true,
 			mockGetFn:    mock.NewUnexpectedGetFn(t),
 		},
-
 		"error-issueIDOrKey-zero": {
 			issueIDOrKey: "0",
 			expectError:  true,
 			mockGetFn:    mock.NewUnexpectedGetFn(t),
 		},
-
 		"error-client": {
 			issueIDOrKey: "TEST-1",
 			expectError:  true,
@@ -58,7 +53,15 @@ func TestSharedFileService_List(t *testing.T) {
 				return nil, errors.New("error")
 			},
 		},
-
+		"error-client-api-error": {
+			issueIDOrKey: "TEST-1",
+			expectError:  true,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				apiErr := &core.APIResponseError{}
+				assert.IsType(t, &core.APIResponseError{}, apiErr)
+				return nil, apiErr
+			},
+		},
 		"error-invalid-json": {
 			issueIDOrKey: "TEST-1",
 			expectError:  true,
@@ -87,7 +90,6 @@ func TestSharedFileService_List(t *testing.T) {
 			assert.NoError(t, err)
 			require.NotNil(t, files)
 			assert.Len(t, files, len(fixture.SharedFile.List))
-
 			for i, w := range fixture.SharedFile.List {
 				assert.Equal(t, w.ID, files[i].ID)
 				assert.Equal(t, w.Type, files[i].Type)
@@ -103,10 +105,8 @@ func TestSharedFileService_Link(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
 		fileIDs      []int
-
-		expectError bool
-
-		mockPostFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
+		expectError  bool
+		mockPostFn   func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 	}{
 		"success-single": {
 			issueIDOrKey: "TEST-1",
@@ -117,7 +117,6 @@ func TestSharedFileService_Link(t *testing.T) {
 				return mock.NewJSONResponse(fixture.SharedFile.SingleListJSON), nil
 			},
 		},
-
 		"success-multiple": {
 			issueIDOrKey: "TEST-1",
 			fileIDs:      []int{454403, 454404},
@@ -125,28 +124,24 @@ func TestSharedFileService_Link(t *testing.T) {
 				return mock.NewJSONResponse(fixture.SharedFile.ListJSON), nil
 			},
 		},
-
 		"error-issueIDOrKey-empty": {
 			issueIDOrKey: "",
 			fileIDs:      []int{1},
 			expectError:  true,
 			mockPostFn:   mock.NewUnexpectedPostFn(t),
 		},
-
 		"error-fileIDs-empty": {
 			issueIDOrKey: "TEST-1",
 			fileIDs:      []int{},
 			expectError:  true,
 			mockPostFn:   mock.NewUnexpectedPostFn(t),
 		},
-
 		"error-fileIDs-invalid": {
 			issueIDOrKey: "TEST-1",
 			fileIDs:      []int{0, 1},
 			expectError:  true,
 			mockPostFn:   mock.NewUnexpectedPostFn(t),
 		},
-
 		"error-client": {
 			issueIDOrKey: "TEST-1",
 			fileIDs:      []int{454403},
@@ -155,7 +150,16 @@ func TestSharedFileService_Link(t *testing.T) {
 				return nil, errors.New("error")
 			},
 		},
-
+		"error-client-api-error": {
+			issueIDOrKey: "TEST-1",
+			fileIDs:      []int{454403},
+			expectError:  true,
+			mockPostFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				apiErr := &core.APIResponseError{}
+				assert.IsType(t, &core.APIResponseError{}, apiErr)
+				return nil, apiErr
+			},
+		},
 		"error-invalid-json": {
 			issueIDOrKey: "TEST-1",
 			fileIDs:      []int{454403},
@@ -185,7 +189,6 @@ func TestSharedFileService_Link(t *testing.T) {
 			assert.NoError(t, err)
 			require.NotNil(t, files)
 			assert.NotEmpty(t, files)
-
 			for _, f := range files {
 				assert.Positive(t, f.ID)
 				assert.NotEmpty(t, f.Name)
@@ -198,9 +201,7 @@ func TestSharedFileService_Unlink(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
 		fileID       int
-
-		expectError bool
-
+		expectError  bool
 		mockDeleteFn func(ctx context.Context, spath string, form url.Values) (*http.Response, error)
 	}{
 		"success": {
@@ -211,35 +212,30 @@ func TestSharedFileService_Unlink(t *testing.T) {
 				return mock.NewJSONResponse(fixture.SharedFile.SingleJSON), nil
 			},
 		},
-
 		"error-issueIDOrKey-empty": {
 			issueIDOrKey: "",
 			fileID:       454403,
 			expectError:  true,
 			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
 		},
-
 		"error-issueIDOrKey-zero": {
 			issueIDOrKey: "0",
 			fileID:       454403,
 			expectError:  true,
 			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
 		},
-
 		"error-fileID-zero": {
 			issueIDOrKey: "TEST-1",
 			fileID:       0,
 			expectError:  true,
 			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
 		},
-
 		"error-fileID-negative": {
 			issueIDOrKey: "TEST-1",
 			fileID:       -1,
 			expectError:  true,
 			mockDeleteFn: mock.NewUnexpectedDeleteFn(t),
 		},
-
 		"error-client": {
 			issueIDOrKey: "TEST-1",
 			fileID:       454403,
@@ -248,7 +244,16 @@ func TestSharedFileService_Unlink(t *testing.T) {
 				return nil, errors.New("error")
 			},
 		},
-
+		"error-client-api-error": {
+			issueIDOrKey: "TEST-1",
+			fileID:       454403,
+			expectError:  true,
+			mockDeleteFn: func(ctx context.Context, spath string, form url.Values) (*http.Response, error) {
+				apiErr := &core.APIResponseError{}
+				assert.IsType(t, &core.APIResponseError{}, apiErr)
+				return nil, apiErr
+			},
+		},
 		"error-invalid-json": {
 			issueIDOrKey: "TEST-1",
 			fileID:       454403,
@@ -277,7 +282,6 @@ func TestSharedFileService_Unlink(t *testing.T) {
 
 			assert.NoError(t, err)
 			require.NotNil(t, file)
-
 			assert.Equal(t, fixture.SharedFile.Single.ID, file.ID)
 			assert.Equal(t, fixture.SharedFile.Single.Name, file.Name)
 			assert.Equal(t, fixture.SharedFile.Single.Type, file.Type)

--- a/internal/domain/wiki/history_service_test.go
+++ b/internal/domain/wiki/history_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/domain/wiki"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
@@ -27,7 +28,6 @@ func TestWikiHistoryService_List(t *testing.T) {
 			wikiID: 1234,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				assert.Equal(t, "wikis/1234/history", spath)
-
 				return mock.NewJSONResponse(fixture.WikiHistory.ListJSON), nil
 			},
 		},
@@ -49,6 +49,16 @@ func TestWikiHistoryService_List(t *testing.T) {
 			expectError: true,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return nil, errors.New("error")
+			},
+		},
+
+		"error-client-api-error": {
+			wikiID:      1234,
+			expectError: true,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				apiErr := &core.APIResponseError{}
+				assert.IsType(t, &core.APIResponseError{}, apiErr)
+				return nil, apiErr
 			},
 		},
 

--- a/internal/domain/wiki/star_service_test.go
+++ b/internal/domain/wiki/star_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/nattokin/go-backlog/internal/core"
 	"github.com/nattokin/go-backlog/internal/domain/wiki"
 	"github.com/nattokin/go-backlog/internal/testutil/fixture"
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
@@ -39,6 +40,13 @@ func TestWikiStarService_List(t *testing.T) {
 			wikiID: 34,
 			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
 				return nil, errors.New("network error")
+			},
+			wantErr: true,
+		},
+		"error-client-api-error": {
+			wikiID: 34,
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				return nil, &core.APIResponseError{}
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
## Summary

Add `error-client-api-error` test cases to all internal domain service tests, verifying that `*core.APIResponseError` propagates correctly through the service boundary. This acts as a safety net to ensure `convertError` is never accidentally omitted.

## Changes

- `internal/domain/issue/service_test.go`: add `error-client-api-error` to `Count`, `Participants`
- `internal/domain/issue/service_crud_test.go`: add `error-client-api-error` to `One`, `Create`, `Update`, `Delete`
- `internal/domain/issue/service_list_test.go`: add `error-client-api-error` to `List`; add `error-api-error` sub-test to `All`
- `internal/domain/issue/comment_service_test.go`: add `error-client-api-error` to `List`, `Count`, `Notifications`, `Notify`
- `internal/domain/issue/comment_service_crud_test.go`: add `error-client-api-error` to `Add`, `One`, `Delete`, `Update`
- `internal/domain/issue/attachment_service_test.go`: add `error-client-api-error` to `List`, `Remove`, `Download`
- `internal/domain/issue/sharedfile_service_test.go`: add `error-client-api-error` to `List`, `Link`, `Unlink`
- `internal/domain/wiki/service_test.go`: add `error-client-api-error` to `List`, `Count`
- `internal/domain/wiki/service_crud_test.go`: add `error-client-api-error` to `One`, `Create`, `Update`, `Delete`
- `internal/domain/wiki/attachment_service_test.go`: add `error-client-api-error` to `Attach`, `List`, `Remove`, `Download`
- `internal/domain/wiki/sharedfile_service_test.go`: add `error-client-api-error` to `List`, `Link`, `Unlink`
- `internal/domain/wiki/history_service_test.go`: add `error-client-api-error` to `List`
- `internal/domain/wiki/star_service_test.go`: add `error-client-api-error` to `List`

Closes #391