### PR TITLE
chore: rename TestXxxService_ to TestService_ in internal/domain tests

### DIFF
--- a/internal/domain/issue/service_crud_test.go
+++ b/internal/domain/issue/service_crud_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestIssueService_One(t *testing.T) {
+func TestService_One(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
 
@@ -100,7 +100,7 @@ func TestIssueService_One(t *testing.T) {
 	}
 }
 
-func TestIssueService_Create(t *testing.T) {
+func TestService_Create(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -250,7 +250,7 @@ func TestIssueService_Create(t *testing.T) {
 	}
 }
 
-func TestIssueService_Update(t *testing.T) {
+func TestService_Update(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -374,7 +374,7 @@ func TestIssueService_Update(t *testing.T) {
 	}
 }
 
-func TestIssueService_Delete(t *testing.T) {
+func TestService_Delete(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
 

--- a/internal/domain/issue/service_list_test.go
+++ b/internal/domain/issue/service_list_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestIssueService_List(t *testing.T) {
+func TestService_List(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -182,7 +182,7 @@ func TestIssueService_List(t *testing.T) {
 	}
 }
 
-func TestIssueService_All(t *testing.T) {
+func TestService_All(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("multi-page", func(t *testing.T) {

--- a/internal/domain/issue/service_test.go
+++ b/internal/domain/issue/service_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestIssueService_Count(t *testing.T) {
+func TestService_Count(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -107,7 +107,7 @@ func TestIssueService_Count(t *testing.T) {
 	}
 }
 
-func TestIssueService_Participants(t *testing.T) {
+func TestService_Participants(t *testing.T) {
 	cases := map[string]struct {
 		issueIDOrKey string
 

--- a/internal/domain/pullrequest/service_crud_test.go
+++ b/internal/domain/pullrequest/service_crud_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestPullRequestService_One(t *testing.T) {
+func TestService_One(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 		repoIDOrName   string
@@ -102,7 +102,7 @@ func TestPullRequestService_One(t *testing.T) {
 	}
 }
 
-func TestPullRequestService_Create(t *testing.T) {
+func TestService_Create(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -273,7 +273,7 @@ func TestPullRequestService_Create(t *testing.T) {
 	}
 }
 
-func TestPullRequestService_Update(t *testing.T) {
+func TestService_Update(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {

--- a/internal/domain/pullrequest/service_list_test.go
+++ b/internal/domain/pullrequest/service_list_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestPullRequestService_List(t *testing.T) {
+func TestService_List(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -157,7 +157,7 @@ func TestPullRequestService_List(t *testing.T) {
 	}
 }
 
-func TestPullRequestService_All(t *testing.T) {
+func TestService_All(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("multi-page", func(t *testing.T) {

--- a/internal/domain/pullrequest/service_test.go
+++ b/internal/domain/pullrequest/service_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestPullRequestService_Count(t *testing.T) {
+func TestService_Count(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {

--- a/internal/domain/repository/service_test.go
+++ b/internal/domain/repository/service_test.go
@@ -22,7 +22,7 @@ const (
 	testRepo    = "repo1"
 )
 
-func TestRepositoryService_List(t *testing.T) {
+func TestService_List(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 
@@ -92,7 +92,7 @@ func TestRepositoryService_List(t *testing.T) {
 	}
 }
 
-func TestRepositoryService_One(t *testing.T) {
+func TestService_One(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 		repoIDOrName   string

--- a/internal/domain/space/service_test.go
+++ b/internal/domain/space/service_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestSpaceService_Info(t *testing.T) {
+func TestService_Info(t *testing.T) {
 	cases := map[string]struct {
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
@@ -78,7 +78,7 @@ func TestSpaceService_Info(t *testing.T) {
 	}
 }
 
-func TestSpaceService_DiskUsage(t *testing.T) {
+func TestService_DiskUsage(t *testing.T) {
 	cases := map[string]struct {
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
@@ -142,7 +142,7 @@ func TestSpaceService_DiskUsage(t *testing.T) {
 	}
 }
 
-func TestSpaceService_Notification(t *testing.T) {
+func TestService_Notification(t *testing.T) {
 	cases := map[string]struct {
 		mockGetFn func(ctx context.Context, spath string, query url.Values) (*http.Response, error)
 
@@ -200,7 +200,7 @@ func TestSpaceService_Notification(t *testing.T) {
 	}
 }
 
-func TestSpaceService_UpdateNotification(t *testing.T) {
+func TestService_UpdateNotification(t *testing.T) {
 	cases := map[string]struct {
 		content string
 

--- a/internal/domain/wiki/service_crud_test.go
+++ b/internal/domain/wiki/service_crud_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestWikiService_One(t *testing.T) {
+func TestService_One(t *testing.T) {
 	cases := map[string]struct {
 		wikiID int
 
@@ -94,7 +94,7 @@ func TestWikiService_One(t *testing.T) {
 	}
 }
 
-func TestWikiService_Create(t *testing.T) {
+func TestService_Create(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -229,7 +229,7 @@ func TestWikiService_Create(t *testing.T) {
 	}
 }
 
-func TestWikiService_Update(t *testing.T) {
+func TestService_Update(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -370,7 +370,7 @@ func TestWikiService_Update(t *testing.T) {
 	}
 }
 
-func TestWikiService_Delete(t *testing.T) {
+func TestService_Delete(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {

--- a/internal/domain/wiki/service_test.go
+++ b/internal/domain/wiki/service_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nattokin/go-backlog/internal/testutil/mock"
 )
 
-func TestWikiService_List(t *testing.T) {
+func TestService_List(t *testing.T) {
 	o := &core.OptionService{}
 
 	cases := map[string]struct {
@@ -124,7 +124,7 @@ func TestWikiService_List(t *testing.T) {
 	}
 }
 
-func TestWikiService_Count(t *testing.T) {
+func TestService_Count(t *testing.T) {
 	cases := map[string]struct {
 		projectIDOrKey string
 


### PR DESCRIPTION
## Summary

Rename test functions in `internal/domain` packages from `TestXxxService_Method` to `TestService_Method`. Since each test file already lives in its own domain package (e.g. `internal/domain/issue`), the service type name in the function prefix is redundant.

## Changes

- `internal/domain/issue`: rename `TestIssueService_*` → `TestService_*` (6 functions)
- `internal/domain/pullrequest`: rename `TestPullRequestService_*` → `TestService_*` (6 functions)
- `internal/domain/repository`: rename `TestRepositoryService_*` → `TestService_*` (2 functions)
- `internal/domain/space`: rename `TestSpaceService_*` → `TestService_*` (4 functions)
- `internal/domain/wiki`: rename `TestWikiService_*` → `TestService_*` (4 functions)