### PR TITLE
refactor: extract package-level validTypes variables in issue service

### DIFF
--- a/internal/domain/issue/service.go
+++ b/internal/domain/issue/service.go
@@ -14,44 +14,6 @@ import (
 	"github.com/nattokin/go-backlog/internal/validate"
 )
 
-// filterValidTypes are the options accepted by both List and All (filter + sort params,
-// excluding WithOffset and WithCount).
-var filterValidTypes = []core.APIParamOptionType{
-	core.ParamProjectIDs,
-	core.ParamIssueTypeIDs,
-	core.ParamCategoryIDs,
-	core.ParamVersionIDs,
-	core.ParamMilestoneIDs,
-	core.ParamStatusIDs,
-	core.ParamPriorityIDs,
-	core.ParamAssigneeIDs,
-	core.ParamCreatedUserIDs,
-	core.ParamResolutionIDs,
-	core.ParamParentChild,
-	core.ParamAttachment,
-	core.ParamSharedFile,
-	core.ParamSort,
-	core.ParamOrder,
-	core.ParamCreatedSince,
-	core.ParamCreatedUntil,
-	core.ParamUpdatedSince,
-	core.ParamUpdatedUntil,
-	core.ParamStartDateSince,
-	core.ParamStartDateUntil,
-	core.ParamDueDateSince,
-	core.ParamDueDateUntil,
-	core.ParamHasDueDate,
-	core.ParamIDs,
-	core.ParamParentIssueIDs,
-	core.ParamKeyword,
-}
-
-// listValidTypes are the options accepted by List (filter/sort params + pagination).
-var listValidTypes = append(filterValidTypes,
-	core.ParamOffset,
-	core.ParamCount,
-)
-
 // countValidTypes are the options accepted by Count (filter params only,
 // excluding sort and pagination).
 var countValidTypes = []core.APIParamOptionType{
@@ -81,6 +43,18 @@ var countValidTypes = []core.APIParamOptionType{
 	core.ParamParentIssueIDs,
 	core.ParamKeyword,
 }
+
+// filterValidTypes are the options accepted by All (countValidTypes plus sort and order).
+var filterValidTypes = append(countValidTypes,
+	core.ParamSort,
+	core.ParamOrder,
+)
+
+// listValidTypes are the options accepted by List (filterValidTypes plus pagination).
+var listValidTypes = append(filterValidTypes,
+	core.ParamOffset,
+	core.ParamCount,
+)
 
 // createValidTypes are the options accepted by Create.
 var createValidTypes = []core.APIParamOptionType{

--- a/internal/domain/issue/service.go
+++ b/internal/domain/issue/service.go
@@ -52,6 +52,64 @@ var listValidTypes = append(filterValidTypes,
 	core.ParamCount,
 )
 
+// countValidTypes are the options accepted by Count (filter params only,
+// excluding sort and pagination).
+var countValidTypes = []core.APIParamOptionType{
+	core.ParamProjectIDs,
+	core.ParamIssueTypeIDs,
+	core.ParamCategoryIDs,
+	core.ParamVersionIDs,
+	core.ParamMilestoneIDs,
+	core.ParamStatusIDs,
+	core.ParamPriorityIDs,
+	core.ParamAssigneeIDs,
+	core.ParamCreatedUserIDs,
+	core.ParamResolutionIDs,
+	core.ParamParentChild,
+	core.ParamAttachment,
+	core.ParamSharedFile,
+	core.ParamCreatedSince,
+	core.ParamCreatedUntil,
+	core.ParamUpdatedSince,
+	core.ParamUpdatedUntil,
+	core.ParamStartDateSince,
+	core.ParamStartDateUntil,
+	core.ParamDueDateSince,
+	core.ParamDueDateUntil,
+	core.ParamHasDueDate,
+	core.ParamIDs,
+	core.ParamParentIssueIDs,
+	core.ParamKeyword,
+}
+
+// createValidTypes are the options accepted by Create.
+var createValidTypes = []core.APIParamOptionType{
+	core.ParamSummary,
+	core.ParamIssueTypeID,
+	core.ParamPriorityID,
+	core.ParamDescription,
+	core.ParamStartDate,
+	core.ParamDueDate,
+	core.ParamEstimatedHours,
+	core.ParamActualHours,
+	core.ParamCategoryIDs,
+	core.ParamVersionIDs,
+	core.ParamMilestoneIDs,
+	core.ParamAssigneeID,
+	core.ParamParentIssueID,
+	core.ParamNotifiedUserIDs,
+	core.ParamAttachmentIDs,
+	core.ParamCustomField,
+}
+
+// updateValidTypes are the options accepted by Update (createValidTypes plus
+// status, resolution, and comment).
+var updateValidTypes = append(createValidTypes,
+	core.ParamStatusID,
+	core.ParamResolutionID,
+	core.ParamComment,
+)
+
 // Service handles issue-related Backlog API calls.
 type Service struct {
 	method *core.Method
@@ -116,34 +174,7 @@ func (s *Service) All(ctx context.Context, perPage int, opts ...core.RequestOpti
 // Backlog API docs: https://developer.nulab.com/docs/backlog/api/2/count-issue
 func (s *Service) Count(ctx context.Context, opts ...core.RequestOption) (int, error) {
 	query := url.Values{}
-	validTypes := []core.APIParamOptionType{
-		core.ParamProjectIDs,
-		core.ParamIssueTypeIDs,
-		core.ParamCategoryIDs,
-		core.ParamVersionIDs,
-		core.ParamMilestoneIDs,
-		core.ParamStatusIDs,
-		core.ParamPriorityIDs,
-		core.ParamAssigneeIDs,
-		core.ParamCreatedUserIDs,
-		core.ParamResolutionIDs,
-		core.ParamParentChild,
-		core.ParamAttachment,
-		core.ParamSharedFile,
-		core.ParamCreatedSince,
-		core.ParamCreatedUntil,
-		core.ParamUpdatedSince,
-		core.ParamUpdatedUntil,
-		core.ParamStartDateSince,
-		core.ParamStartDateUntil,
-		core.ParamDueDateSince,
-		core.ParamDueDateUntil,
-		core.ParamHasDueDate,
-		core.ParamIDs,
-		core.ParamParentIssueIDs,
-		core.ParamKeyword,
-	}
-	if err := core.ApplyOptions(query, validTypes, opts...); err != nil {
+	if err := core.ApplyOptions(query, countValidTypes, opts...); err != nil {
 		return 0, err
 	}
 
@@ -192,24 +223,6 @@ func (s *Service) Create(ctx context.Context, projectID int, summary string, iss
 
 	o := &core.OptionService{}
 	form := url.Values{}
-	validTypes := []core.APIParamOptionType{
-		core.ParamSummary,
-		core.ParamIssueTypeID,
-		core.ParamPriorityID,
-		core.ParamDescription,
-		core.ParamStartDate,
-		core.ParamDueDate,
-		core.ParamEstimatedHours,
-		core.ParamActualHours,
-		core.ParamCategoryIDs,
-		core.ParamVersionIDs,
-		core.ParamMilestoneIDs,
-		core.ParamAssigneeID,
-		core.ParamParentIssueID,
-		core.ParamNotifiedUserIDs,
-		core.ParamAttachmentIDs,
-		core.ParamCustomField,
-	}
 	options := append(
 		[]core.RequestOption{
 			o.WithSummary(summary),
@@ -218,7 +231,7 @@ func (s *Service) Create(ctx context.Context, projectID int, summary string, iss
 		},
 		opts...,
 	)
-	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
+	if err := core.ApplyOptions(form, createValidTypes, options...); err != nil {
 		return nil, err
 	}
 
@@ -246,29 +259,8 @@ func (s *Service) Update(ctx context.Context, issueIDOrKey string, option core.R
 	}
 
 	form := url.Values{}
-	validTypes := []core.APIParamOptionType{
-		core.ParamSummary,
-		core.ParamDescription,
-		core.ParamIssueTypeID,
-		core.ParamCategoryIDs,
-		core.ParamVersionIDs,
-		core.ParamMilestoneIDs,
-		core.ParamStartDate,
-		core.ParamDueDate,
-		core.ParamEstimatedHours,
-		core.ParamActualHours,
-		core.ParamAssigneeID,
-		core.ParamParentIssueID,
-		core.ParamPriorityID,
-		core.ParamStatusID,
-		core.ParamResolutionID,
-		core.ParamNotifiedUserIDs,
-		core.ParamAttachmentIDs,
-		core.ParamComment,
-		core.ParamCustomField,
-	}
 	options := append([]core.RequestOption{option}, opts...)
-	if err := core.ApplyOptions(form, validTypes, options...); err != nil {
+	if err := core.ApplyOptions(form, updateValidTypes, options...); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Extract inline `validTypes` slices in `internal/domain/issue/service.go` to package-level variables, building each on top of the previous to form a clear hierarchy.

## Changes

- Add `countValidTypes`: base filter params (no sort, no pagination)
- Change `filterValidTypes` to `append(countValidTypes, ParamSort, ParamOrder)` — used by All
- Keep `listValidTypes` as `append(filterValidTypes, ParamOffset, ParamCount)` — used by List
- Add `createValidTypes`: write params accepted by Create
- Add `updateValidTypes`: `append(createValidTypes, ParamStatusID, ParamResolutionID, ParamComment)`
- Replace inline slices in `Count`, `Create`, and `Update` with the new package-level variables