### PR TITLE
refactor: add success-with-all-options cases for PullRequestService.List and All

### DIFF
--- a/internal/domain/pullrequest/service_list_test.go
+++ b/internal/domain/pullrequest/service_list_test.go
@@ -42,6 +42,28 @@ func TestService_List(t *testing.T) {
 			},
 			wantNumbers: []int{1, 2},
 		},
+		"success-with-all-options": {
+			projectIDOrKey: "PRJ",
+			repoIDOrName:   "repo1",
+			opts: []core.RequestOption{
+				o.WithStatusIDs([]int{1, 2}),
+				o.WithAssigneeIDs([]int{10}),
+				o.WithIssueIDs([]int{100}),
+				o.WithCreatedUserIDs([]int{11}),
+				o.WithOffset(5),
+				o.WithCount(50),
+			},
+			mockGetFn: func(ctx context.Context, spath string, query url.Values) (*http.Response, error) {
+				assert.Equal(t, []string{"1", "2"}, query["statusId[]"])
+				assert.Equal(t, []string{"10"}, query["assigneeId[]"])
+				assert.Equal(t, []string{"100"}, query["issueId[]"])
+				assert.Equal(t, []string{"11"}, query["createdUserId[]"])
+				assert.Equal(t, "5", query.Get("offset"))
+				assert.Equal(t, "50", query.Get("count"))
+				return mock.NewJSONResponse(fixture.PullRequest.ListJSON), nil
+			},
+			wantNumbers: []int{1, 2},
+		},
 		"success-with-statusIDs": {
 			projectIDOrKey: "PRJ",
 			repoIDOrName:   "repo1",
@@ -199,6 +221,37 @@ func TestService_All(t *testing.T) {
 
 		assert.Equal(t, int32(2), callCount.Load())
 		assert.Equal(t, []int{1, 2, 3}, got)
+	})
+
+	t.Run("success-with-all-options", func(t *testing.T) {
+		t.Parallel()
+
+		o := &core.OptionService{}
+		method := mock.NewMethod(t)
+		method.Get = func(_ context.Context, _ string, query url.Values) (*http.Response, error) {
+			assert.Equal(t, []string{"1", "2"}, query["statusId[]"])
+			assert.Equal(t, []string{"10"}, query["assigneeId[]"])
+			assert.Equal(t, []string{"100"}, query["issueId[]"])
+			assert.Equal(t, []string{"11"}, query["createdUserId[]"])
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(pullRequestLastPageJSON)),
+			}, nil
+		}
+
+		s := pullrequest.NewService(method)
+		seq, err := s.All(ctx, 10, "PRJ", "repo1",
+			o.WithStatusIDs([]int{1, 2}),
+			o.WithAssigneeIDs([]int{10}),
+			o.WithIssueIDs([]int{100}),
+			o.WithCreatedUserIDs([]int{11}),
+		)
+		require.NoError(t, err)
+		for pr, err := range seq {
+			require.NoError(t, err)
+			assert.NotNil(t, pr)
+			break
+		}
 	})
 
 	t.Run("break", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Add `"success-with-all-options"` test cases to `TestService_List` and `TestService_All` in `internal/domain/pullrequest/service_list_test.go`.

The intent is not to re-test individual option validation logic (that is covered by `core/option_*_test.go`), but to verify that the service layer accepts every option that appears in `listValidTypes` / `filterValidTypes`. Previously, `assigneeId[]`, `issueId[]`, and `createdUserId[]` had no success-path coverage at all.

## Changes

- `TestService_List`: add `"success-with-all-options"` table case covering all 6 options in `listValidTypes` (`statusId[]`, `assigneeId[]`, `issueId[]`, `createdUserId[]`, `offset`, `count`) and asserting each query parameter is set correctly
- `TestService_All`: add `"success-with-all-options"` sub-test covering all 4 options in `filterValidTypes` (`statusId[]`, `assigneeId[]`, `issueId[]`, `createdUserId[]`; excludes `count` and `offset`, which `All` intentionally rejects)

Closes #404
