### PR TITLE
refactor: rename Mock-prefixed types in mock package

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -38,7 +38,7 @@ func TestNewClient(t *testing.T) {
 	})
 
 	t.Run("with-doer", func(t *testing.T) {
-		mockDoer := &mock.MockDoer{T: t,
+		mockDoer := &mock.Doer{T: t,
 			DoFunc: func(_ *http.Request) (*http.Response, error) { return nil, nil },
 		}
 		c, err := NewClient(baseURL, token, WithDoer(mockDoer))

--- a/internal/core/client_test.go
+++ b/internal/core/client_test.go
@@ -82,7 +82,7 @@ func TestNewClient_initialization(t *testing.T) {
 	t.Run("with-Doer", func(t *testing.T) {
 		t.Parallel()
 
-		mockDoer := &mock.MockDoer{T: t,
+		mockDoer := &mock.Doer{T: t,
 			DoFunc: func(_ *http.Request) (*http.Response, error) { return nil, errors.New("mockDoer error") },
 		}
 		c, err := core.NewClient(baseURL, token, core.WithDoer(mockDoer))
@@ -562,7 +562,7 @@ func TestClient_methodUpload_errors(t *testing.T) {
 			fileName: "filename",
 			fileData: "dummy",
 			setup: func(c *core.Client) {
-				c.Wrapper = mock.MockWrapper{CreateErr: errors.New("mock createFormFile error")}
+				c.Wrapper = mock.Wrapper{CreateErr: errors.New("mock createFormFile error")}
 			},
 		},
 
@@ -571,7 +571,7 @@ func TestClient_methodUpload_errors(t *testing.T) {
 			fileName: "filename",
 			fileData: "dummy",
 			setup: func(c *core.Client) {
-				c.Wrapper = mock.MockWrapper{CloseErr: errors.New("mock close error")}
+				c.Wrapper = mock.Wrapper{CloseErr: errors.New("mock close error")}
 			},
 		},
 
@@ -580,7 +580,7 @@ func TestClient_methodUpload_errors(t *testing.T) {
 			fileName: "filename",
 			fileData: "dummy",
 			setup: func(c *core.Client) {
-				c.Wrapper = mock.MockWrapper{CopyErr: errors.New("mock copy error")}
+				c.Wrapper = mock.Wrapper{CopyErr: errors.New("mock copy error")}
 			},
 		},
 	}

--- a/internal/testutil/mock/mock.go
+++ b/internal/testutil/mock/mock.go
@@ -20,12 +20,12 @@ import (
 //  Doer mock
 // ──────────────────────────────────────────────────────────────
 
-type MockDoer struct {
+type Doer struct {
 	T      *testing.T
 	DoFunc func(req *http.Request) (*http.Response, error)
 }
 
-func (m *MockDoer) Do(req *http.Request) (*http.Response, error) {
+func (m *Doer) Do(req *http.Request) (*http.Response, error) {
 	assert.NotNil(m.T, req)
 	return m.DoFunc(req)
 }
@@ -34,32 +34,32 @@ func (m *MockDoer) Do(req *http.Request) (*http.Response, error) {
 //  Wrapper mock
 // ──────────────────────────────────────────────────────────────
 
-type MockWrapper struct {
+type Wrapper struct {
 	CreateErr error
 	CopyErr   error
 	CloseErr  error
 }
 
-func (w MockWrapper) NewMultipartWriter(_ io.Writer) core.MultipartWriter {
-	return &MockMultipartWriter{wrapper: w}
+func (w Wrapper) NewMultipartWriter(_ io.Writer) core.MultipartWriter {
+	return &multipartWriter{wrapper: w}
 }
 
-func (w MockWrapper) Copy(_ io.Writer, _ io.Reader) error {
+func (w Wrapper) Copy(_ io.Writer, _ io.Reader) error {
 	return w.CopyErr
 }
 
-type MockMultipartWriter struct {
-	wrapper MockWrapper
+type multipartWriter struct {
+	wrapper Wrapper
 }
 
-func (mw *MockMultipartWriter) CreateFormFile(fieldname, filename string) (io.Writer, error) {
+func (mw *multipartWriter) CreateFormFile(fieldname, filename string) (io.Writer, error) {
 	if mw.wrapper.CreateErr != nil {
 		return nil, mw.wrapper.CreateErr
 	}
 	return io.Discard, nil
 }
-func (mw *MockMultipartWriter) FormDataContentType() string { return "mock/type" }
-func (mw *MockMultipartWriter) Close() error                { return mw.wrapper.CloseErr }
+func (mw *multipartWriter) FormDataContentType() string { return "mock/type" }
+func (mw *multipartWriter) Close() error                { return mw.wrapper.CloseErr }
 
 // ──────────────────────────────────────────────────────────────
 //  RequestOption mock
@@ -160,7 +160,7 @@ func NewClient(t *testing.T, doFunc func(*http.Request) (*http.Response, error))
 		}
 	}
 
-	c, err := core.NewClient(testBaseURL, testToken, core.WithDoer(&MockDoer{T: t, DoFunc: doFunc}))
+	c, err := core.NewClient(testBaseURL, testToken, core.WithDoer(&Doer{T: t, DoFunc: doFunc}))
 	require.NoError(t, err)
 
 	return c


### PR DESCRIPTION
## Summary

Remove the redundant `Mock` prefix from types in the `internal/testutil/mock` package, consistent with the naming convention established by `mock.NewClient` and `mock.Capture`.

## Changes

### `internal/testutil/mock/mock.go`

- Rename `MockDoer` → `Doer`
- Rename `MockWrapper` → `Wrapper`
- Rename `MockMultipartWriter` → `multipartWriter` (unexported; only referenced internally via `Wrapper`)

### `internal/core/client_test.go`

- Update `mock.MockDoer{...}` → `mock.Doer{...}`
- Update `mock.MockWrapper{...}` → `mock.Wrapper{...}`
