### PR TITLE
ci: add test commit type for test-only changes

### DIFF
--- a/.github/scripts/label-pr.js
+++ b/.github/scripts/label-pr.js
@@ -31,6 +31,7 @@ const LABEL_RULES = [
   { pattern: /^docs:/,     labels: ['documentation'] },
   { pattern: /^ci:/,       labels: ['ci'] },
   { pattern: /^chore:/,    labels: ['chore'] },
+  { pattern: /^test:/,     labels: ['test'] },
 ];
 
 // ──────────────────────────────────────────────────────────────

--- a/cliff.toml
+++ b/cliff.toml
@@ -3,7 +3,7 @@ header = ""
 body = """
 ## What's Changed
 {% if commits | length == 0 %}
-No changes to production code in this release.
+This release contains no changes affecting library behavior.
 {% else %}\
 {% set breaking_commits = commits | filter(attribute="breaking", value=true) %}\
 {% if breaking_commits %}

--- a/cliff.toml
+++ b/cliff.toml
@@ -9,6 +9,9 @@ body = """
 - {{ commit.breaking_description | default(value=commit.message) | upper_first }}
 {% endfor %}
 {% endif %}\
+{% if commits | length == 0 %}
+No changes to production code in this release.
+{% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}\
 {% if group != "⚠️ Breaking Changes" %}
 ### {{ group }}
@@ -36,6 +39,7 @@ commit_parsers = [
   { message = "^docs", group = "📚 Documentation" },
   { message = "^ci", group = "⚙️ CI" },
   { message = "^chore", group = "🧹 Chores" },
+  { message = "^test", skip = true },
   { message = ".*", skip = true },
 ]
 filter_commits = true

--- a/cliff.toml
+++ b/cliff.toml
@@ -2,15 +2,15 @@
 header = ""
 body = """
 ## What's Changed
+{% if commits | length == 0 %}
+No changes to production code in this release.
+{% else %}\
 {% set breaking_commits = commits | filter(attribute="breaking", value=true) %}\
 {% if breaking_commits %}
 ### ⚠️ Breaking Changes
 {% for commit in breaking_commits %}\
 - {{ commit.breaking_description | default(value=commit.message) | upper_first }}
 {% endfor %}
-{% endif %}\
-{% if commits | length == 0 %}
-No changes to production code in this release.
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}\
 {% if group != "⚠️ Breaking Changes" %}
@@ -21,7 +21,8 @@ No changes to production code in this release.
 
 {% endfor %}
 {% endif %}\
-{% endfor %}
+{% endfor %}\
+{% endif %}
 """
 trim = true
 footer = ""

--- a/cliff.toml
+++ b/cliff.toml
@@ -38,8 +38,8 @@ commit_parsers = [
   { message = "^fix", group = "🐛 Bug Fixes" },
   { message = "^refactor", group = "🔨 Refactoring" },
   { message = "^docs", group = "📚 Documentation" },
-  { message = "^ci", group = "⚙️ CI" },
-  { message = "^chore", group = "🧹 Chores" },
+  { message = "^ci", skip = true },
+  { message = "^chore", skip = true },
   { message = "^test", skip = true },
   { message = ".*", skip = true },
 ]


### PR DESCRIPTION
## Summary

Introduces `test:` as a first-class commit type, and aligns release note coverage to exclude all commit types that are irrelevant to library users.

## Changes

- **cliff.toml**:
  - Add `{ message = "^test", skip = true }` so `test:` commits are excluded from release notes
  - Change `ci:` and `chore:` from grouped entries to `skip = true` — these are contributor-only concerns with no impact on library behavior
  - Add a fallback message at the top of the body template when no user-facing commits exist: "This release contains no changes affecting library behavior."
- **label-pr.js**: Add `{ pattern: /^test:/, labels: ['test'] }` rule to automatically apply the `test` label to PRs with `test:` prefix.

## Notes

The `test` GitHub label must be created manually (suggested color: `#8b5cf6`).

`artifact_rules.md` will be updated separately as it is managed outside the repository.